### PR TITLE
Add Upload Preferences to Settings -> Nightscout

### DIFF
--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -29,6 +29,7 @@ extension NightscoutConfig {
         @Published var localPort: Decimal = 0
         @Published var units: GlucoseUnits = .mmolL
         @Published var importedHasRun = false
+        @Published var isPreferencesUploadOK = false
 
         override func subscribe() {
             url = keychain.getValue(String.self, forKey: Config.urlKey) ?? ""
@@ -238,6 +239,20 @@ extension NightscoutConfig {
                 if coredataContext.hasChanges {
                     try? coredataContext.save()
                 }
+            }
+        }
+
+        func pushPreferences() {
+            isPreferencesUploadOK = false
+
+            nightscoutManager.uploadPreferences()
+
+            while nightscoutManager.isPreferencesUploaded == -1 {
+                sleep(1)
+            }
+
+            if nightscoutManager.isPreferencesUploaded == 0 {
+                isPreferencesUploadOK = true
             }
         }
 

--- a/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/View/NightscoutConfigRootView.swift
@@ -8,6 +8,7 @@ extension NightscoutConfig {
         @StateObject var state = StateModel()
         @State var importAlert: Alert?
         @State var isImportAlertPresented = false
+        @State var showPreferencesAlert = false
 
         @FetchRequest(
             entity: ImportError.entity(),
@@ -106,6 +107,26 @@ extension NightscoutConfig {
                             secondaryButton: .cancel()
                         )
                     }
+
+                Section {
+                    Button("Upload Preferences") {
+                        state.pushPreferences()
+                        showPreferencesAlert = true
+                    }
+                    .alert(isPresented: $showPreferencesAlert) {
+                        var prefsMessage = "Preferences: Failed"
+                        if state.isPreferencesUploadOK {
+                            prefsMessage = "Preferences: OK"
+                        }
+
+                        return Alert(
+                            title: Text("Upload Status"),
+                            message: Text(prefsMessage)
+                        )
+                    }
+                    .disabled(state.url.isEmpty || state.connecting)
+
+                } header: { Text("Manual Uploads") }
 
                 Section {
                     Toggle("Use local glucose server", isOn: $state.useLocalSource)

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -17,6 +17,8 @@ protocol NightscoutManager: GlucoseSource {
     func uploadPreferences()
     func uploadProfile()
     var cgmURL: URL? { get }
+
+    var isPreferencesUploaded: Int { get }
 }
 
 final class BaseNightscoutManager: NightscoutManager, Injectable {
@@ -31,6 +33,8 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     @Injected() private var broadcaster: Broadcaster!
     @Injected() private var reachabilityManager: ReachabilityManager!
     @Injected() var healthkitManager: HealthKitManager!
+
+    @Published var isPreferencesUploaded: Int = -1
 
     private let processQueue = DispatchQueue(label: "BaseNetworkManager.processQueue")
     private var ping: TimeInterval?
@@ -275,6 +279,8 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
     }
 
     func uploadPreferences() {
+        isPreferencesUploaded = -1
+
         let prefs = NightscoutPreferences(
             preferences: settingsManager.preferences
         )
@@ -289,8 +295,10 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
                     switch completion {
                     case .finished:
                         debug(.nightscout, "Preferences uploaded")
+                        self.isPreferencesUploaded = 0
                     case let .failure(error):
                         debug(.nightscout, error.localizedDescription)
+                        self.isPreferencesUploaded = 1
                     }
                 } receiveValue: {}
                 .store(in: &self.lifetime)


### PR DESCRIPTION
Add section to Nightscout for Manual Uploads, starting with just uploadPreferences

Simplify the whole pushSettings code from before ... uploading statistics out of schedule isn't critical as uploading preferences.