### PR TITLE
Change permissions required for calendar in iOS 17+

### DIFF
--- a/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
+++ b/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
@@ -63,6 +63,19 @@ extension CGM {
                             }
                             Toggle("Display Emojis as Labels", isOn: $state.displayCalendarEmojis)
                             Toggle("Display IOB and COB", isOn: $state.displayCalendarIOBandCOB)
+                        } else if state.createCalendarEvents {
+                            if #available(iOS 17.0, *) {
+                                Text(
+                                    "If you are not seeing calendars to choose here, please go to Settings -> iAPS -> Calendars and change permissions to \"Full Access\""
+                                ).font(.footnote)
+
+                                Button("Open Settings") {
+                                    // Get the settings URL and open it
+                                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                                        UIApplication.shared.open(url)
+                                    }
+                                }
+                            }
                         }
                     }
 

--- a/FreeAPS/Sources/Services/Calendar/CalendarManager.swift
+++ b/FreeAPS/Sources/Services/Calendar/CalendarManager.swift
@@ -32,17 +32,55 @@ final class BaseCalendarManager: CalendarManager, Injectable {
             let status = EKEventStore.authorizationStatus(for: .event)
             switch status {
             case .notDetermined:
-                EKEventStore().requestAccess(to: .event) { granted, error in
-                    if let error = error {
-                        warning(.service, "Calendar access not granded", error: error)
+                #if swift(>=5.9)
+                    if #available(iOS 17.0, *) {
+                        EKEventStore().requestFullAccessToEvents(completion: { (granted: Bool, error: Error?) -> Void in
+                            if let error = error {
+                                warning(.service, "Calendar access not granded", error: error)
+                            }
+                            promise(.success(granted))
+                        })
+                    } else {
+                        EKEventStore().requestAccess(to: .event) { granted, error in
+                            if let error = error {
+                                warning(.service, "Calendar access not granded", error: error)
+                            }
+                            promise(.success(granted))
+                        }
                     }
-                    promise(.success(granted))
-                }
+                #else
+                    EKEventStore().requestAccess(to: .event) { granted, error in
+                        if let error = error {
+                            warning(.service, "Calendar access not granded", error: error)
+                        }
+                        promise(.success(granted))
+                    }
+                #endif
             case .denied,
                  .restricted:
                 promise(.success(false))
             case .authorized:
                 promise(.success(true))
+
+            #if swift(>=5.9)
+                case .fullAccess:
+                    promise(.success(true))
+            #endif
+
+            case .writeOnly:
+                #if swift(>=5.9)
+                    if #available(iOS 17.0, *) {
+                        print("hello i am called")
+                        EKEventStore().requestFullAccessToEvents(completion: { (granted: Bool, error: Error?) -> Void in
+                            if let error = error {
+                                print("Calendar access not upgraded")
+                                warning(.service, "Calendar access not upgraded", error: error)
+                            }
+                            promise(.success(granted))
+                        })
+                    }
+                #endif
+
             @unknown default:
                 warning(.service, "Unknown calendar access status")
                 promise(.success(false))


### PR DESCRIPTION
This PR fixes an issue caused by iOS 17+ requiring higher permissions for the calendar integration in iAPS.

Enabling calendar when no permissions have been granted or rejected:
![Asking permissions from notDetermined state](https://github.com/Artificial-Pancreas/iAPS/assets/143836/cacc1724-321f-4381-b1ea-df27ba71868e)

Enabling calendar when existing permissions are not enough:
![Permission elevation required](https://github.com/Artificial-Pancreas/iAPS/assets/143836/d5a22a57-44f6-4897-9692-f0c2e920be48)

Untested on xcode 14, but it's a port of these PRs from XDrip4iOS:

https://github.com/JohanDegraeve/xdripswift/pull/461
https://github.com/JohanDegraeve/xdripswift/pull/470

There might also be issues with permissions in Info.plist, but I don't quite understand how to change that information in xcode. I would appreciate someone more knowledgeable had a look at that particular part. 

