### PR TITLE
Add non-pump insulin and new colorways to Treatments history

### DIFF
--- a/FreeAPS/Resources/Assets.xcassets/Colors/NonPumpInsulin.colorset/Contents.json
+++ b/FreeAPS/Resources/Assets.xcassets/Colors/NonPumpInsulin.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "250",
+          "green" : "213",
+          "red" : "63"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "250",
+          "green" : "213",
+          "red" : "63"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FreeAPS/Resources/Assets.xcassets/Colors/SMB.colorset/Contents.json
+++ b/FreeAPS/Resources/Assets.xcassets/Colors/SMB.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "194",
+          "green" : "117",
+          "red" : "58"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "194",
+          "green" : "117",
+          "red" : "58"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -262,7 +262,7 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                     enteredBy: NigtscoutTreatment.local,
                     bolus: event,
                     insulin: event.amount,
-                    notes: (event.isNonPumpInsulin ?? false) ? "Bolus with non-pump insulin" : nil,
+                    notes: nil,
                     carbs: nil,
                     fat: nil,
                     protein: nil,

--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -45,7 +45,8 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                         rate: nil,
                         temp: nil,
                         carbInput: nil,
-                        isSMB: dose.automatic
+                        isSMB: dose.automatic,
+                        isNonPumpInsulin: dose.manuallyEntered
                     )]
                 case .tempBasal:
                     guard let dose = event.dose else { return [] }
@@ -256,12 +257,12 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
                     rawRate: nil,
                     absolute: nil,
                     rate: nil,
-                    eventType: (event.isSMB ?? false) ? .smb : .bolus,
+                    eventType: (event.isSMB ?? false) ? .smb : (event.isNonPumpInsulin ?? false) ? .nonPumpInsulin : .bolus,
                     createdAt: event.timestamp,
                     enteredBy: NigtscoutTreatment.local,
                     bolus: event,
                     insulin: event.amount,
-                    notes: nil,
+                    notes: (event.isNonPumpInsulin ?? false) ? "Bolus with non-pump insulin" : nil,
                     carbs: nil,
                     fat: nil,
                     protein: nil,

--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -211,6 +211,16 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
         }
     }
 
