### PR TITLE
Remove trailing slash from NS URL

### DIFF
--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -61,6 +61,10 @@ extension NightscoutConfig {
         }
 
         func connect() {
+            if let CheckURL = url.last, CheckURL == "/" {
+                let fixedURL = url.dropLast()
+                url = String(fixedURL)
+            }
             guard let url = URL(string: url) else {
                 message = "Invalid URL"
                 return


### PR DESCRIPTION
Remove trailing slash from Nightscout URL, if entered as such by the user, to prevent 404/"Not Found!" errors due to double slashes in the full URI/path.

This fixes https://github.com/Artificial-Pancreas/iAPS/issues/355. Thanks to @Jon-b-m :)