### PR TITLE
Fix Nightscout uploads being held back for FSL users

### DIFF
--- a/FreeAPS/Sources/APS/CGM/LibreTransmitterSource.swift
+++ b/FreeAPS/Sources/APS/CGM/LibreTransmitterSource.swift
@@ -72,7 +72,7 @@ extension BaseLibreTransmitterSource: LibreTransmitterManagerDelegate {
         case let .success(newGlucose):
             let glucose = newGlucose.map { value -> BloodGlucose in
                 BloodGlucose(
-                    _id: value.syncId,
+                    _id: UUID().uuidString,
                     sgv: Int(value.glucose),
                     direction: manager.glucoseDisplay?.trendType
                         .map { .init(trendType: $0) },


### PR DESCRIPTION
Fixes introduced to patch problems with non-unique ID's in Nightscout accidentally ensured that FSL1 and FSL2 users would no longer see their values (BG) uploaded to Nightscout as they do *not* get a valid UUID.

This commit streamlines the _id field with Dexcom G5, G6 and G7 and ensures it has a unique UUID in compliance with commit https://github.com/Artificial-Pancreas/iAPS/commit/7c7693c05332667efdb4a703aa4fe2cc1f979dca by @avouspierre.

This should fix the problems mentioned by @JohnKitching and @antoinekh under issue https://github.com/Artificial-Pancreas/iAPS/issues/280. 
As I do not have an FSL2, I was unable to verify/test this. 