### PR TITLE
Display meal presets only when FPU is enabled

### DIFF
--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -78,8 +78,10 @@ extension AddCarbs {
                         }
                     }
                 }
-                Section {
-                    mealPresets
+                if state.useFPU {
+                    Section {
+                        mealPresets
+                    }
                 }
 
                 Section {

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -53,28 +53,28 @@ extension AddCarbs {
 
                         if state.useFPU {
                             proteinAndFat()
-                        }
-                        HStack {
-                            Button {
-                                isPromtPresented = true
+                            HStack {
+                                Button {
+                                    isPromtPresented = true
+                                }
+                                label: { Text("Save as Preset") }
                             }
-                            label: { Text("Save as Preset") }
-                        }
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                        .controlSize(.mini)
-                        .buttonStyle(BorderlessButtonStyle())
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                            .controlSize(.mini)
+                            .buttonStyle(BorderlessButtonStyle())
 
-                        .disabled(
-                            (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0) ||
-                                (
-                                    (((state.selection?.carbs ?? 0) as NSDecimalNumber) as Decimal) == state
-                                        .carbs && (((state.selection?.fat ?? 0) as NSDecimalNumber) as Decimal) == state
-                                        .fat && (((state.selection?.protein ?? 0) as NSDecimalNumber) as Decimal) == state
-                                        .protein
-                                )
-                        )
-                        .popover(isPresented: $isPromtPresented) {
-                            presetPopover
+                            .disabled(
+                                (state.carbs <= 0 && state.fat <= 0 && state.protein <= 0) ||
+                                    (
+                                        (((state.selection?.carbs ?? 0) as NSDecimalNumber) as Decimal) == state
+                                            .carbs && (((state.selection?.fat ?? 0) as NSDecimalNumber) as Decimal) == state
+                                            .fat && (((state.selection?.protein ?? 0) as NSDecimalNumber) as Decimal) == state
+                                            .protein
+                                    )
+                            )
+                            .popover(isPresented: $isPromtPresented) {
+                                presetPopover
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
The Meal Presets seems useful for complex meal entries containing combinations of carbs, protein and fat. For plain carb entries when FPU is not enabled, the presets seem redundant. This PR simplifies the Carbs screen by hiding "Meal Presets" and "Save as Preset" unless Fat and Protein (FPU) is enabled

Another benefit with this change is that the "Save and continue" button is available without scrolling or hiding of the keyboard.

<img src="https://user-images.githubusercontent.com/63544115/230214621-ff17bde0-8de2-4b30-ad4d-d56e7b23c938.png" width="400">