### PR TITLE
Move useFPU toggle from FPUConfigRootView to AddCarbsRootView

### DIFF
--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -102,7 +102,10 @@ extension AddCarbs {
                 }
             }
             .onAppear(perform: configureView)
-            .navigationBarItems(leading: Button("Close", action: state.hideModal))
+            .navigationBarItems(
+                leading: Button("Close", action: state.hideModal),
+                trailing: Toggle("FPU", isOn: $state.useFPU) // .foregroundColor(.red)
+            )
         }
 
         var presetPopover: some View {
@@ -194,7 +197,6 @@ extension AddCarbs {
 
                         state.removePresetFromNewMeal()
                         if state.carbs == 0, state.fat == 0, state.protein == 0 { state.summation = [] }
-
                     }
                     label: { Text("[ -1 ]") }
                         .disabled(

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -246,7 +246,6 @@ extension AddCarbs {
                     formatter: formatter,
                     autofocus: false,
                     cleanInput: true
-                ).foregroundColor(.loopRed)
 
                 Text("grams").foregroundColor(.secondary)
             }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -226,6 +226,18 @@ extension AddCarbs {
 
         @ViewBuilder private func proteinAndFat() -> some View {
             HStack {
+                Text("Fat").foregroundColor(.orange) // .fontWeight(.thin)
+                Spacer()
+                DecimalTextField(
+                    "0",
+                    value: $state.fat,
+                    formatter: formatter,
+                    autofocus: false,
+                    cleanInput: true
+                )
+                Text("grams").foregroundColor(.secondary)
+            }
+            HStack {
                 Text("Protein").foregroundColor(.red) // .fontWeight(.thin)
                 Spacer()
                 DecimalTextField(
@@ -236,18 +248,6 @@ extension AddCarbs {
                     cleanInput: true
                 ).foregroundColor(.loopRed)
 
-                Text("grams").foregroundColor(.secondary)
-            }
-            HStack {
-                Text("Fat").foregroundColor(.orange) // .fontWeight(.thin)
-                Spacer()
-                DecimalTextField(
-                    "0",
-                    value: $state.fat,
-                    formatter: formatter,
-                    autofocus: false,
-                    cleanInput: true
-                )
                 Text("grams").foregroundColor(.secondary)
             }
         }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -104,7 +104,7 @@ extension AddCarbs {
             .onAppear(perform: configureView)
             .navigationBarItems(
                 leading: Button("Close", action: state.hideModal),
-                trailing: Toggle("FPU", isOn: $state.useFPU) // .foregroundColor(.red)
+                trailing: Toggle("Use FPU", isOn: $state.useFPU)
             )
         }
 

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -104,7 +104,7 @@ extension AddCarbs {
             .onAppear(perform: configureView)
             .navigationBarItems(
                 leading: Button("Close", action: state.hideModal),
-                trailing: Toggle("Use FPU", isOn: $state.useFPU)
+                trailing: Toggle("Fat and Protein", isOn: $state.useFPU)
             )
         }
 

--- a/FreeAPS/Sources/Modules/FPUConfig/View/FPUConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/FPUConfig/View/FPUConfigRootView.swift
@@ -22,10 +22,6 @@ extension FPUConfig {
 
         var body: some View {
             Form {
-                Section(header: Text("Convert Fat and Protein")) {
-                    Toggle("Enable", isOn: $state.useFPUconversion)
-                }
-
                 Section(header: Text("Conversion settings")) {
                     HStack {
                         Text("Delay In Minutes")


### PR DESCRIPTION
An attempt to make FPU more accessible without "always" being displayed.

The toggle is here more of a clickable button. Currently it is displayed as "Use FPU" with blue text, and when active, it is highlighted with black text on blue background. I am open to suggestions for using different colours, or a different text.

The "Use FPU" text is not localized (I don't know how to do that yet).