### PR TITLE
ISSUE-257 | Fix typo in `Last loop was more than` message

### DIFF
--- a/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ar.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ca.lproj/Localizable.strings
@@ -940,7 +940,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/da.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/de.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS ist nicht aktiv";
 
 /* */
-"Last loop was more then %d min ago" = "Letzter Loop vor mehr als %d Minuten";
+"Last loop was more than %d min ago" = "Letzter Loop vor mehr als %d Minuten";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Zeige Glucosewert auf dem App Symbol";

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
  "iAPS not active" = "iAPS not active";
 
  /* */
- "Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+ "Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/es.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fi.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/fr.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS pas actif";
 
 /* */
-"Last loop was more then %d min ago" = "Dernier bouclage depuis plus de %d min";
+"Last loop was more than %d min ago" = "Dernier bouclage depuis plus de %d min";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Afficher glycémie en tant que badge";

--- a/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/he.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/it.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/it.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS non attivo";
 
 /* */
-"Last loop was more then %d min ago" = "L'ultimo ciclo è stato più di %d min fa";
+"Last loop was more than %d min ago" = "L'ultimo ciclo è stato più di %d min fa";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Mostra il glicemie sul badge dell'app";

--- a/FreeAPS/Sources/Localizations/Main/nb.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/nb.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS ikke aktiv";
 
 /* */
-"Last loop was more then %d min ago" = "Siste loop var mer enn %d min siden";
+"Last loop was more than %d min ago" = "Siste loop var mer enn %d min siden";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Vis blodsukker på app-ikonet";

--- a/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/nl.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS is niet actief!";
 
 /* */
-"Last loop was more then %d min ago" = "Laatste loop was meer dan %d min geleden";
+"Last loop was more than %d min ago" = "Laatste loop was meer dan %d min geleden";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Toon glucosewaarde op de app icoon";

--- a/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pl.lproj/Localizable.strings
@@ -989,7 +989,7 @@ Połączono z Nightscout!";
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-BR.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/pt-PT.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS неактивен";
 
 /* */
-"Last loop was more then %d min ago" = "Последний цикл был более %d минут назад";
+"Last loop was more than %d min ago" = "Последний цикл был более %d минут назад";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Показывать глюкозу на значке приложения";

--- a/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sk.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS not active";
 
 /* */
-"Last loop was more then %d min ago" = "Last loop was more then %d min ago";
+"Last loop was more than %d min ago" = "Last loop was more than %d min ago";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Show glucose on the app badge";

--- a/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS är inte aktiv";
 
 /* */
-"Last loop was more then %d min ago" = "Senaste loopen var mer än %d min sedan";
+"Last loop was more than %d min ago" = "Senaste loopen var mer än %d min sedan";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Visa glukosvärde på app-ikon";

--- a/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/tr.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS etkin değil";
 
 /* */
-"Last loop was more then %d min ago" = "Son döngü %d dak kadar önceydi";
+"Last loop was more than %d min ago" = "Son döngü %d dak kadar önceydi";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Uygulama rozetinde glikozu göster";

--- a/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/uk.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS не активний";
 
 /* */
-"Last loop was more then %d min ago" = "Останній цикл був більше, ніж %d хв тому";
+"Last loop was more than %d min ago" = "Останній цикл був більше, ніж %d хв тому";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "Показувати глюкозу на значку додатку";

--- a/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/zh-Hans.lproj/Localizable.strings
@@ -987,7 +987,7 @@ Enact a temp Basal or a temp target */
 "iAPS not active" = "iAPS 未激活";
 
 /* */
-"Last loop was more then %d min ago" = "上次闭环成功在 %d 分钟前";
+"Last loop was more than %d min ago" = "上次闭环成功在 %d 分钟前";
 
 /* Glucose badge */
 "Show glucose on the app badge" = "在应用图表上显示葡萄糖。";

--- a/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
+++ b/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
@@ -127,7 +127,7 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
     private func scheduleMissingLoopNotifiactions(date _: Date) {
         ensureCanSendNotification {
             let title = NSLocalizedString("iAPS not active", comment: "iAPS not active")
-            let body = NSLocalizedString("Last loop was more then %d min ago", comment: "Last loop was more then %d min ago")
+            let body = NSLocalizedString("Last loop was more than %d min ago", comment: "Last loop was more than %d min ago")
 
             let firstInterval = 20 // min
             let secondInterval = 40 // min


### PR DESCRIPTION
Changed "Last loop was more th**e**n ..." to "Last loop was more th**a**n"