### PR TITLE
ISSUE-381 | Replace dummy text in `APP EXPLANATION` on Apple Watch

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -3326,9 +3326,9 @@
 				INFOPLIST_FILE = "FreeAPSWatch WatchKit Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "iAPS WatchKit Extension";
 				INFOPLIST_KEY_CLKComplicationPrincipalClass = FreeAPSWatch_WatchKit_Extension.ComplicationController;
-				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "Bla bla Record Health";
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "Bla bla Share Health";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Bla bla Update Health";
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = NO;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -3366,9 +3366,9 @@
 				INFOPLIST_FILE = "FreeAPSWatch WatchKit Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "iAPS WatchKit Extension";
 				INFOPLIST_KEY_CLKComplicationPrincipalClass = FreeAPSWatch_WatchKit_Extension.ComplicationController;
-				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "Bla bla Record Health";
-				INFOPLIST_KEY_NSHealthShareUsageDescription = "Bla bla Share Health";
-				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "Bla bla Update Health";
+				INFOPLIST_KEY_NSHealthClinicalHealthRecordsShareUsageDescription = "For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.";
+				INFOPLIST_KEY_NSHealthUpdateUsageDescription = "For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INFOPLIST_KEY_WKRunsIndependentlyOfCompanionApp = NO;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/FreeAPSWatch WatchKit Extension/Info.plist
+++ b/FreeAPSWatch WatchKit Extension/Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>NSHealthClinicalHealthRecordsShareUsageDescription</key>
-	<string>Bla bla Record Health</string>
+	<string>For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>Bla bla Share Health</string>
+	<string>For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>Bla bla Update Health</string>
+	<string>For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
#381

## Blocked by

- [ ] Add [localization support](https://developer.apple.com/forums/thread/124254)

## Changes

- Replaced `Bla bla {Record,Share,Update}` text with `For the iAPS app to work on the Apple Watch, please ensure that you have enabled HealthKit permissions.`