### PR TITLE
Live activity updates 2

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -3563,7 +3563,7 @@
 				INFOPLIST_FILE = LiveActivity/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LiveActivity;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -3597,7 +3597,7 @@
 				INFOPLIST_FILE = LiveActivity/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = LiveActivity;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/FreeAPS/Sources/Modules/NotificationsConfig/View/NotificationsConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NotificationsConfig/View/NotificationsConfigRootView.swift
@@ -1,3 +1,5 @@
+import ActivityKit
+import Combine
 import SwiftUI
 import Swinject
 
@@ -5,6 +7,14 @@ extension NotificationsConfig {
     struct RootView: BaseView {
         let resolver: Resolver
         @StateObject var state = StateModel()
+
+        @State private var systemLiveActivitySetting: Bool = {
+            if #available(iOS 16.1, *) {
+                ActivityAuthorizationInfo().areActivitiesEnabled
+            } else {
+                false
+            }
+        }()
 
         private var glucoseFormatter: NumberFormatter {
             let formatter = NumberFormatter()
@@ -22,6 +32,19 @@ extension NotificationsConfig {
             formatter.numberStyle = .decimal
             formatter.maximumFractionDigits = 0
             return formatter
+        }
+
+        private func liveActivityFooterText() -> String {
+            var footer =
+                "Live activity displays blood glucose live on the lock screen and on the dynamic island (if available)"
+
+            if !systemLiveActivitySetting {
+                footer =
+                    "Live activities are turned OFF in system settings. To enable live activities, go to Settings app -> iAPS -> Turn live Activities ON.\n\n" +
+                    footer
+            }
+
+            return footer
         }
 
         var body: some View {
@@ -60,11 +83,14 @@ extension NotificationsConfig {
                     Section(
                         header: Text("Live Activity"),
                         footer: Text(
-                            "Live activity displays blood glucose live on the lock screen and on the dynamic island (if available)"
-                        )
-                    ) {
-                        Toggle("Show live activity", isOn: $state.useLiveActivity)
-                    }
+                            liveActivityFooterText()
+                        ),
+                        content: { Toggle("Show live activity", isOn: $state.useLiveActivity) }
+                    )
+                    .disabled(!systemLiveActivitySetting)
+                    .onReceive(resolver.resolve(LiveActivityBridge.self)!.$systemEnabled, perform: {
+                        self.systemLiveActivitySetting = $0
+                    })
                 }
             }
             .onAppear(perform: configureView)

--- a/FreeAPS/Sources/Modules/NotificationsConfig/View/NotificationsConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/NotificationsConfig/View/NotificationsConfigRootView.swift
@@ -85,9 +85,15 @@ extension NotificationsConfig {
                         footer: Text(
                             liveActivityFooterText()
                         ),
-                        content: { Toggle("Show live activity", isOn: $state.useLiveActivity) }
+                        content: {
+                            if !systemLiveActivitySetting {
+                                Button("Open Settings App") {
+                                    UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
+                                }
+                            } else {
+                                Toggle("Show Live Activity", isOn: $state.useLiveActivity) }
+                        }
                     )
-                    .disabled(!systemLiveActivitySetting)
                     .onReceive(resolver.resolve(LiveActivityBridge.self)!.$systemEnabled, perform: {
                         self.systemLiveActivitySetting = $0
                     })

--- a/FreeAPS/Sources/Services/LiveActivity/LiveActitiyShared.swift
+++ b/FreeAPS/Sources/Services/LiveActivity/LiveActitiyShared.swift
@@ -4,7 +4,7 @@ import Foundation
 struct LiveActivityAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {
         let bg: String
-        let trendSystemImage: String?
+        let direction: String?
         let change: String
         let date: Date
     }