+    func determineBolusEventType(for event: PumpHistoryEvent) -> EventType {
+        if event.isSMB ?? false {
+            return .smb
+        }
+        if event.isNonPumpInsulin ?? false {
+            return .nonPumpInsulin
+        }
+        return event.type
+    }
+
     func nightscoutTretmentsNotUploaded() -> [NigtscoutTreatment] {
         let events = recent()
         guard !events.isEmpty else { return [] }
@@ -251,13 +261,14 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
         let bolusesAndCarbs = events.compactMap { event -> NigtscoutTreatment? in
             switch event.type {
             case .bolus:
+                let eventType = determineBolusEventType(for: event)
                 return NigtscoutTreatment(
                     duration: event.duration,
                     rawDuration: nil,
                     rawRate: nil,
                     absolute: nil,
                     rate: nil,
-                    eventType: (event.isSMB ?? false) ? .smb : (event.isNonPumpInsulin ?? false) ? .nonPumpInsulin : .bolus,
+                    eventType: eventType,
                     createdAt: event.timestamp,
                     enteredBy: NigtscoutTreatment.local,
                     bolus: event,

--- a/FreeAPS/Sources/Helpers/Color+Extensions.swift
+++ b/FreeAPS/Sources/Helpers/Color+Extensions.swift
@@ -10,6 +10,10 @@ extension Color {
 
     static let insulin = Color("Insulin")
 
+    static let smb = Color("SMB")
+
+    static let nonPumpInsulin = Color("NonPumpInsulin")
+
     // The loopAccent color is intended to be use as the app accent color.
     public static let loopAccent = Color("accent")
 

--- a/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
@@ -1114,6 +1114,12 @@ Enact a temp Basal or a temp target */
 /* Manual temp basal mode */
 "Manual" = "manuell";
 
+/* An Automatic delivered bolus (SMB) */
+"SMB" = "SMB";
+
+/* A manually entered dose of non-pump insulin */
+"Non-pump Insulin" = "Externes Insulin";
+
 /* Status highlight when manual temp basal is running. */
 "Manual Basal" = "Manuelle Temporäre Basalrate";
 

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -527,6 +527,9 @@ Enact a temp Basal or a temp target */
 /* Automatic delivered treatments */
 "Automatic" = "Automatic";
 
+/* Non-pump insulin treatments */
+"Non-Pump" = "Non-Pump";
+
 /* */
 "Other" = "Other";
 

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -1121,6 +1121,9 @@ Enact a temp Basal or a temp target */
 /* An Automatic delivered bolus (SMB) */
 "SMB" = "SMB";
 
+/* A manually entered dose of non-pump insulin */
+"Non-pump Insulin" = "Non-pump Insulin";
+
 /* Status highlight when manual temp basal is running. */
 "Manual Basal" = "Manual Basal";
 

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -46,7 +46,7 @@ struct PumpHistoryEvent: JSON, Equatable {
 enum EventType: String, JSON {
     case bolus = "Bolus"
     case smb = "SMB"
-    case nonPumpInsulin = "Non-pump insulin"
+    case nonPumpInsulin = "Non-pump Insulin"
     case mealBolus = "Meal Bolus"
     case correctionBolus = "Correction Bolus"
     case snackBolus = "Snack Bolus"

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -12,6 +12,7 @@ struct PumpHistoryEvent: JSON, Equatable {
     let carbInput: Int?
     let note: String?
     let isSMB: Bool?
+    let isNonPumpInsulin: Bool?
 
     init(
         id: String,
@@ -24,7 +25,8 @@ struct PumpHistoryEvent: JSON, Equatable {
         temp: TempType? = nil,
         carbInput: Int? = nil,
         note: String? = nil,
-        isSMB: Bool? = nil
+        isSMB: Bool? = nil,
+        isNonPumpInsulin: Bool? = nil
     ) {
         self.id = id
         self.type = type
@@ -37,13 +39,15 @@ struct PumpHistoryEvent: JSON, Equatable {
         self.carbInput = carbInput
         self.note = note
         self.isSMB = isSMB
+        self.isNonPumpInsulin = isNonPumpInsulin
     }
 }
 
 enum EventType: String, JSON {
     case bolus = "Bolus"
     case smb = "SMB"
-    case mealBulus = "Meal Bolus"
+    case nonPumpInsulin = "Bolus with non-pump insulin"
+    case mealBolus = "Meal Bolus"
     case correctionBolus = "Correction Bolus"
     case snackBolus = "Snack Bolus"
     case bolusWizard = "BolusWizard"
@@ -85,5 +89,6 @@ extension PumpHistoryEvent {
         case carbInput = "carb_input"
         case note
         case isSMB
+        case isNonPumpInsulin
     }
 }

--- a/FreeAPS/Sources/Models/PumpHistoryEvent.swift
+++ b/FreeAPS/Sources/Models/PumpHistoryEvent.swift
@@ -46,7 +46,7 @@ struct PumpHistoryEvent: JSON, Equatable {
 enum EventType: String, JSON {
     case bolus = "Bolus"
     case smb = "SMB"
-    case nonPumpInsulin = "Bolus with non-pump insulin"
+    case nonPumpInsulin = "Non-pump insulin"
     case mealBolus = "Meal Bolus"
     case correctionBolus = "Correction Bolus"
     case snackBolus = "Snack Bolus"

--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -83,7 +83,8 @@ extension Bolus {
                         durationMin: nil,
                         rate: nil,
                         temp: nil,
-                        carbInput: nil
+                        carbInput: nil,
+                        isNonPumpInsulin: true
                     )
                 ]
             )

--- a/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
@@ -143,7 +143,7 @@ enum DataTable {
                 if isSMB ?? false {
                     bolusText += NSLocalizedString("Automatic", comment: "Automatic delivered treatments")
                 } else if isNonPump ?? false {
-                    bolusText += NSLocalizedString("Non-Pump", comment: "Bolus with non-pump insulin")
+                    bolusText += NSLocalizedString("Non-Pump", comment: "Non-pump insulin")
                 } else {
                     bolusText += NSLocalizedString("Manual", comment: "Manual Bolus")
                 }

--- a/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
@@ -143,7 +143,7 @@ enum DataTable {
                 if isSMB ?? false {
                     bolusText += NSLocalizedString("Automatic", comment: "Automatic delivered treatments")
                 } else if isNonPump ?? false {
-                    bolusText += NSLocalizedString("Non-Pump", comment: "Non-pump insulin")
+                    bolusText += NSLocalizedString("Non-Pump", comment: "Non-pump Insulin")
                 } else {
                     bolusText += NSLocalizedString("Manual", comment: "Manual Bolus")
                 }

--- a/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableDataFlow.swift
@@ -67,6 +67,7 @@ enum DataTable {
         let fpuID: String?
         let note: String?
         let isSMB: Bool?
+        let isNonPump: Bool?
 
         private var numberFormatter: NumberFormatter {
             let formatter = NumberFormatter()
@@ -94,7 +95,8 @@ enum DataTable {
             isFPU: Bool? = nil,
             fpuID: String? = nil,
             note: String? = nil,
-            isSMB: Bool? = nil
+            isSMB: Bool? = nil,
+            isNonPump: Bool? = nil
         ) {
             self.units = units
             self.type = type
@@ -108,6 +110,7 @@ enum DataTable {
             self.fpuID = fpuID
             self.note = note
             self.isSMB = isSMB
+            self.isNonPump = isNonPump
         }
 
         static func == (lhs: Treatment, rhs: Treatment) -> Bool {
@@ -135,12 +138,18 @@ enum DataTable {
                 return numberFormatter
                     .string(from: amount as NSNumber)! + NSLocalizedString(" g", comment: "gram of carb equilvalents")
             case .bolus:
+                var bolusText = " "
+
+                if isSMB ?? false {
+                    bolusText += NSLocalizedString("Automatic", comment: "Automatic delivered treatments")
+                } else if isNonPump ?? false {
+                    bolusText += NSLocalizedString("Non-Pump", comment: "Bolus with non-pump insulin")
+                } else {
+                    bolusText += NSLocalizedString("Manual", comment: "Manual Bolus")
+                }
+
                 return numberFormatter
-                    .string(from: amount as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit") +
-                    (
-                        (isSMB ?? false) ? " " + NSLocalizedString("Automatic", comment: "Automatic delivered treatments") : " " +
-                            NSLocalizedString("Manual", comment: "Manual Bolus")
-                    )
+                    .string(from: amount as NSNumber)! + NSLocalizedString(" U", comment: "Insulin unit") + bolusText
             case .tempBasal:
                 return numberFormatter
                     .string(from: amount as NSNumber)! + NSLocalizedString(" U/hr", comment: "Unit insulin per hour")
@@ -172,9 +181,9 @@ enum DataTable {
             case .fpus:
                 return .loopRed
             case .bolus:
-                return .insulin
+                return (isNonPump ?? false) ? Color.nonPumpInsulin : (isSMB ?? false) ? Color.smb : Color.insulin
             case .tempBasal:
-                return Color.insulin.opacity(0.5)
+                return Color.insulin.opacity(0.4)
             case .resume,
                  .suspend,
                  .tempTarget:

--- a/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
@@ -72,7 +72,8 @@ extension DataTable {
                             date: $0.timestamp,
                             amount: $0.amount,
                             idPumpEvent: $0.id,
-                            isSMB: $0.isSMB
+                            isSMB: $0.isSMB,
+                            isNonPump: $0.isNonPumpInsulin
                         )
                     }
 


### PR DESCRIPTION
This PR provides two new additions to iAPS:
* new event type `nonPumpInsulin` to differentiate between boluses entered from the pod/pump and external insulin
  * also adds a new event type to Nightscout treatments; possible side effects for LoopFollow and similar applications
* new colorways to differentiate between manual bolus, automated bolus (=SMB), non-pump insulin bolus and temp basal

New Treatments history UI:
| Light Mode | Dark Mode |
|--------|--------|
| <img width="1024" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/bdf8d7fd-f994-4d94-b653-9fb709c72965"> | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/abe461bf-f8d1-481a-b998-771f835cbb56) |
| Simulator screenshot (iPhone 15 Pro) | Phone screenshot (iPhone 11) | 

New colorways:
| Automated bolus (SMB) | Non-pump insulin  |
|--------|--------|
| <img width="85" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/e33bae7f-7562-4a44-bc53-9357cf17b27b"> | <img width="85" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/e760e316-5186-4508-8296-875c66cbdd4d"> |
| #3ED4FA | #3A75C2 |

The home view main chart is not touched by this change; currently only limited to the history treatments tab. 

Nightscouts treatments look as follows: 
<img width="1105" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/daceb8ad-6c53-4541-9b7b-00d301738301">
 
