### PR TITLE
Alternative bolus calculator: Color coding

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -11,6 +11,7 @@ extension Bolus {
         @State private var showInfo = false
         @State private var exceededMaxBolus = false
         @State private var keepForNextWiew: Bool = false
+        @State private var displayError = false
 
         private enum Config {
             static let dividerHeight: CGFloat = 2
@@ -98,23 +99,83 @@ extension Bolus {
 
                     if state.waitForSuggestion {
                         HStack {
+                            Image(systemName: "timer").foregroundColor(.secondary)
                             Text("Wait please").foregroundColor(.secondary)
                             Spacer()
-                            ActivityIndicator(isAnimating: .constant(true), style: .medium) // fix iOS 15 bug
+                            Image(systemName: "timer").foregroundColor(.secondary)
+                            Text("Beräknar...").foregroundColor(.secondary)
                         }
-                    } else {
+                    }
+                    if state.error && state.insulinCalculated > 0 {
                         HStack {
-                            Text("Recommended Bolus")
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                                .onTapGesture {
+                                    showInfo.toggle()
+                                }
+                            Text("Wait before Bolusing")
+                                .foregroundColor(.orange)
+                                .onTapGesture {
+                                    showInfo.toggle()
+                                }
                             Spacer()
                             Text(
                                 formatter
-                                    .string(from: Double(state.insulinCalculated) as NSNumber) ?? ""
-                            )
+                                    .string(from: state.insulinCalculated as NSNumber)! +
+                                    NSLocalizedString(" U", comment: "Insulin unit")
+                            ).foregroundColor(.orange)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    displayError = true
+                                }
+                        }
+                    } else if state.insulinCalculated <= 0 {
+                        HStack {
+                            Image(systemName: "x.circle.fill")
+                                .foregroundColor(.loopRed)
+                                .onTapGesture {
+                                    showInfo.toggle()
+                                }
+                            Text("No Bolus recommended")
+                                .foregroundColor(.loopRed)
+                                .onTapGesture {
+                                    showInfo.toggle()
+                                }
+                            Spacer()
                             Text(
-                                NSLocalizedString(" U", comment: "Unit in number of units delivered (keep the space character!)")
-                            ).foregroundColor(.secondary)
-                        }.contentShape(Rectangle())
-                            .onTapGesture { state.amount = state.insulinCalculated }
+                                formatter
+                                    .string(from: state.insulinCalculated as NSNumber)! +
+                                    NSLocalizedString(" U", comment: "Insulin unit")
+                            ).foregroundColor(.loopRed)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    showInfo.toggle()
+                                    state.insulinCalculated = state.calculateInsulin()
+                                }
+                        }
+                    } else {
+                        HStack {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                                .onTapGesture {
+                                    showInfo.toggle()
+                                }
+                            Text("Suggested Bolus")
+                                .foregroundColor(.green)
+                                .onTapGesture {
+                                    showInfo.toggle()
+                                }
+                            Spacer()
+                            Text(
+                                formatter
+                                    .string(from: state.insulinCalculated as NSNumber)! +
+                                    NSLocalizedString(" U", comment: "Insulin unit")
+                            ).foregroundColor(.green)
+                                .contentShape(Rectangle())
+                                .onTapGesture {
+                                    state.amount = state.insulinCalculated
+                                }
+                        }
                     }
 
                     if !state.waitForSuggestion {
@@ -138,7 +199,8 @@ extension Bolus {
                             }
                         }
                     }
-                } header: { Text("Bolus Summary") }
+                }
+                header: { Text("Bolus Summary") }
 
                 if state.amount > 0 {
                     Section {
@@ -163,6 +225,20 @@ extension Bolus {
                         label: { Text("Continue without bolus") }.frame(maxWidth: .infinity, alignment: .center)
                     }
                 }
+            }
+            .alert(isPresented: $displayError) {
+                Alert(
+                    title: Text("Warning!"),
+                    message: Text("\n" + alertString() + "\n"),
+                    primaryButton: .destructive(
+                        Text("Add"),
+                        action: {
+                            state.amount = state.insulinCalculated
+                            displayError = false
+                        }
+                    ),
+                    secondaryButton: .cancel()
+                )
             }
             .blur(radius: showInfo ? 3 : 0)
             .navigationTitle("Enact Bolus")
