### PR TITLE
Always upload artifacts from GitHub Actions build

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -56,8 +56,9 @@ jobs:
           FASTLANE_KEY: ${{ secrets.FASTLANE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
 
-      # Upload IPA and Symbols
-      - name: Upload IPA and Symbol artifacts
+      # Upload Build artifacts
+      - name: Upload build log, IPA and Symbol artifacts
+        if: always()
         uses: actions/upload-artifact@v3
         with:
           name: build-artifacts


### PR DESCRIPTION
Will upload build-log for more detailed build debug also with failed builds.

Copied from LoopWorkspace