### PR TITLE
Fix a source of possible 0x31 pod faults during pod setup

### DIFF
--- a/Dependencies/OmniBLE/OmniBLE.xcodeproj/project.pbxproj
+++ b/Dependencies/OmniBLE/OmniBLE.xcodeproj/project.pbxproj
@@ -636,15 +636,15 @@
 		84752EAD26ED11A4009FD801 /* PumpManager */ = {
 			isa = PBXGroup;
 			children = (
-				C1C001C027A2349D00533D35 /* OmniBLE.swift */,
 				D8896C6127890E6B00E09A96 /* DetailedStatus+OmniBLE.swift */,
 				10389A2226FF7841002115E9 /* MessageTransport.swift */,
+				C1C001C027A2349D00533D35 /* OmniBLE.swift */,
 				1029AE4627094D0E00B7F5B6 /* OmniBLEPumpManager.swift */,
 				1029AE4727094D0E00B7F5B6 /* OmniBLEPumpManagerState.swift */,
-				102111422709462300784F13 /* PodCommsSession.swift */,
-				1021114C2709467400784F13 /* PodComms.swift */,
-				102111402709462300784F13 /* PodState.swift */,
 				C1D27A1A27911E9900C41EBA /* PodAdvertisement.swift */,
+				1021114C2709467400784F13 /* PodComms.swift */,
+				102111422709462300784F13 /* PodCommsSession.swift */,
+				102111402709462300784F13 /* PodState.swift */,
 			);
 			path = PumpManager;
 			sourceTree = "<group>";

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
@@ -741,9 +741,9 @@ public class PodCommsSession {
         let basalExtraCommand = BasalScheduleExtraCommand.init(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, programReminderInterval: programReminderInterval)
 
         do {
-            if !(podState.lastCommsOK && podState.deliveryStatusVerified) {
-                // Can't trust the current delivery state -- do a cancel all
-                // to be sure that setting a basal program won't fault the pod.
+            if podState.setupProgress == .completed && !(podState.lastCommsOK && podState.deliveryStatusVerified) {
+                // The pod setup is complete and the current delivery state can't be trusted so
+                // do a cancel all to be sure that setting the basal program won't fault the pod.
                 let _: StatusResponse = try send([CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)])
             }
             var status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])

--- a/Dependencies/OmniKit/OmniKit.xcodeproj/project.pbxproj
+++ b/Dependencies/OmniKit/OmniKit.xcodeproj/project.pbxproj
@@ -598,11 +598,11 @@
 		C12401A929C7D8E900B32844 /* PumpManager */ = {
 			isa = PBXGroup;
 			children = (
-				C12401AA29C7D8E900B32844 /* PodComms.swift */,
 				C12401AB29C7D8E900B32844 /* DetailedStatus+OmniKit.swift */,
-				C12401AC29C7D8E900B32844 /* PodCommsSession.swift */,
-				C12401AD29C7D8E900B32844 /* OmnipodPumpManagerState.swift */,
 				C12401AE29C7D8E900B32844 /* OmnipodPumpManager.swift */,
+				C12401AD29C7D8E900B32844 /* OmnipodPumpManagerState.swift */,
+				C12401AA29C7D8E900B32844 /* PodComms.swift */,
+				C12401AC29C7D8E900B32844 /* PodCommsSession.swift */,
 				C12401AF29C7D8E900B32844 /* PodState.swift */,
 			);
 			path = PumpManager;

--- a/Dependencies/OmniKit/OmniKit/PumpManager/PodCommsSession.swift
+++ b/Dependencies/OmniKit/OmniKit/PumpManager/PodCommsSession.swift
@@ -747,9 +747,9 @@ public class PodCommsSession {
         let basalExtraCommand = BasalScheduleExtraCommand.init(schedule: schedule, scheduleOffset: scheduleOffset, acknowledgementBeep: acknowledgementBeep, programReminderInterval: programReminderInterval)
 
         do {
-            if !(podState.lastCommsOK && podState.deliveryStatusVerified) {
-                // Can't trust the current delivery state -- do a cancel all
-                // to be sure that setting a basal program won't fault the pod.
+            if podState.setupProgress == .completed && !(podState.lastCommsOK && podState.deliveryStatusVerified) {
+                // The pod setup is complete and the current delivery state can't be trusted so
+                // do a cancel all to be sure that setting the basal program won't fault the pod.
                 let _: StatusResponse = try send([CancelDeliveryCommand(nonce: podState.currentNonce, deliveryType: .all, beepType: .noBeepCancel)])
             }
             var status: StatusResponse = try send([basalScheduleCommand, basalExtraCommand])


### PR DESCRIPTION
+ Verify setup is complete before doing cancel for non-verified pod state
+ Sort files in the Omni{BLE,Kit}/PumpManager directories in Xcode