### PR TITLE
Update to Cancel Bolus Action

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -313,14 +313,19 @@ extension Home {
                     Text("Max IOB: 0").font(.callout).foregroundColor(.orange).padding(.trailing, 20)
                 }
 
-                if let progress = state.bolusProgress {
-                    Text("Bolusing")
-                        .font(.system(size: 12, weight: .bold)).foregroundColor(.insulin)
-                    ProgressView(value: Double(progress))
-                        .progressViewStyle(BolusProgressViewStyle())
-                        .padding(.trailing, 8)
-                        .onTapGesture {
-                            state.cancelBolus()
+                Button(action: {
+                        state.cancelBolus()
+                    }) {
+                        HStack {
+                            Text("Bolusing")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundColor(.insulin)
+                            ProgressView(value: Double(progress))
+                                .progressViewStyle(BolusProgressViewStyle())
+                                .padding(.trailing, 8)
+                        }
+                    }
+                    .contentShape(Rectangle())
                         }
                 }
             }

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -313,7 +313,7 @@ extension Home {
                     Text("Max IOB: 0").font(.callout).foregroundColor(.orange).padding(.trailing, 20)
                 }
 
-                Button(action: {
+                                    Button(action: {
                         state.cancelBolus()
                     }) {
                         HStack {
@@ -326,7 +326,7 @@ extension Home {
                         }
                     }
                     .contentShape(Rectangle())
-                        }
+                    .onTapGesture {}
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: 30)


### PR DESCRIPTION
Update to HomeRootView.swift to add a button that encompasses both the bolusing icon and text "Bolusing" to make canceling a bolus easier to tap when needed. Visually, it is identical to previous versions.