### PR TITLE
Eventual BG with 1 decimal

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -32,6 +32,13 @@ extension Home {
             return formatter
         }
 
+        private var eventualBGFormatter: NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 1
+            return formatter
+        }
+
         private var targetFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
@@ -532,7 +539,7 @@ extension Home {
 
                     if let eventualBG = state.eventualBG {
                         Text(
-                            "⇢ " + numberFormatter.string(
+                            "⇢ " + eventualBGFormatter.string(
                                 from: (state.units == .mmolL ? eventualBG.asMmolL : Decimal(eventualBG)) as NSNumber
                             )!
                         )


### PR DESCRIPTION
The eventual BG value is a highly uncertain estimate, hence it makes little sense to present this number with two decimal places. 

"numberFormatter" was replaced with a new "eventualBGFormatter", since the former is used in many places, and I did not want to check the implications of changing this formatter for all.