### PR TITLE
Add SMB flag for treatment history

### DIFF
--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -44,7 +44,8 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                         durationMin: nil,
                         rate: nil,
                         temp: nil,
-                        carbInput: nil
+                        carbInput: nil,
+                        isSMB: dose.automatic
                     )]
                 case .tempBasal:
                     guard let dose = event.dose else { return [] }

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -11,6 +11,7 @@ struct PumpHistoryEvent: JSON, Equatable {
     let temp: TempType?
     let carbInput: Int?
     let note: String?
+    let isSMB: Bool?
 
     init(
         id: String,
@@ -22,7 +23,8 @@ struct PumpHistoryEvent: JSON, Equatable {
         rate: Decimal? = nil,
         temp: TempType? = nil,
         carbInput: Int? = nil,
-        note: String? = nil
+        note: String? = nil,
+        isSMB: Bool? = nil
     ) {
         self.id = id
         self.type = type
@@ -34,6 +36,7 @@ struct PumpHistoryEvent: JSON, Equatable {
         self.temp = temp
         self.carbInput = carbInput
         self.note = note
+        self.isSMB = isSMB
     }
 }
 
@@ -80,5 +83,6 @@ extension PumpHistoryEvent {
         case temp
         case carbInput = "carb_input"
         case note
+        case isSMB
     }
 }

--- a/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
@@ -137,7 +137,7 @@ enum DataTable {
             case .bolus:
                 return numberFormatter
                     .string(from: amount as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit") +
-                    "\((isSMB ?? true)! ? " SMB" : " Manual")"
+                    "\(isSMB ?? false ? " SMB" : "")"
             case .tempBasal:
                 return numberFormatter
                     .string(from: amount as NSNumber)! + NSLocalizedString(" U/hr", comment: "Unit insulin per hour")

--- a/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
@@ -66,8 +66,9 @@ enum DataTable {
         let isFPU: Bool?
         let fpuID: String?
         let note: String?
+        let isSMB: Bool?
 
-        private var numberFormater: NumberFormatter {
+        private var numberFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
             formatter.maximumFractionDigits = 2
@@ -92,7 +93,8 @@ enum DataTable {
             idPumpEvent: String? = nil,
             isFPU: Bool? = false,
             fpuID: String? = nil,
-            note: String? = nil
+            note: String? = nil,
+            isSMB: Bool? = nil
         ) {
             self.units = units
             self.type = type
@@ -105,6 +107,7 @@ enum DataTable {
             self.isFPU = isFPU
             self.fpuID = fpuID
             self.note = note
+            self.isSMB = isSMB
         }
 
         static func == (lhs: Treatment, rhs: Treatment) -> Bool {
@@ -126,14 +129,17 @@ enum DataTable {
 
             switch type {
             case .carbs:
-                return numberFormater.string(from: amount as NSNumber)! + NSLocalizedString(" g", comment: "gram of carbs")
+                return numberFormatter
+                    .string(from: amount as NSNumber)! + NSLocalizedString(" g", comment: "gram of carbs")
             case .fpus:
-                return numberFormater
+                return numberFormatter
                     .string(from: amount as NSNumber)! + NSLocalizedString(" g", comment: "gram of carb equilvalents")
             case .bolus:
-                return numberFormater.string(from: amount as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit")
+                return numberFormatter
+                    .string(from: amount as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit") +
+                    "\((isSMB ?? true)! ? " SMB" : " Manual")"
             case .tempBasal:
-                return numberFormater
+                return numberFormatter
                     .string(from: amount as NSNumber)! + NSLocalizedString(" U/hr", comment: "Unit insulin per hour")
             case .tempTarget:
                 var converted = amount
@@ -142,7 +148,7 @@ enum DataTable {
                 }
 
                 guard var secondAmount = secondAmount else {
-                    return numberFormater.string(from: converted as NSNumber)! + " \(units.rawValue)"
+                    return numberFormatter.string(from: converted as NSNumber)! + " \(units.rawValue)"
                 }
                 if units == .mmolL {
                     secondAmount = secondAmount.asMmolL
@@ -177,7 +183,7 @@ enum DataTable {
             guard let duration = duration, duration > 0 else {
                 return nil
             }
-            return numberFormater.string(from: duration as NSNumber)! + " min"
+            return numberFormatter.string(from: duration as NSNumber)! + " min"
         }
     }
 

--- a/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
@@ -66,7 +66,14 @@ extension DataTable {
                 let boluses = self.provider.pumpHistory()
                     .filter { $0.type == .bolus }
                     .map {
-                        Treatment(units: units, type: .bolus, date: $0.timestamp, amount: $0.amount, idPumpEvent: $0.id)
+                        Treatment(
+                            units: units,
+                            type: .bolus,
+                            date: $0.timestamp,
+                            amount: $0.amount,
+                            idPumpEvent: $0.id,
+                            isSMB: $0.isSMB
+                        )
                     }
 
                 let tempBasals = self.provider.pumpHistory()

--- a/FreeAPS/Sources/Modules/DataTable/View/DataTableRootView.swift
+++ b/FreeAPS/Sources/Modules/DataTable/View/DataTableRootView.swift
@@ -113,8 +113,9 @@ extension DataTable {
                 Image(systemName: "circle.fill").foregroundColor(item.color)
                 Text(dateFormatter.string(from: item.date))
                     .moveDisabled(true)
-                Text(item.type.name)
+                Text((item.isSMB ?? false) ? "🤖" : item.type.name)
                 Text(item.amountText).foregroundColor(.secondary)
+
                 if let duration = item.durationText {
                     Text(duration).foregroundColor(.secondary)
                 }

--- a/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
+++ b/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
@@ -232,6 +232,7 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
             }
         }
     }
+
     private func glucoseText(glucoseValue: Int, delta: Int?, direction: BloodGlucose.Direction?) -> String {
         let units = settingsManager.settings.units
         let glucoseText = glucoseFormatter


### PR DESCRIPTION
This PR adds a flag for SMB boluses to the `PumpHistoryStorage` and subsequently alters the treatment history when displaying boluses. For a manual bolus, it displays a blue filled circle with the word "Bolus" and dosage. For an SMB bolus, it displays a blue filled circle, instead of "Bolus" it displays 🤖 and the dosage.

<img width="587" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/397154c8-a074-4942-9d36-99f52804a6fc">