@@ -503,6 +579,68 @@ extension Bolus {
                     Text(" U")
                         .foregroundColor(.secondary)
                 }
+            }
+        }
+
+        private func alertString() -> String {
+            switch state.errorString {
+            case 1,
+                 2:
+                return NSLocalizedString(
+                    "Eventual Glucose > Target Glucose, but glucose is predicted to first drop down to ",
+                    comment: "Bolus pop-up / Alert string. Make translations concise!"
+                ) + state.minGuardBG
+                    .formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))) + " " +
+                    state.units
+                    .rawValue + ", " +
+                    NSLocalizedString(
+                        "which is below your Threshold (",
+                        comment: "Bolus pop-up / Alert string. Make translations concise!"
+                    ) + state
+                    .threshold
+                    .formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))) + ")"
+            case 3:
+                return NSLocalizedString(
+                    "Eventual Glucose > Target Glucose, but glucose is climbing slower than expected. Expected: ",
+                    comment: "Bolus pop-up / Alert string. Make translations concise!"
+                ) +
+                    state.expectedDelta
+                    .formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))) +
+                    NSLocalizedString(". Climbing: ", comment: "Bolus pop-up / Alert string. Make translatons concise!") +
+                    state
+                    .minDelta.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits)))
+            case 4:
+                return NSLocalizedString(
+                    "Eventual Glucose > Target Glucose, but glucose is falling faster than expected. Expected: ",
+                    comment: "Bolus pop-up / Alert string. Make translations concise!"
+                ) +
+                    state.expectedDelta
+                    .formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))) +
+                    NSLocalizedString(". Falling: ", comment: "Bolus pop-up / Alert string. Make translations concise!") +
+                    state
+                    .minDelta.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits)))
+            case 5:
+                return NSLocalizedString(
+                    "Eventual Glucose > Target Glucose, but glucose is changing faster than expected. Expected: ",
+                    comment: "Bolus pop-up / Alert string. Make translations concise!"
+                ) +
+                    state.expectedDelta
+                    .formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))) +
+                    NSLocalizedString(". Changing: ", comment: "Bolus pop-up / Alert string. Make translations concise!") +
+                    state
+                    .minDelta.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits)))
+            case 6:
+                return NSLocalizedString(
+                    "Eventual Glucose > Target Glucose, but glucose is predicted to first drop down to ",
+                    comment: "Bolus pop-up / Alert string. Make translations concise!"
+                ) + state
+                    .minPredBG
+                    .formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))) + " " +
+                    state
+                    .units
+                    .rawValue
+            default:
+                return "Ignore Warning..."
             }
         }
     }


### PR DESCRIPTION
- Implement same warnings based on prediction as in default boluscalc
- Color coding of suggestion based on warning and insulincalculated
- This is my first PR targeting the bolus calculator. Upcoming changes will focus on color coding and formatting of the calculator popup

![dark green](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/8425b74f-5b9b-4e7e-92b6-1c0778154760)
![dark orange](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/f5519977-c7b9-4af4-9c9a-9973a7c54b61)
![dark orange warning](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/7e754c72-b263-4d4b-842a-5f057261dec8)
![dark red](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/e13297f6-fa36-4b8d-9f5b-c8e840e79ba0)
![Light green](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/1f8c5c7d-04ae-4056-bc1a-8c1066bfd4b7)
![Light orange](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/707b2942-a26c-4a85-ba90-7035be32d5ee)
![light orange warning'](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/9d588323-dc55-46b9-9391-6b092b698191)
![light red](https://github.com/Artificial-Pancreas/iAPS/assets/72826201/48ee2b86-d910-4dc4-985e-e823806ee124)
