### PR TITLE
Fixed chart display of (temp)basal in darkmode

### DIFF
--- a/FreeAPS/Resources/Assets.xcassets/Colors/Basal.colorset/Contents.json
+++ b/FreeAPS/Resources/Assets.xcassets/Colors/Basal.colorset/Contents.json
@@ -22,10 +22,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "1.000",
-          "green" : "1.000",
-          "red" : "1.000"
+          "alpha" : "0.500",
+          "blue" : "0.988",
+          "green" : "0.588",
+          "red" : "0.118"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
This PR fixes the display of (temp) basal in the chart for darkmode in iAPS. 
It holds additions contained in PR #236, so that that PR can get smaller. 

**Quoting from PR #236:**
> fixed display of (temp) basal bars in dark mode on home screen, i.e. has proper blue-ish color now
![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/32ee3938-22f5-4f41-b4d8-83a4e10a5ebb)