### PR TITLE
Use same rounding mode for glucose in history as everywhere else

### DIFF
--- a/FreeAPS/Sources/Modules/DataTable/View/DataTableRootView.swift
+++ b/FreeAPS/Sources/Modules/DataTable/View/DataTableRootView.swift
@@ -31,9 +31,10 @@ extension DataTable {
             formatter.numberStyle = .decimal
             formatter.maximumFractionDigits = 0
             if state.units == .mmolL {
+                formatter.minimumFractionDigits = 1
                 formatter.maximumFractionDigits = 1
-                formatter.roundingMode = .ceiling
             }
+            formatter.roundingMode = .halfUp
             return formatter
         }
 


### PR DESCRIPTION
Addresses rounding offset as reported in issue #398 