### PR TITLE
Refactored generate function for clarity and consistency

### DIFF
--- a/FreeAPS/Resources/javascript/prepare/determine-basal.js
+++ b/FreeAPS/Resources/javascript/prepare/determine-basal.js
@@ -1,49 +1,19 @@
-//для enact/smb-suggested.json параметры: monitor/iob.json monitor/temp_basal.json monitor/glucose.json settings/profile.json settings/autosens.json --meal monitor/meal.json --microbolus --reservoir monitor/reservoir.json
+// FOR: enact/smb-suggested.json
+// PARAMETERS: monitor/iob.json monitor/temp_basal.json monitor/glucose.json settings/profile.json settings/autosens.json --meal monitor/meal.json --microbolus --reservoir monitor/reservoir.json
 
 function generate(iob, currenttemp, glucose, profile, autosens = null, meal = null, microbolusAllowed = false, reservoir = null, clock = new Date(), pump_history, preferences, basalProfile, oref2_variables) {
-
-    var clock = new Date();
     
-    var middleware_was_used = "";
+    let middleware_was_used = "";
+
     try {
         var middlewareReason = middleware(iob, currenttemp, glucose, profile, autosens, meal, reservoir, clock, pump_history, preferences, basalProfile, oref2_variables);
-        middleware_was_used = (middlewareReason || "Nothing changed");
+        middleware_was_used = middlewareReason || "Nothing changed";
         console.log("Middleware reason: " + middleware_was_used);
     } catch (error) {
-        console.log("Invalid middleware: " + error);
-    };
-
-    var glucose_status = freeaps_glucoseGetLast(glucose);
-    var autosens_data = null;
-
-    if (autosens) {
-        autosens_data = autosens;
-    }
-    
-    var reservoir_data = null;
-    if (reservoir) {
-        reservoir_data = reservoir;
+        console.error("Invalid middleware: " + error);
     }
 
-    var meal_data = {};
-    if (meal) {
-        meal_data = meal;
-    }
-    
-    var pumphistory = {};
-    if (pump_history) {
-        pumphistory = pump_history;
-    }
-    
-    var basalprofile = {};
-    if (basalProfile) {
-        basalprofile = basalProfile;
-    }
-    
-    var oref2_variables_ = {};
-    if (oref2_variables) {
-        oref2_variables_ = oref2_variables;
-    }
-    
-    return freeaps_determineBasal(glucose_status, currenttemp, iob, profile, autosens_data, meal_data, freeaps_basalSetTemp, microbolusAllowed, reservoir_data, clock, pumphistory, preferences, basalprofile, oref2_variables_, middleware_was_used);
+    const glucose_status = freeaps_glucoseGetLast(glucose);
+
+    return freeaps_determineBasal(glucose_status, currenttemp, iob, profile, autosens, meal || {}, freeaps_basalSetTemp, microbolusAllowed, reservoir, clock, pump_history || {}, preferences, basalProfile || {}, oref2_variables || {}, middleware_was_used);
 }

--- a/FreeAPS/Resources/javascript/prepare/determine-basal.js
+++ b/FreeAPS/Resources/javascript/prepare/determine-basal.js
@@ -6,7 +6,7 @@ function generate(iob, currenttemp, glucose, profile, autosens = null, meal = nu
     let middleware_was_used = "";
 
     try {
-        var middlewareReason = middleware(iob, currenttemp, glucose, profile, autosens, meal, reservoir, clock, pump_history, preferences, basalProfile, oref2_variables);
+        const middlewareReason = middleware(iob, currenttemp, glucose, profile, autosens, meal, reservoir, clock, pump_history, preferences, basalProfile, oref2_variables);
         middleware_was_used = middlewareReason || "Nothing changed";
         console.log("Middleware reason: " + middleware_was_used);
     } catch (error) {


### PR DESCRIPTION
This PR proposes the suggested changes in #473 's PR review to `FreeAPS/Resources/javascript/prepare/determine-basal.js`'s `generate` function, in particular:

* Simplified date initialization; removed redundant var clock = new Date();.
* Streamlined middleware result assignment and logging.
* Used const for immutable variables where applicable (glucose_status).
* Enhanced error logging with console.error.
* Simplified assignment of optional parameters (autosens_data, reservoir_data, meal_data, pumphistory, basalprofile, oref2_variables_).
* Maintained default parameter values for readability and consistency.

Tested in iOS 17 simulator, tested on iPhone 15 Pro running iOS 17.1.1