### PR TITLE
Change the "rotation hint" for watch bolus confirmation

### DIFF
--- a/FreeAPSWatch WatchKit Extension/Views/BolusConfirmationView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/BolusConfirmationView.swift
@@ -40,7 +40,7 @@ struct BolusConfirmationView: View {
                     if isCrownLeftOriented {
                         Spacer().frame(width: elementSize / 2)
                     } else {
-                        Image(systemName: "arrow.down")
+                        Image(systemName: "digitalcrown.arrow.counterclockwise.fill")
                             .resizable()
                             .frame(width: elementSize / 2, height: elementSize / 2)
                             .foregroundColor(.primary)
@@ -51,7 +51,7 @@ struct BolusConfirmationView: View {
             .padding()
             HStack(spacing: 16) {
                 if isCrownLeftOriented {
-                    Image(systemName: "arrow.down")
+                    Image(systemName: "digitalcrown.arrow.counterclockwise.fill")
                         .resizable()
                         .frame(width: elementSize / 2, height: elementSize / 2)
                         .foregroundColor(.primary)


### PR DESCRIPTION
This PR changes the "rotation hint" for the bolus confirmation on the iAPS watch app. 

## DESCRIPTION
This solves an issue, where the current icon may be confused for tapping/sliding the displayed arrow on the watch screen rather then turning the crown to confirm the bolus. 

Example user report on Discord:
> Any advice on not being able to slide this to enact the bolus? The arrow just won’t move when I touch and slide
> Are you supposed to use the watch knob to “wind” it down?

## CONTENT

| Before Change  | \***NEW**\* After Change           |
|----------------|-------------------------|
| downward arrow | downward rotating crown |
| <img width="378" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/e985c742-a4d5-4c17-ab7e-0a097dd0c441">              | <img width="378" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/b6a32cfc-97b1-4dca-bc07-cc3bf213b112">                       |

Tested with watch orientation set to left and right wrist and crown orientation set to left and right.