### PR TITLE
NS-style blue basal icicles fill by mountrcg

### DIFF
--- a/FreeAPS/Resources/Assets.xcassets/Colors/Basal.colorset/Contents.json
+++ b/FreeAPS/Resources/Assets.xcassets/Colors/Basal.colorset/Contents.json
@@ -19,15 +19,6 @@
           "value" : "dark"
         }
       ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
-        }
-      },
       "idiom" : "universal"
     }
   ],

--- a/FreeAPS/Resources/Assets.xcassets/Colors/TempBasal.colorset/Contents.json
+++ b/FreeAPS/Resources/Assets.xcassets/Colors/TempBasal.colorset/Contents.json
@@ -2,30 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "srgb",
+        "color-space" : "display-p3",
         "components" : {
-          "alpha" : "0.500",
-          "blue" : "0.976",
-          "green" : "0.839",
-          "red" : "0.635"
-        }
-      },
-      "idiom" : "universal"
-    },
-    {
-      "appearances" : [
-        {
-          "appearance" : "luminosity",
-          "value" : "dark"
-        }
-      ],
-      "color" : {
-        "color-space" : "srgb",
-        "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.988",
-          "green" : "0.588",
-          "red" : "0.118"
+          "alpha" : "0.350",
+          "blue" : "0.608",
+          "green" : "0.804",
+          "red" : "0.529"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
Colour changes only are cherry-picked from https://github.com/mountrcg/freeaps/commit/437ee2edd50acd8844e546ab9c108614f27ca93e

The code for NS "icicle" style basal rendering seems to emerge from mountrcg, but is missing the nice blue colour. This cherry-pick should fix this. It's a lot easier on the eyes, and matches NS.

Current iAPS rendering:
![image](https://user-images.githubusercontent.com/63544115/227373603-163bcf9e-9763-48a6-a31f-bcce42e9b119.png)


Rendering in this PR:
![image](https://user-images.githubusercontent.com/63544115/227373748-6b4f06d0-c9c8-4b95-a565-3bc12442f87c.png)
