### PR TITLE
ISSUE-141 | Fix Target Glucose value after saving a new Profile when units set to mmol/L

### DIFF
--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -90,10 +90,11 @@ extension OverrideProfilesConfig {
                 saveOverride.id = id
                 saveOverride.date = Date()
                 if override_target {
-                    if units == .mmolL {
-                        target = target.asMgdL
-                    }
-                    saveOverride.target = target as NSDecimalNumber
+                    saveOverride.target = (
+                        units == .mmolL
+                            ? target.asMgdL
+                            : target
+                    ) as NSDecimalNumber
                 } else { saveOverride.target = 0 }
 
                 if advancedSettings {


### PR DESCRIPTION
ISSUE URL: https://github.com/Artificial-Pancreas/iAPS/issues/141

Currently, after saving a new Profile the code performs an unnecessary conversion of the `target` state variable into `mg/dL` if a user is using `mmol/L` before assigning it to `saveOverride.target`.
The fix removes the conversion and assigns the converted value directly to `saveOverride.target`.

|Before|After
|-|-
|<video src="https://github.com/Artificial-Pancreas/iAPS/assets/17122466/50d46466-6ab1-4d23-b84a-1d9502118925" />|<video src="https://github.com/Artificial-Pancreas/iAPS/assets/17122466/8d4a41ab-87e6-4b81-999a-78dc52c968d5" />

