### PR TITLE
Rework Alternative Bolus Calculator Popup

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -45,12 +45,11 @@ extension Bolus {
         @Published var fifteenMinInsulin: Decimal = 0
         @Published var deltaBG: Decimal = 0
         @Published var targetDifferenceInsulin: Decimal = 0
+        @Published var targetDifference: Decimal = 0
         @Published var wholeCobInsulin: Decimal = 0
         @Published var iobInsulinReduction: Decimal = 0
         @Published var wholeCalc: Decimal = 0
-        @Published var roundedWholeCalc: Decimal = 0
         @Published var insulinCalculated: Decimal = 0
-        @Published var roundedInsulinCalculated: Decimal = 0
         @Published var fraction: Decimal = 0
         @Published var useCalc: Bool = false
         @Published var basal: Decimal = 0
@@ -115,7 +114,7 @@ extension Bolus {
                 conversion = 0.0555
             }
             // insulin needed for the current blood glucose
-            let targetDifference = (currentBG - target) * conversion
+            targetDifference = (currentBG - target) * conversion
             targetDifferenceInsulin = targetDifference / isf
 
             // more or less insulin because of bg trend in the last 15 minutes
@@ -140,9 +139,6 @@ extension Bolus {
                     wholeCalc = (targetDifferenceInsulin + iobInsulinReduction + wholeCobInsulin)
                 }
             }
-            // rounding
-            let wholeCalcAsDouble = Double(wholeCalc)
-            roundedWholeCalc = Decimal(round(100 * wholeCalcAsDouble) / 100)
 
             // apply custom factor at the end of the calculations
             let result = wholeCalc * fraction
