### PR TITLE
Change Temp Target Slider Numbering Positioning

### DIFF
--- a/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
+++ b/FreeAPS/Sources/Modules/AddTempTarget/View/AddTempTargetRootView.swift
@@ -41,10 +41,12 @@ extension AddTempTarget {
                 }
 
                 if state.viewPercantage {
-                    Section(
-                        header: Text("")
-                    ) {
+                    Section {
                         VStack {
+                            Text("\(state.percentage.formatted(.number)) % Insulin")
+                                .foregroundColor(isEditing ? .orange : .blue)
+                                .font(.largeTitle)
+                                .padding(.vertical)
                             Slider(
                                 value: $state.percentage,
                                 in: 15 ...
@@ -54,33 +56,27 @@ extension AddTempTarget {
                                     isEditing = editing
                                 }
                             )
-                            HStack {
-                                Text("\(state.percentage.formatted(.number)) % Insulin")
-                                    .foregroundColor(isEditing ? .orange : .blue)
-                                    .font(.largeTitle)
-                            }
                             // Only display target slider when not 100 %
                             if state.percentage != 100 {
+                                Spacer()
                                 Divider()
+                                Text(
+                                    (
+                                        state
+                                            .units == .mmolL ?
+                                            "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
+                                            "\(state.computeTarget().formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) mg/dl"
+                                    )
+                                        + NSLocalizedString(" Target Glucose", comment: "")
+                                )
+                                .foregroundColor(.green)
+                                .padding(.vertical)
 
                                 Slider(
                                     value: $state.hbt,
                                     in: 101 ... 295,
                                     step: 1
                                 ).accentColor(.green)
-
-                                HStack {
-                                    Text(
-                                        (
-                                            state
-                                                .units == .mmolL ?
-                                                "\(state.computeTarget().asMmolL.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1)))) mmol/L" :
-                                                "\(state.computeTarget().formatted(.number.grouping(.never).rounded().precision(.fractionLength(0)))) mg/dl"
-                                        )
-                                            + NSLocalizedString("  Target Glucose", comment: "")
-                                    )
-                                    .foregroundColor(.green)
-                                }
                             }
                         }
                     }


### PR DESCRIPTION
This PR changes the slider number positioning for the Temp Target editor to be consistent with the changed positioning of the profile override percentage slider introduced with PR #316. It thereby adheres to feature request as of #291. 

Side notes:
* A little more spacing was also added to give the thumb/finger a bit more screen space to control the slider
* The empty section heading (`Section(header: Text(""))`) was removed to get consistent `Section` spacing.

| Before | After \***NEW\*** |
|--------|--------|
| <img width="592" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/d59ff110-1004-45d8-9ed2-1580f21521ba"> | <img width="592" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/18a75e3f-4325-4b33-8f00-1797c4c2dad4"> |
| <img width="592" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/48a74251-b271-415a-b2af-52ab926546e6"> | <img width="592" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/b2284939-6bb0-4b05-8048-1c32edfcee85"> | 