### PR TITLE
ISSUE-161 | Rename title `Target Ranges` to `Target Glucose`

### DIFF
--- a/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
-
 /* When bolusing */
 "Bolusing" = "Bolusing";
 

--- a/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
@@ -452,8 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
 
 /* When bolusing */
 "Bolusing" = "Bolusing";

--- a/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
-
 /* When bolusing */
 "Bolusing" = "Bolusing";
 

--- a/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Untere Grenze";
 
-/*  */
-"Target Ranges" = "Zielbereiche";
-
 /* When bolusing */
 "Bolusing" = "Bolusabgabe";
 

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -455,9 +455,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
-
 /* When bolusing */
 "Bolusing" = "Bolusing";
 

--- a/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Objectivo Bajo";
 
-/*  */
-"Target Ranges" = "Rango Objetivo";
-
 /* When bolusing */
 "Bolusing" = "Administrando Bolo";
 

--- a/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
-
 /* When bolusing */
 "Bolusing" = "Bolusing";
 

--- a/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Cible basse";
 
-/*  */
-"Target Ranges" = "Zone cible";
-
 /* When bolusing */
 "Bolusing" = "Bolus en cours";
 

--- a/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
-
 /* When bolusing */
 "Bolusing" = "Bolusing";
 

--- a/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Ondergrens doel";
 
-/*  */
-"Target Ranges" = "Streefdoel";
-
 /* When bolusing */
 "Bolusing" = "Bolussen";
 

--- a/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
@@ -454,9 +454,6 @@ Połączono z Nightscout!";
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
-
 /* When bolusing */
 "Bolusing" = "Bolusing";
 

--- a/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Meta baixa";
 
-/*  */
-"Target Ranges" = "Limites da meta";
-
 /* When bolusing */
 "Bolusing" = "Aplicando bolus";
 

--- a/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Meta baixa";
 
-/*  */
-"Target Ranges" = "Limites da meta";
-
 /* When bolusing */
 "Bolusing" = "Aplicando bolus";
 

--- a/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Нижняя цель";
 
-/*  */
-"Target Ranges" = "Целевой диапазон";
-
 /* When bolusing */
 "Bolusing" = "Подается болюс";
 

--- a/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Low target";
 
-/*  */
-"Target Ranges" = "Target Ranges";
-
 /* When bolusing */
 "Bolusing" = "Bolusing";
 

--- a/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Undre målvärde";
 
-/*  */
-"Target Ranges" = "Målområden";
-
 /* When bolusing */
 "Bolusing" = "Ger bolus";
 

--- a/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "Düşük hedef";
 
-/*  */
-"Target Ranges" = "Hedef Aralığı";
-
 /* When bolusing */
 "Bolusing" = "Bolus veriliyor";
 

--- a/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
@@ -417,9 +417,6 @@ Enact a temp Basal or a temp target */
 "Add devices" = "Додати пристрій";
 
 /* */
-"Glucose Target" = "Мета глюкози";
-
-/* */
 "Heart Rate" = "Пульс";
 
 /* */
@@ -451,9 +448,6 @@ Enact a temp Basal or a temp target */
 
 /* Lower target */
 "Low target" = "Низька ціль";
-
-/*  */
-"Target Ranges" = "Цільові Діапазони";
 
 /* When bolusing */
 "Bolusing" = "Подаю болюс";

--- a/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
@@ -452,9 +452,6 @@ Enact a temp Basal or a temp target */
 /* Lower target */
 "Low target" = "血糖低目标";
 
-/*  */
-"Target Ranges" = "目标范围：";
-
 /* When bolusing */
 "Bolusing" = "注射中";
 

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -41,7 +41,7 @@ extension Settings {
                     Text("Basal Profile").navigationLink(to: .basalProfileEditor, from: self)
                     Text("Insulin Sensitivities").navigationLink(to: .isfEditor, from: self)
                     Text("Carb Ratios").navigationLink(to: .crEditor, from: self)
-                    Text("Target Ranges").navigationLink(to: .targetsEditor, from: self)
+                    Text("Target Glucose").navigationLink(to: .targetsEditor, from: self)
                     Text("Autotune").navigationLink(to: .autotuneConfig, from: self)
                 }
 

--- a/FreeAPS/Sources/Modules/TargetsEditor/View/TargetsEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/TargetsEditor/View/TargetsEditorRootView.swift
@@ -39,7 +39,7 @@ extension TargetsEditor {
                 }
             }
             .onAppear(perform: configureView)
-            .navigationTitle("Target Ranges")
+            .navigationTitle("Target Glucose")
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarItems(
                 trailing: EditButton()


### PR DESCRIPTION
[ISSUE-161](https://github.com/Artificial-Pancreas/iAPS/issues/161)

## Changes
- Renamed `Target Ranges` to `Target Glucose`
- Removed unused `Target Ranges` localization string from localization files.

## Notes
- The app has the `Target Glucose` localization string [here](https://github.com/Artificial-Pancreas/iAPS/blob/dev/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings#L1296C37-L1296C37) already.

## Screenshot
|Settings screen|Target Glucose screen
|-|-
|<img width="564" alt="Screenshot 2023-08-07 at 21 50 17" src="https://github.com/Artificial-Pancreas/iAPS/assets/17122466/e8ed4384-baea-4f67-9144-5edebc4cf255">|<img width="564" alt="Screenshot 2023-08-07 at 21 50 21" src="https://github.com/Artificial-Pancreas/iAPS/assets/17122466/b8c781d3-68e3-47eb-b1e6-bb4e1c2fca66">
