### PR TITLE
fix rounding to 0 decimals

### DIFF
--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -81,7 +81,7 @@ extension AddTempTarget {
                     target = (c / ratio) - c + 100
                 }
                 lowTarget = target
-                lowTarget = Decimal(round(Double(target * 10)) / 10)
+                lowTarget = Decimal(round(Double(target)))
             }
             var highTarget = lowTarget
 

--- a/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/AddTempTargetStateModel.swift
@@ -40,7 +40,7 @@ extension AddTempTarget {
                     target = (c / ratio) - c + 100
                 }
                 lowTarget = target
-                lowTarget = Decimal(round(Double(target * 10)) / 10)
+                lowTarget = Decimal(round(Double(target)))
             }
             var highTarget = lowTarget
 


### PR DESCRIPTION
will give full mg/dL targets and mmol/L will just convert fine, also setting in mmol/L works as intended in single decimal digits