### PR TITLE
Changed xDrip name to xDrip4iOS in settings

### DIFF
--- a/FreeAPS/Sources/APS/CGM/CGMType.swift
+++ b/FreeAPS/Sources/APS/CGM/CGMType.swift
@@ -18,7 +18,7 @@ enum CGMType: String, JSON, CaseIterable, Identifiable {
         case .nightscout:
             return "Nightscout"
         case .xdrip:
-            return "xDrip"
+            return "xDrip4iOS"
         case .glucoseDirect:
             return "Glucose Direct"
         case .dexcomG5:


### PR DESCRIPTION
Not necessary at all, just a little more precise imho.

When I built to my phone I had to change my CGM in settings to something else and then back to xDrip4iOS, but it's been working without issue since.