### PR TITLE
Add branch+commit to "What to Test" field in TestFlight.

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,6 +126,7 @@ platform :ios do
       skip_submission: false,
       ipa: "iAPS.ipa",
       skip_waiting_for_build_processing: true,
+      changelog: git_branch+" "+last_git_commit[:abbreviated_commit_hash],
     )
   end
 


### PR DESCRIPTION
Adds the branch and last commit to the "What to Test" field in TestFlight to more easily determine the version of each available option in your TestFlight is.

![IMG_3165](https://github.com/Artificial-Pancreas/iAPS/assets/82073483/08e8e811-6a9b-4d65-ac0b-17f239793421)