--- a/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
+++ b/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
@@ -22,47 +22,19 @@ extension LiveActivityAttributes.ContentState {
     }
 
     init?(new bg: BloodGlucose, prev: BloodGlucose?, mmol: Bool) {
-        guard let glucose = bg.glucose,
-              bg.dateString.timeIntervalSinceNow > -TimeInterval(minutes: 6)
-        else {
+        guard let glucose = bg.glucose else {
             return nil
         }
 
         let formattedBG = Self.formatGlucose(glucose, mmol: mmol, forceSign: false)
 
-        let trendString: String?
-        switch bg.direction {
-        case .doubleUp,
-             .singleUp,
-             .tripleUp:
-            trendString = "arrow.up"
-
-        case .fortyFiveUp:
-            trendString = "arrow.up.right"
-
-        case .flat:
-            trendString = "arrow.right"
-
-        case .fortyFiveDown:
-            trendString = "arrow.down.right"
-
-        case .doubleDown,
-             .singleDown,
-             .tripleDown:
-            trendString = "arrow.down"
-
-        case .notComputable,
-             Optional.none,
-             .rateOutOfRange,
-             .some(.none):
-            trendString = nil
-        }
+        let trendString = bg.direction?.symbol
 
         let change = prev?.glucose.map({
             Self.formatGlucose(glucose - $0, mmol: mmol, forceSign: true)
         }) ?? ""
 
-        self.init(bg: formattedBG, trendSystemImage: trendString, change: change, date: bg.dateString)
+        self.init(bg: formattedBG, direction: trendString, change: change, date: bg.dateString)
     }
 }
 
@@ -86,10 +58,13 @@ extension LiveActivityAttributes.ContentState {
     }
 }
 
