### PR TITLE
Fix to prevent overwriting/deleting of recent carbs...

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -186,13 +186,17 @@ extension Bolus {
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarItems(
                 leading: Button {
-                    carbsView()
+                    if fetch { // Only activate the button when coming to bolusview from carbsview (breaks possibility to start meal registration from bolusview but solves issue with overwriting/deleting previous entered carbs when coming to carbsview from bolusview)
+                        carbsView()
+                    }
                 }
                 label: {
+                    if fetch { // Only show button label when coming to bolusview from carbsview
                     HStack {
                         Image(systemName: "chevron.backward")
                         Text("Meal")
                     }
+                }
                 },
                 trailing: Button { state.hideModal() }
                 label: { Text("Close") }

--- a/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
@@ -168,12 +168,16 @@ extension Bolus {
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarItems(
                 leading: Button {
-                    carbsView()
+                    if fetch { // Only activate button when coming to bolusview from carbsview (breaks possibility to start meal registration from bolusview but solves issue with overwriting/deleting previous entered carbs when coming to carbsview from bolusview)
+                        carbsView()
+                    }
                 }
                 label: {
-                    HStack {
-                        Image(systemName: "chevron.backward")
-                        Text("Meal")
+                    if fetch { // Only show button label when coming to bolusview from carbsview
+                        HStack {
+                            Image(systemName: "chevron.backward")
+                            Text("Meal")
+                        }
                     }
                 },
                 trailing: Button { state.hideModal() }


### PR DESCRIPTION
 ...when coming to meal view from bolus view.
(breaks possibility to start meal registration from bolusview which maybe could be relevant for users with "skip bolus screen after entering carbs" setting)

Interim quick fix for Issue #457 (could probably be solved in a more elegant way)