### PR TITLE
Backport OmniBLE PR #94 & #105, OmniKit PR #9 & #18 and MinimedKit PR #6

### DIFF
--- a/Dependencies/MinimedKit/MinimedKit/PumpManager/UnfinalizedDose.swift
+++ b/Dependencies/MinimedKit/MinimedKit/PumpManager/UnfinalizedDose.swift
@@ -117,7 +117,9 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         
         let programmedUnits = units
         self.programmedUnits = programmedUnits
-        let newDuration = date.timeIntervalSince(startTime)
+
+        // Guard against negative duration if clock has changed
+        let newDuration = max(0, date.timeIntervalSince(startTime))
 
         switch doseType {
         case .bolus:

--- a/Dependencies/OmniBLE/OmniBLE/OmnipodCommon/Pod.swift
+++ b/Dependencies/OmniBLE/OmniBLE/OmnipodCommon/Pod.swift
@@ -93,7 +93,7 @@ public struct Pod {
     public static let defaultLowReservoirReminder: Double = 10
 
     // Allowed Low Reservoir reminder values
-    public static let allowedLowReservoirReminderValues = Array(stride(from: 10, through: 50, by: 1))
+    public static let allowedLowReservoirReminderValues = Array(stride(from: 1, through: 50, by: 1))
 }
 
 // DeliveryStatus used in StatusResponse and DetailedStatus

--- a/Dependencies/OmniBLE/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
+++ b/Dependencies/OmniBLE/OmniBLE/OmnipodCommon/UnfinalizedDose.swift
@@ -147,7 +147,9 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         }
 
         scheduledUnits = units
-        let newDuration = date.timeIntervalSince(startTime)
+
+        // Guard against negative duration if clock has changed
+        let newDuration = max(0, date.timeIntervalSince(startTime))
 
         switch doseType {
         case .bolus:

--- a/Dependencies/OmniKit/OmniKit/OmnipodCommon/Pod.swift
+++ b/Dependencies/OmniKit/OmniKit/OmnipodCommon/Pod.swift
@@ -95,7 +95,7 @@ public struct Pod {
     public static let defaultLowReservoirReminder: Double = 10
 
     // Allowed Low Reservoir reminder values
-    public static let allowedLowReservoirReminderValues = Array(stride(from: 10, through: 50, by: 1))
+    public static let allowedLowReservoirReminderValues = Array(stride(from: 1, through: 50, by: 1))
 }
 
 // DeliveryStatus used in StatusResponse and DetailedStatus

--- a/Dependencies/OmniKit/OmniKit/OmnipodCommon/UnfinalizedDose.swift
+++ b/Dependencies/OmniKit/OmniKit/OmnipodCommon/UnfinalizedDose.swift
@@ -147,7 +147,9 @@ public struct UnfinalizedDose: RawRepresentable, Equatable, CustomStringConverti
         }
 
         scheduledUnits = units
-        let newDuration = date.timeIntervalSince(startTime)
+
+        // Guard against negative duration if clock has changed
+        let newDuration = max(0, date.timeIntervalSince(startTime))
 
         switch doseType {
         case .bolus:


### PR DESCRIPTION
+ Extend low reservoir notification range
+ Prevent negative duration doses, which can happen if the phone clock is changed
+ Fixes Loop crash when changing time back and cancelling bolus, Loop Issue #2057