### PR TITLE
Fixing data model sent over to the Garmin device

### DIFF
--- a/FreeAPSWatch WatchKit Extension/DataFlow.swift
+++ b/FreeAPSWatch WatchKit Extension/DataFlow.swift
@@ -6,6 +6,7 @@ struct WatchState: Codable {
     var trendRaw: String?
     var delta: String?
     var glucoseDate: Date?
+    var glucoseDateInterval: UInt64?
     var lastLoopDate: Date?
     var lastLoopDateInterval: UInt64?
     var bolusIncrement: Decimal?


### PR DESCRIPTION
This PR resolves some issues with the data model sent to the Garmin devices.

Added: **glucoseDateInterval** - Simply the numerical date value of the date the last BG was received
Updated: **trendRaw** - Garmin code expects this to be the textual description of the trend and not special characters. 

Fixed a spelling mistake on the function eventualBGString.

![IMG_6700](https://github.com/Artificial-Pancreas/iAPS/assets/4158482/1d5fdf06-6912-44d6-be2e-ddba630a2a88)


