### PR TITLE
Update Bolus Cancel Button

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -314,17 +314,15 @@ extension Home {
                 }
 
                 if let progress = state.bolusProgress {
-                    Button(action: {
+                    HStack {
+                        Text("Bolusing")
+                            .font(.system(size: 12, weight: .bold)).foregroundColor(.insulin)
+                        ProgressView(value: Double(progress))
+                            .progressViewStyle(BolusProgressViewStyle())
+                            .padding(.trailing, 8)
+                    }
+                    .onTapGesture {
                         state.cancelBolus()
-                    }) {
-                        HStack {
-                            Text("Bolusing")
-                                .font(.system(size: 12, weight: .bold))
-                                .foregroundColor(.insulin)
-                            ProgressView(value: Double(progress))
-                                .progressViewStyle(BolusProgressViewStyle())
-                                .padding(.trailing, 8)
-                        }
                     }
                 }
             }

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -314,14 +314,18 @@ extension Home {
                 }
 
                 if let progress = state.bolusProgress {
-                    Text("Bolusing")
-                        .font(.system(size: 12, weight: .bold)).foregroundColor(.insulin)
-                    ProgressView(value: Double(progress))
-                        .progressViewStyle(BolusProgressViewStyle())
-                        .padding(.trailing, 8)
-                        .onTapGesture {
-                            state.cancelBolus()
+                    Button(action: {
+                        state.cancelBolus()
+                    }) {
+                        HStack {
+                            Text("Bolusing")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundColor(.insulin)
+                            ProgressView(value: Double(progress))
+                                .progressViewStyle(BolusProgressViewStyle())
+                                .padding(.trailing, 8)
                         }
+                    }
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: 30)


### PR DESCRIPTION
This PR addresses concerns over being unable to cancel a bolus due to the icon being too small. This creates a button encompassing the existing text and icon, so users can cancel by tapping either part of the status instead of just the icon. The appearance of the app is unchanged.