### PR TITLE
Remove trailing slash from NS URL 

### DIFF
--- a/FreeAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FreeAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -30,7 +30,7 @@
       },
       {
         "package": "SwiftCharts",
-        "repositoryURL": "https://github.com/ivanschuetz/SwiftCharts",
+        "repositoryURL": "https://github.com/ivanschuetz/SwiftCharts.git",
         "state": {
           "branch": "master",
           "revision": "c354c1945bb35a1f01b665b22474f6db28cba4a2",

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -508,21 +508,6 @@ struct MainChartView: View {
         }
     }
 
-    private func fpuView(fullSize: CGSize) -> some View {
-        ZStack {
-            fpuPath
-                .fill(.orange.opacity(0.5))
-            fpuPath
-                .stroke(Color.primary, lineWidth: 0.2)
-        }
-        .onChange(of: carbs) { _ in
-            calculateFPUsDots(fullSize: fullSize)
-        }
-        .onChange(of: didAppearTrigger) { _ in
-            calculateFPUsDots(fullSize: fullSize)
-        }
-    }
-
     private func tempTargetsView(fullSize: CGSize) -> some View {
         ZStack {
             tempTargetsPath

--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -61,6 +61,10 @@ extension NightscoutConfig {
         }
 
         func connect() {
+            if let CheckURL = url.last, CheckURL == "/" {
+                let fixedURL = url.dropLast()
+                url = String(fixedURL)
+            }
             guard let url = URL(string: url) else {
                 message = "Invalid URL"
                 return


### PR DESCRIPTION
Remove trailing slash from Nightscout URL, if entered as such by the user, to prevent 404/"Not Found!" errors due to double slashes in the full URI/path.

This fixes #355. Thanks to @Jon-b-m :) 