### PR TITLE
TempTargets: Better visibility and consistent colouring of temp targets

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -413,9 +413,9 @@ struct MainChartView: View {
     private func tempTargetsView(fullSize: CGSize) -> some View {
         ZStack {
             tempTargetsPath
-                .fill(Color.tempBasal.opacity(0.5))
+                .fill(Color.loopGreen.opacity(0.4))
             tempTargetsPath
-                .stroke(Color.basal.opacity(0.5), lineWidth: 1)
+                .stroke(Color.loopGreen.opacity(0.5), lineWidth: 1)
         }
         .onChange(of: glucose) { _ in
             calculateTempTargetsRects(fullSize: fullSize)


### PR DESCRIPTION
The colour .loopGreen is used for the temp target icon, and should also be used with temp targets displayed in the BG chart.
The default rendering is too dark and hard to see. 