-@available(iOS 16.2, *) final class LiveActivityBridge: Injectable {
+@available(iOS 16.2, *) final class LiveActivityBridge: Injectable, ObservableObject {
     @Injected() private var settingsManager: SettingsManager!
     @Injected() private var glucoseStorage: GlucoseStorage!
     @Injected() private var broadcaster: Broadcaster!
+
+    private let activityAuthorizationInfo = ActivityAuthorizationInfo()
+    @Published private(set) var systemEnabled: Bool
 
     private var settings: FreeAPSSettings {
         settingsManager.settings
@@ -99,6 +74,8 @@ extension LiveActivityAttributes.ContentState {
     private var latestGlucose: BloodGlucose?
 
     init(resolver: Resolver) {
+        systemEnabled = activityAuthorizationInfo.areActivitiesEnabled
+
         injectServices(resolver)
         broadcaster.register(GlucoseObserver.self, observer: self)
 
@@ -116,6 +93,20 @@ extension LiveActivityAttributes.ContentState {
             queue: nil
         ) { _ in
             self.forceActivityUpdate()
+        }
+
+        monitorForLiveActivityAuthorizationChanges()
+    }
+
+    private func monitorForLiveActivityAuthorizationChanges() {
+        Task {
+            for await activityState in activityAuthorizationInfo.activityEnablementUpdates {
+                if activityState != systemEnabled {
+                    await MainActor.run {
+                        systemEnabled = activityState
+                    }
+                }
+            }
         }
     }
 
@@ -145,9 +136,9 @@ extension LiveActivityAttributes.ContentState {
             await unknownActivity.end(nil, dismissalPolicy: .immediate)
         }
 
-        let content = ActivityContent(state: state, staleDate: state.date.addingTimeInterval(TimeInterval(6 * 60)))
-
         if let currentActivity {
+            let content = ActivityContent(state: state, staleDate: state.date.addingTimeInterval(TimeInterval(6 * 60)))
+
             if currentActivity.needsRecreation(), UIApplication.shared.applicationState == .active {
                 // activity is no longer visible or old. End it and try to push the update again
                 await endActivity()
@@ -157,12 +148,24 @@ extension LiveActivityAttributes.ContentState {
             }
         } else {
             do {
+                // always push a non-stale content as the first update
+                // pushing a stale content as the frst content results in the activity not being shown at all
+                // we want it shown though even if it is iniially stale, as we expect new BG readings to become available soon, which should then be displayed
+                let nonStale = ActivityContent(
+                    state: LiveActivityAttributes.ContentState(bg: "--", direction: nil, change: "--", date: Date.now),
+                    staleDate: Date.now.addingTimeInterval(60)
+                )
+
                 let activity = try Activity.request(
                     attributes: LiveActivityAttributes(startDate: Date.now),
-                    content: content,
+                    content: nonStale,
                     pushType: nil
                 )
+
                 currentActivity = ActiveActivity(activity: activity, startDate: Date.now)
+
+                // then show the actual content
+                await pushUpdate(state)
             } catch {
                 print("activity creation error: \(error)")
             }
@@ -186,6 +189,15 @@ extension LiveActivityAttributes.ContentState {
 @available(iOS 16.2, *)
 extension LiveActivityBridge: GlucoseObserver {
     func glucoseDidUpdate(_ glucose: [BloodGlucose]) {
+        guard settings.useLiveActivity else {
+            if currentActivity != nil {
+                Task {
+                    await self.endActivity()
+                }
+            }
+            return
+        }
+
         // backfill latest glucose if contained in this update
         if glucose.count > 1 {
             latestGlucose = glucose[glucose.count - 2]
@@ -199,7 +211,7 @@ extension LiveActivityBridge: GlucoseObserver {
             prev: latestGlucose,
             mmol: settings.units == .mmolL
         ) else {
-            // no bg or value stale. Don't update the activity if there already is one, just let it turn stale so that it can still be used once current bg is available again
+            // no bg or value, can't update the live activity
             return
         }
 

--- a/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
+++ b/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
@@ -137,7 +137,10 @@ extension LiveActivityAttributes.ContentState {
         }
 
         if let currentActivity {
-            let content = ActivityContent(state: state, staleDate: state.date.addingTimeInterval(TimeInterval(6 * 60)))
+            let content = ActivityContent(
+                state: state,
+                staleDate: min(state.date, Date.now).addingTimeInterval(TimeInterval(6 * 60))
+            )
 
             if currentActivity.needsRecreation(), UIApplication.shared.applicationState == .active {
                 // activity is no longer visible or old. End it and try to push the update again

--- a/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
+++ b/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
@@ -45,10 +45,10 @@ extension LiveActivityAttributes.ContentState {
     func needsRecreation() -> Bool {
         switch activity.activityState {
         case .dismissed,
-             .ended:
+             .ended,
+             .stale:
             return true
-        case .active,
-             .stale: break
+        case .active: break
         @unknown default:
             return true
         }
@@ -137,16 +137,16 @@ extension LiveActivityAttributes.ContentState {
         }
 
         if let currentActivity {
-            let content = ActivityContent(
-                state: state,
-                staleDate: min(state.date, Date.now).addingTimeInterval(TimeInterval(6 * 60))
-            )
-
             if currentActivity.needsRecreation(), UIApplication.shared.applicationState == .active {
                 // activity is no longer visible or old. End it and try to push the update again
                 await endActivity()
                 await pushUpdate(state)
             } else {
+                let content = ActivityContent(
+                    state: state,
+                    staleDate: min(state.date, Date.now).addingTimeInterval(TimeInterval(6 * 60))
+                )
+
                 await currentActivity.activity.update(content)
             }
         } else {
@@ -178,7 +178,7 @@ extension LiveActivityAttributes.ContentState {
     /// ends all live activities immediateny
     private func endActivity() async {
         if let currentActivity {
-            await currentActivity.activity.end(nil, dismissalPolicy: ActivityUIDismissalPolicy.immediate)
+            await currentActivity.activity.end(nil, dismissalPolicy: .immediate)
             self.currentActivity = nil
         }
 

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -32,7 +32,11 @@ struct LiveActivity: Widget {
     private func updatedLabel(context: ActivityViewContext<LiveActivityAttributes>) -> Text {
         let text = Text("Updated: \(dateFormatter.string(from: context.state.date))")
         if context.isStale {
-            return text.bold().foregroundStyle(.red)
+            if #available(iOSApplicationExtension 17.0, *) {
+                return text.bold().foregroundStyle(.red)
+            } else {
+                return text.bold().foregroundColor(.red)
+            }
         } else {
             return text
         }
@@ -193,6 +197,7 @@ private extension LiveActivityAttributes.ContentState {
     }
 }
 
+@available(iOS 17.0, iOSApplicationExtension 17.0, *)
 #Preview("Notification", as: .content, using: LiveActivityAttributes.preview) {
     LiveActivity()
 } contentStates: {

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -30,37 +30,38 @@ struct LiveActivity: Widget {
         }
     }
 
-    @ViewBuilder func bgAndTrend(context: ActivityViewContext<LiveActivityAttributes>) -> some View {
+    func bgAndTrend(context: ActivityViewContext<LiveActivityAttributes>) -> Text {
         if context.isStale {
-            Text("--")
+            return Text("--")
         } else {
-            Text(context.state.bg)
-            if let trendSystemImage = context.state.trendSystemImage {
-                Image(systemName: trendSystemImage)
+            var str = context.state.bg
+            if let direction = context.state.direction {
+                // half width space
+                str += "\u{2009}" + direction
             }
+            return Text(str)
         }
     }
 
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: LiveActivityAttributes.self) { context in
             // Lock screen/banner UI goes here
-
             HStack(spacing: 3) {
                 bgAndTrend(context: context).font(.title)
                 Spacer()
                 VStack(alignment: .trailing, spacing: 5) {
                     changeLabel(context: context).font(.title3)
-                    updatedLabel(context: context).font(.caption).foregroundStyle(.black.opacity(0.7))
+                    updatedLabel(context: context).font(.caption).foregroundStyle(Color.secondary)
                 }
             }
             .privacySensitive()
-            .imageScale(.small)
             .padding(.all, 15)
-            .background(Color.white.opacity(0.2))
-            .foregroundColor(Color.black)
-            .activityBackgroundTint(Color.cyan.opacity(0.2))
-            .activitySystemActionForegroundColor(Color.black)
-
+            // Semantic BackgroundStyle and Color values work here. They adapt to the given interface style (light mode, dark mode)
+            // Semantic UIColors do NOT (as of iOS 17.1.1). Like UIColor.systemBackgroundColor (it does not adapt to changes of the interface style)
+            // The colorScheme environment varaible that is usually used to detect dark mode does NOT work here (it reports false values)
+            .foregroundStyle(Color.primary)
+            .background(BackgroundStyle.background.opacity(0.4))
+            .activityBackgroundTint(Color.clear)
         } dynamicIsland: { context in
             DynamicIsland {
                 // Expanded UI goes here.  Compose the expanded UI through
@@ -68,7 +69,7 @@ struct LiveActivity: Widget {
                 DynamicIslandExpandedRegion(.leading) {
                     HStack(spacing: 3) {
                         bgAndTrend(context: context)
-                    }.imageScale(.small).font(.title).padding(.leading, 5)
+                    }.font(.title).padding(.leading, 5)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     changeLabel(context: context).font(.title).padding(.trailing, 5)
@@ -80,11 +81,11 @@ struct LiveActivity: Widget {
             } compactLeading: {
                 HStack(spacing: 1) {
                     bgAndTrend(context: context)
-                }.bold().imageScale(.small).padding(.leading, 5)
+                }.padding(.leading, 5)
             } compactTrailing: {
                 changeLabel(context: context).padding(.trailing, 5)
             } minimal: {
-                bgLabel(context: context).bold()
+                bgLabel(context: context)
             }
             .widgetURL(URL(string: "freeaps-x://"))
             .keylineTint(Color.cyan.opacity(0.5))
@@ -100,7 +101,7 @@ private extension LiveActivityAttributes {
 
 private extension LiveActivityAttributes.ContentState {
     static var test: LiveActivityAttributes.ContentState {
-        LiveActivityAttributes.ContentState(bg: "100", trendSystemImage: "arrow.right", change: "+2", date: Date())
+        LiveActivityAttributes.ContentState(bg: "100", direction: "↗︎", change: "+7", date: Date())
     }
 }
 


### PR DESCRIPTION
- Use direction string instead of system icon for trend
- Use semantic colors and improve readability
- Don't hide BG value when data is stale, strikethrough instead
- Prevent flashing live activity briefly when live activities are turned off
- Detect system setting, link to system setting when it is turned off
- Add trend to minimal view (might still get truncated when BG and direction string sum to more than 4 characters)
- Ensure live activity is always started, even when immediately stale
- Fix for iOS < 17