### PR TITLE
Config.xcconfig: Include ../../ConfigOverride.xcconfig

### DIFF
--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -9,4 +9,4 @@ APP_ICON = pod_colorful
 APP_URL_SCHEME = freeaps-x
 
 #include? "ConfigOverride.xcconfig"
-//#include? "../../ConfigOverride.xcconfig"
+#include? "../../ConfigOverride.xcconfig"


### PR DESCRIPTION
Includes ConfigOverride.xcconfig from two directories up as the default configuration. This is helpful when swithcing branches, and is the default fro Loop and other apps too.