@@ -156,8 +152,6 @@ extension Bolus {
 
             // display no negative insulinCalculated
             insulinCalculated = max(insulinCalculated, 0)
-            let insulinCalculatedAsDouble = Double(insulinCalculated)
-            roundedInsulinCalculated = Decimal(round(100 * insulinCalculatedAsDouble) / 100)
             insulinCalculated = min(insulinCalculated, maxBolus)
 
             return apsManager

--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -308,7 +308,7 @@ extension Bolus {
             GridRow(alignment: .top) {
                 Color.clear.gridCellUnsizedAxes([.horizontal, .vertical])
 
-                Text("(Current - Target) / ISF").foregroundColor(.secondary.opacity(0.65)).gridColumnAlignment(.leading)
+                Text("(Current - Target) / ISF").foregroundColor(.secondary.opacity(colorScheme == .dark ? 0.65 : 0.8)).gridColumnAlignment(.leading)
                     .gridCellColumns(2)
             }
             .font(.caption)
@@ -323,7 +323,7 @@ extension Bolus {
                     )
                 }
 
-                Text("Subtract IOB").foregroundColor(.secondary.opacity(0.65)).font(.footnote)
+                Text("Subtract IOB").foregroundColor(.secondary.opacity(colorScheme == .dark ? 0.65 : 0.8)).font(.footnote)
 
                 HStack {
                     Text(
@@ -371,7 +371,7 @@ extension Bolus {
             GridRow(alignment: .center) {
                 Color.clear.gridCellUnsizedAxes([.horizontal, .vertical])
 
-                Text("COB / Carb Ratio").foregroundColor(.secondary.opacity(0.65)).gridColumnAlignment(.leading)
+                Text("COB / Carb Ratio").foregroundColor(.secondary.opacity(colorScheme == .dark ? 0.65 : 0.8)).gridColumnAlignment(.leading)
                     .gridCellColumns(2)
             }
             .font(.caption)
@@ -418,7 +418,7 @@ extension Bolus {
                         state.units.rawValue
                 )
 
-                Text("15min Delta / ISF").font(.caption).foregroundColor(.secondary.opacity(0.65)).gridColumnAlignment(.leading)
+                Text("15min Delta / ISF").font(.caption).foregroundColor(.secondary.opacity(colorScheme == .dark ? 0.65 : 0.8)).gridColumnAlignment(.leading)
                     .gridCellColumns(2).padding(.top, 5)
             }
         }
@@ -480,14 +480,14 @@ extension Bolus {
             GridRow(alignment: .bottom) {
                 if state.useFattyMealCorrectionFactor {
                     Text("Factor x Fatty Meal Factor x Full Bolus")
-                        .foregroundColor(.secondary.opacity(0.65))
+                        .foregroundColor(.secondary.opacity(colorScheme == .dark ? 0.65 : 0.8))
                         .font(.caption)
                         .gridCellAnchor(.center)
                         .gridCellColumns(3)
                 } else {
                     Color.clear.gridCellUnsizedAxes([.horizontal, .vertical])
                     Text("Factor x Full Bolus")
-                        .foregroundColor(.secondary.opacity(0.65))
+                        .foregroundColor(.secondary.opacity(colorScheme == .dark ? 0.65 : 0.8))
                         .font(.caption)
                         .padding(.top, 5)
                         .gridCellAnchor(.leading)

--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -356,7 +356,7 @@ extension Bolus {
                 HStack {
                     Text("Carb Ratio")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     Text(state.carbRatio.formatted())
                         .frame(minWidth: 40, alignment: .trailing)
@@ -368,7 +368,7 @@ extension Bolus {
                 HStack {
                     Text("ISF")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let isf = state.isf
                     Text(isf.formatted())
@@ -381,7 +381,7 @@ extension Bolus {
                 HStack {
                     Text("Target Glucose")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let target = state.units == .mmolL ? state.target.asMmolL : state.target
 
@@ -397,7 +397,7 @@ extension Bolus {
                 HStack {
                     Text("Basal")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let basal = state.basal
                     Text(basal.formatted())
@@ -410,7 +410,7 @@ extension Bolus {
                 HStack {
                     Text("Fraction")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let fraction = state.fraction
                     Text(fraction.formatted())
@@ -422,7 +422,7 @@ extension Bolus {
                     HStack {
                         Text("Fatty Meal Factor")
                             .foregroundColor(.orange)
-                            .frame(minWidth: 120, alignment: .leading)
+                            .frame(minWidth: 115, alignment: .leading)
 //                        Spacer()
                         let fraction = state.fattyMealFactor
                         Text(fraction.formatted())
@@ -440,14 +440,14 @@ extension Bolus {
                 HStack(alignment: .center, spacing: nil) {
                     Text("Glucose")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let glucose = state.units == .mmolL ? state.currentBG.asMmolL : state.currentBG
                     Text(glucose.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))))
                         .frame(minWidth: 40, alignment: .trailing)
                     Text(state.units.rawValue)
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 80, alignment: .leading)
+                        .frame(minWidth: 70, alignment: .leading)
 //                    Spacer()
                     Image(systemName: "arrow.right")
                         .frame(minWidth: 20, alignment: .trailing)
@@ -464,7 +464,7 @@ extension Bolus {
                 HStack(alignment: .center, spacing: nil) {
                     Text("IOB")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let iob = state.iob
                     // rounding
@@ -474,7 +474,7 @@ extension Bolus {
                         .frame(minWidth: 40, alignment: .trailing)
                     Text("U")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 80, alignment: .leading)
+                        .frame(minWidth: 70, alignment: .leading)
 //                    Spacer()
 
                     Image(systemName: "arrow.right")
@@ -491,13 +491,13 @@ extension Bolus {
                 HStack(alignment: .center, spacing: nil) {
                     Text("Trend")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let trend = state.units == .mmolL ? state.deltaBG.asMmolL : state.deltaBG
                     Text(trend.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))))
                         .frame(minWidth: 40, alignment: .trailing)
                     Text(state.units.rawValue).foregroundColor(.secondary)
-                        .frame(minWidth: 80, alignment: .leading)
+                        .frame(minWidth: 70, alignment: .leading)
 //                    Spacer()
 
                     Image(systemName: "arrow.right")
@@ -515,7 +515,7 @@ extension Bolus {
                 HStack(alignment: .center, spacing: nil) {
                     Text("COB")
                         .foregroundColor(.secondary)
-                        .frame(minWidth: 120, alignment: .leading)
+                        .frame(minWidth: 115, alignment: .leading)
 //                    Spacer()
                     let cob = state.cob
                     Text(cob.formatted())
@@ -523,7 +523,7 @@ extension Bolus {
 
                     let unitGrams = NSLocalizedString("g", comment: "grams")
                     Text(unitGrams).foregroundColor(.secondary)
-                        .frame(minWidth: 80, alignment: .leading)
+                        .frame(minWidth: 70, alignment: .leading)
 
 //                    Spacer()
 

--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -201,9 +201,6 @@ extension Bolus {
                         selection: $calculatorDetent
                     )
             }
-//            .popup(isPresented: showInfo) {
-//                bolusInfoAlternativeCalculator
-//            }
         }
 
         var predictionChart: some View {
@@ -221,19 +218,12 @@ extension Bolus {
                 VStack {
                     VStack {
                         VStack(spacing: Config.spacing) {
-                            //                        HStack {
-                            //                        Text("Calculations")
-                            //                            .font(.title3).frame(maxWidth: .infinity, alignment: .center)
-                            //                        }
-                            //                            .padding(10)
-
-                            settings.padding()
-
                             if fetch {
-                                Divider().frame(height: Config.dividerHeight) // .overlay(Config.overlayColour)
                                 mealEntries.padding()
-//                                Divider().frame(height: Config.dividerHeight) // .overlay(Config.overlayColour)
+                                Divider().frame(height: Config.dividerHeight) // .overlay(Config.overlayColour)
                             }
+                            
+                            settings.padding()
                         }
                         Divider().frame(height: Config.dividerHeight) // .overlay(Config.overlayColour)
                         insulinParts.padding()
@@ -264,18 +254,6 @@ extension Bolus {
                             .foregroundStyle(Color.loopRed)
                         }
                     }
-//                    .padding(.top, 10)
-//                    .padding(.bottom, 15)
-                    // Hide pop-up
-//                    VStack {
-//                        Button { showInfo = false }
-//                        label: { Text("OK") }
-//                            .frame(maxWidth: .infinity, alignment: .center)
-//                            .font(.system(size: 16))
-//                            .fontWeight(.semibold)
-//                            .foregroundColor(.blue)
-//                    }
-//                    .padding(.bottom, 20)
 
                     Spacer()
                 }
@@ -287,11 +265,6 @@ extension Bolus {
                     }
                 }
             }
-            //            .font(.footnote)
-            //            .background(
-            //                RoundedRectangle(cornerRadius: 10, style: .continuous)
-            //                    .fill(Color(colorScheme == .dark ? UIColor.systemGray4 : UIColor.systemGray6))
-            //            )
         }
 
         private var disabled: Bool {
@@ -357,7 +330,6 @@ extension Bolus {
                     Text("Carb Ratio")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     Text(state.carbRatio.formatted())
                         .frame(minWidth: 40, alignment: .trailing)
                     Text(NSLocalizedString("g/U", comment: " grams per Unit"))
@@ -369,7 +341,6 @@ extension Bolus {
                     Text("ISF")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let isf = state.isf
                     Text(isf.formatted())
                         .frame(minWidth: 40, alignment: .trailing)
@@ -382,7 +353,6 @@ extension Bolus {
                     Text("Target Glucose")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let target = state.units == .mmolL ? state.target.asMmolL : state.target
 
                     Text(
@@ -398,7 +368,6 @@ extension Bolus {
                     Text("Basal")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let basal = state.basal
                     Text(basal.formatted())
                         .frame(minWidth: 40, alignment: .trailing)
@@ -411,7 +380,6 @@ extension Bolus {
                     Text("Fraction")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let fraction = state.fraction
                     Text(fraction.formatted())
                         .frame(minWidth: 40, alignment: .trailing)
@@ -423,7 +391,6 @@ extension Bolus {
                         Text("Fatty Meal Factor")
                             .foregroundColor(.orange)
                             .frame(minWidth: 115, alignment: .leading)
-//                        Spacer()
                         let fraction = state.fattyMealFactor
                         Text(fraction.formatted())
                         foregroundColor(.orange)
@@ -441,14 +408,12 @@ extension Bolus {
                     Text("Glucose")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let glucose = state.units == .mmolL ? state.currentBG.asMmolL : state.currentBG
                     Text(glucose.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))))
                         .frame(minWidth: 40, alignment: .trailing)
                     Text(state.units.rawValue)
                         .foregroundColor(.secondary)
                         .frame(minWidth: 70, alignment: .leading)
-//                    Spacer()
                     Image(systemName: "arrow.right")
                         .frame(minWidth: 20, alignment: .trailing)
                     Spacer()
@@ -465,7 +430,6 @@ extension Bolus {
                     Text("IOB")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let iob = state.iob
                     // rounding
                     let iobAsDouble = NSDecimalNumber(decimal: iob).doubleValue
@@ -475,7 +439,6 @@ extension Bolus {
                     Text("U")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 70, alignment: .leading)
-//                    Spacer()
 
                     Image(systemName: "arrow.right")
                         .frame(minWidth: 20, alignment: .trailing)
@@ -492,13 +455,11 @@ extension Bolus {
                     Text("Trend")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let trend = state.units == .mmolL ? state.deltaBG.asMmolL : state.deltaBG
                     Text(trend.formatted(.number.grouping(.never).rounded().precision(.fractionLength(fractionDigits))))
                         .frame(minWidth: 40, alignment: .trailing)
                     Text(state.units.rawValue).foregroundColor(.secondary)
                         .frame(minWidth: 70, alignment: .leading)
-//                    Spacer()
 
                     Image(systemName: "arrow.right")
                         .frame(minWidth: 20, alignment: .trailing)
@@ -516,7 +477,6 @@ extension Bolus {
                     Text("COB")
                         .foregroundColor(.secondary)
                         .frame(minWidth: 115, alignment: .leading)
-//                    Spacer()
                     let cob = state.cob
                     Text(cob.formatted())
                         .frame(minWidth: 40, alignment: .trailing)
@@ -524,8 +484,6 @@ extension Bolus {
                     let unitGrams = NSLocalizedString("g", comment: "grams")
                     Text(unitGrams).foregroundColor(.secondary)
                         .frame(minWidth: 70, alignment: .leading)
-
-//                    Spacer()
 
                     Image(systemName: "arrow.right")
                         .frame(minWidth: 20, alignment: .trailing)


### PR DESCRIPTION
## TL;DR
This PR reworks (and adds to) the calculations popup of the **Alternative Bolus Calculator** as of iAPS `dev`.
It introduces a completely refactored layout and adds lots of detail information around the recommended bolus calculations.

## Contents
* Changes the popover to a sheet-based view
* Introduces grid-based layout within view; not based only on VStacks and HStacks
* Introduces calculation formulas and applied math, i.e. filled in formulas with numbers, per single calculation step
* Refactors state model; removes all rounding and rounded values from state model
* Add rounding in view; performed here for formatting only
* Tested on screens down to iPhone 12 mini and up to 15 Pro Max
* Collected feedback from multiple testers (n=7) with screen sizes from iPhone SE to 15 Pro.

## Screen Recording for UI/UX Feel
Recorded on an iPhone 15 Pro simulator build. Download [here via WeTransfer](https://we.tl/t-uFf8BURm6F) due to too large file size (>10 MB).

## Screenhots

**iPhone 15 Pro with and without added meal, with and without fatty meal factor**
| Header | Header | Header |
|--------|--------|--------|
| ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/223788c0-b66a-4ec0-b432-adf2dd632178) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/384cf852-ebb1-4295-8735-070ca565a9ad) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/fb0b7623-4edc-4d24-a6b4-affafa4e91d1) | 
| ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/79f1670a-a7a6-433b-9006-12943f1dd12a) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/48c4c46b-c6da-425e-8c0e-263f51d35d18) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/3ee6e359-9f03-41b5-b0c4-3ce178a44017) |

**iPhone 12 mini with and without added meal, with and without fatty meal factor**

| Header | Header | Header |
|--------|--------|--------|
| ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/e52223bb-4a4e-47f2-acc4-f3123b999609) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/1e43a6e8-ffe7-455b-8f39-8fa3b341b4f8) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/ae8cca69-6974-4918-ae61-dac1ac2171c4) |
| ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/820faf97-6608-4a2b-9145-dc8a99973649) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/6d51ca15-2302-4942-81e8-03e43969602e) | ![image](https://github.com/Artificial-Pancreas/iAPS/assets/48965855/3751039e-b5ff-44ba-a6ec-5fb1699cfdbe) | 

Notes:
* We may want to rename the "factor" to something more descriptive of what it does/means. Open for discussion
* If this design is accepted, I would also rework the popup for the current "default" calculator popup in a similar style.