### PR TITLE
Change Profile Editor Slider Numbering Positioning

### DIFF
--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -72,6 +72,14 @@ extension OverrideProfilesConfig {
                 }
                 Section {
                     VStack {
+                        Spacer()
+                        Text("\(state.percentage.formatted(.number)) %")
+                            .foregroundColor(
+                                state
+                                    .percentage >= 130 ? .red :
+                                    (isEditing ? .orange : .blue)
+                            )
+                            .font(.largeTitle)
                         Slider(
                             value: $state.percentage,
                             in: 10 ... 200,
@@ -80,13 +88,6 @@ extension OverrideProfilesConfig {
                                 isEditing = editing
                             }
                         ).accentColor(state.percentage >= 130 ? .red : .blue)
-                        Text("\(state.percentage.formatted(.number)) %")
-                            .foregroundColor(
-                                state
-                                    .percentage >= 130 ? .red :
-                                    (isEditing ? .orange : .blue)
-                            )
-                            .font(.largeTitle)
                         Spacer()
                         Toggle(isOn: $state._indefinite) {
                             Text("Enable indefinitely")


### PR DESCRIPTION
# Content
This PR addresses the feature request of #291 and changes the position for the slider numbering so that a finger does no longer block the number when sliding the percentage. 

# UI Changes
| Before | After **\*NEW\*** |
|--------|--------|
| <img width="592" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/17a1a893-40c2-4050-95dd-7bd4ab464703"> | <img width="592" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/b5c4bd62-4e3f-422c-b191-920d57dc4dae"> | 