### PR TITLE
Add NFC tag reading capability to TestFlight app from Fastfile

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -12,9 +12,9 @@ jobs:
     needs: secrets
     runs-on: macos-12
     steps:
-      # Uncomment to manually select latest Xcode if needed
-      #- name: Select Latest Xcode
-      #  run: "sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer"
+      # Uncomment to manually select Xcode version if needed
+      #- name: Select Xcode version
+      #  run: "sudo xcode-select --switch /Applications/Xcode_14.1.app/Contents/Developer"
       
       # Checks-out the repo
       - name: Checkout Repo

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -20,9 +20,9 @@ jobs:
     needs: secrets
     runs-on: macos-12
     steps:
-      # Uncomment to manually select latest Xcode if needed
-      - name: Select Latest Xcode
-        run: "sudo xcode-select --switch /Applications/Xcode_14.1.app/Contents/Developer"
+      # Uncomment to manually select Xcode version if needed
+      #- name: Select Xcode version
+      #  run: "sudo xcode-select --switch /Applications/Xcode_14.1.app/Contents/Developer"
 
       # Checks-out the repo
       - name: Checkout Repo

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -12,9 +12,9 @@ jobs:
     needs: secrets
     runs-on: macos-12
     steps:
-      # Uncomment to manually select latest Xcode if needed
-      #- name: Select Latest Xcode
-      #  run: "sudo xcode-select --switch /Applications/Xcode_13.0.app/Contents/Developer"
+      # Uncomment to manually select Xcode version if needed
+      #- name: Select Xcode version
+      #  run: "sudo xcode-select --switch /Applications/Xcode_14.1.app/Contents/Developer"
       
       # Checks-out the repo
       - name: Checkout Repo

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -149,7 +149,8 @@ platform :ios do
 
     configure_bundle_id("FreeAPS", "ru.artpancreas.#{TEAMID}.FreeAPS", [
       Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
-      Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT
+      Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT,
+      Spaceship::ConnectAPI::BundleIdCapability::Type::NFC_TAG_READING
     ])
 
     configure_bundle_id("FreeAPSWatch WatchKit Extension", "ru.artpancreas.#{TEAMID}.FreeAPS.watchkitapp.watchkitextension", [
@@ -201,7 +202,7 @@ platform :ios do
       bundle_id = Spaceship::ConnectAPI::BundleId.find(identifier)
     end
 
-    find_bundle_id("com.#{TEAMID}.loopkit.Loop")
+    find_bundle_id("ru.artpancreas.#{TEAMID}.FreeAPS")
   end
 
   desc "Nuke Certs"

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -93,14 +93,6 @@ _Please note that in default builds of iAPS, the app group is actually identical
 1. Click "Confirm".
 1. Remember to do this for each of the identifiers above.
 
-## Add NFC Tag Reading to FreeeAPS App ID
-1. Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) on the apple developer site.
-1. Click on the "FreeeAPS" identifier
-1. Scroll down to "NFC Tag Reading"
-1. Tap the check box to enable NFC Tag Reading.
-1. Click "Save".
-1. Click "Confirm".
-
 ## Create iAPS App in App Store Connect
 
 If you have created a iAPS app in App Store Connect before, you can skip this section as well.


### PR DESCRIPTION
This should remove the need to manually set the NFC capability in Apple Developer (https://github.com/Artificial-Pancreas/iAPS/blob/main/fastlane/testflight.md#add-nfc-tag-reading-to-freeeaps-app-id). 

There is little info on this online, so I am unsure if this works correctly (I already have my apps set up). But I have tested that it does not break anything.

It would be good if someone who have not built iAPS with Xcode->TestFlight nor GitHub Actions->TestFlight could verify if the NFC capability will be set by this change.

Also made some other minor changes to the workflows, to avoid pinning the Xcode version, but use the latest stable version available on macos-12 instead.

The changes have been briefly tested and should be safe to merge immediately.