### PR TITLE
Prevent Nightscout collisions from occurring when a transmitter ID is recycled

### DIFF
--- a/FreeAPS/Sources/APS/CGM/DexcomSourceG5.swift
+++ b/FreeAPS/Sources/APS/CGM/DexcomSourceG5.swift
@@ -148,7 +148,7 @@ extension DexcomSourceG5: CGMManagerDelegate {
                 let quantity = newGlucoseSample.quantity
                 let value = Int(quantity.doubleValue(for: .milligramsPerDeciliter))
                 return BloodGlucose(
-                    _id: newGlucoseSample.syncIdentifier,
+                    _id: UUID().uuidString,
                     sgv: value,
                     direction: .init(trendType: newGlucoseSample.trend),
                     date: Decimal(Int(newGlucoseSample.date.timeIntervalSince1970 * 1000)),

--- a/FreeAPS/Sources/APS/CGM/DexcomSourceG6.swift
+++ b/FreeAPS/Sources/APS/CGM/DexcomSourceG6.swift
@@ -153,7 +153,7 @@ extension DexcomSourceG6: CGMManagerDelegate {
                     let quantity = newGlucoseSample.quantity
                     let value = Int(quantity.doubleValue(for: .milligramsPerDeciliter))
                     return BloodGlucose(
-                        _id: newGlucoseSample.syncIdentifier,
+                        _id: UUID().uuidString,
                         sgv: value,
                         direction: .init(trendType: newGlucoseSample.trend),
                         date: Decimal(Int(newGlucoseSample.date.timeIntervalSince1970 * 1000)),

--- a/FreeAPS/Sources/APS/CGM/dexcomSourceG7.swift
+++ b/FreeAPS/Sources/APS/CGM/dexcomSourceG7.swift
@@ -148,7 +148,7 @@ extension DexcomSourceG7: CGMManagerDelegate {
                 let quantity = newGlucoseSample.quantity
                 let value = Int(quantity.doubleValue(for: .milligramsPerDeciliter))
                 return BloodGlucose(
-                    _id: newGlucoseSample.syncIdentifier,
+                    _id: UUID().uuidString,
                     sgv: value,
                     direction: .init(trendType: newGlucoseSample.trend),
                     date: Decimal(Int(newGlucoseSample.date.timeIntervalSince1970 * 1000)),


### PR DESCRIPTION
Generate unique _id value for G5, G6 and G7 to prevent Mongo collisions in Nightscout when Transmitter ID's are re-used (eg: recycling of TxID's by Dexcom OR users with reset enabled transmitters (eg: Anubis)).

Note: this does not fix the discussed issue of re-uploads generating 500 errors for users whom are already affected by issues caused by ID collisions, it only fixes the root cause that kickstarts the issue and ensures it won't happen in the future.