### PR TITLE
Make "Max IOB 0" warning more prominent

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -310,7 +310,10 @@ extension Home {
                 }
 
                 if state.closedLoop, state.settingsManager.preferences.maxIOB == 0 {
-                    Text("Max IOB: 0").font(.callout).foregroundColor(.orange).padding(.trailing, 20)
+                    (Text(Image(systemName: "exclamationmark.triangle")) + Text(" Max IOB: 0"))
+                        .font(.callout)
+                        .foregroundColor(.red)
+                        .padding(.trailing, 8)
                 }
 
                 if let progress = state.bolusProgress {


### PR DESCRIPTION
## Description

On many occasions, there have been confused iAPS beginners around the warning `Max IOB: 0` that is displayed on the home screen. It's been one of the more frequently asked questions on FB and it was also prominently explained on one of the Loop'n'Learn YouTube iAPS Walkthrough videos. Recently, a user on Discord thought that this mean "No limit" – and was wondering why there were no SMBs given. So this still seems to be an issue!

## Content
This PR introduces a small warning icon and changes the text from orange to make this warning more prominent. It makes it more obvious that there is something "wrong", when a user has closed loop enabled and still has max IOB set to 0. It also adjusts to `.padding` to be consistent with all other elements in the top right corner of the info area, so `.padding(.trailing, 8)`.

## UI Changes
| Before | After |
|--------|--------|
| <img width="442" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/be22bbf2-4f64-440c-b9ec-577a99dbc066"> | <img width="424" alt="image" src="https://github.com/Artificial-Pancreas/iAPS/assets/48965855/78a22fe5-ad63-45c4-bf58-c5ca13342990"> |