### PR TITLE
GitHub Actions build on MacOS 13 / Xcode 14.3

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -10,7 +10,7 @@ jobs:
 
   identifiers:
     needs: secrets
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Uncomment to manually select Xcode version if needed
       #- name: Select Xcode version

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -18,11 +18,11 @@ jobs:
 
   build:
     needs: secrets
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Uncomment to manually select Xcode version if needed
-      #- name: Select Xcode version
-      #  run: "sudo xcode-select --switch /Applications/Xcode_14.1.app/Contents/Developer"
+      - name: Select Xcode version
+        run: "sudo xcode-select --switch /Applications/Xcode_14.3.app/Contents/Developer"
 
       # Checks-out the repo
       - name: Checkout Repo

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -10,7 +10,7 @@ jobs:
 
   certificates:
     needs: secrets
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Uncomment to manually select Xcode version if needed
       #- name: Select Xcode version

--- a/.github/workflows/validate_secrets.yml
+++ b/.github/workflows/validate_secrets.yml
@@ -4,7 +4,7 @@ on: [workflow_call, workflow_dispatch]
 
 jobs:
   validate:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       # Checks-out the repo
       - name: Checkout Repo


### PR DESCRIPTION
Use macos-13 (currently in beta) for all workflows, use Xcode 14.3 for build_iAPS.yml

https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md

Building of iAPS has been briefly verified to work. Icon selection screen is now displayed correctly.

Beta announcement:
https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/