### PR TITLE
Step one towards adjustable Autotune Days

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -1481,7 +1481,6 @@
 		3811DED425C9E1E300A708ED /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				38AEE75625F0F18E0013F05B /* CarbsStorage.swift */,
 				388E597125AD9CF10019842D /* json */,
 				388E596E25AD96040019842D /* javascript */,
 				3811DEC725C9DA7300A708ED /* FreeAPS.entitlements */,
@@ -1777,6 +1776,7 @@
 		38A0362725ECF05300FCBB52 /* Storage */ = {
 			isa = PBXGroup;
 			children = (
+				38AEE75625F0F18E0013F05B /* CarbsStorage.swift */,
 				385CEAC325F2F154002D6D5B /* AnnouncementsStorage.swift */,
 				38A0363A25ECF07E00FCBB52 /* GlucoseStorage.swift */,
 				38FCF3FC25E997A80078B0D1 /* PumpHistoryStorage.swift */,

--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -44,6 +44,7 @@
   "displayFatAndProteinOnWatch" : false,
   "confirmBolusFaster" : false,
   "onlyAutotuneBasals" : false,
+  "autotuneTuneDays" : 1,
   "overrideFactor" : 0.8,
   "useCalc" : false,
   "fattyMeals" : false,

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -28,9 +28,24 @@ final class OpenAPS {
                 self.storage.save(tempBasal, as: Monitor.tempBasal)
 
                 // meal
-                let pumpHistory = self.loadFileFromStorage(name: OpenAPS.Monitor.pumpHistory)
-                let carbs = self.loadFileFromStorage(name: Monitor.carbHistory)
-                let glucose = self.loadFileFromStorage(name: Monitor.glucose)
+                let pumpHistory = self.storage.retrieve(OpenAPS.Monitor.pumpHistory, as: [PumpHistoryEvent].self)?
+                    .filter {
+                        $0.timestamp
+                            .addingTimeInterval(1.days.timeInterval) > Date() }
+                    .sorted { $0.timestamp > $1.timestamp } ?? []
+
+                let carbs = self.storage.retrieve(Monitor.carbHistory, as: [CarbsEntry].self)?
+                    .filter {
+                        $0.createdAt
+                            .addingTimeInterval(1.days.timeInterval) > Date() }
+                    .sorted { $0.createdAt > $1.createdAt } ?? []
+
+                let glucose = self.storage.retrieve(Monitor.glucose, as: [Glucose].self)?
+                    .filter {
+                        $0.date
+                            .addingTimeInterval(1.days.timeInterval) > Date() }
+                    .sorted { $0.date > $1.date } ?? []
+
                 let profile = self.loadFileFromStorage(name: Settings.profile)
                 let basalProfile = self.loadFileFromStorage(name: Settings.basalProfile)
 

--- a/FreeAPS/Sources/APS/Storage/CarbsStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/CarbsStorage.swift
@@ -167,7 +167,7 @@ final class BaseCarbsStorage: CarbsStorage, Injectable {
     }
 
     func syncDate() -> Date {
-        Date().addingTimeInterval(-settingsManager.settings.autotuneTuneDays.days.timeInterval)
+        Date().addingTimeInterval(-1.days.timeInterval)
     }
 
     func recent() -> [CarbsEntry] {

--- a/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
@@ -55,7 +55,9 @@ final class BaseGlucoseStorage: GlucoseStorage, Injectable {
                 storage.append(glucose, to: file, uniqBy: \.dateString)
 
                 let uniqEvents = storage.retrieve(file, as: [BloodGlucose].self)?
-                    .filter { $0.dateString.addingTimeInterval(24.hours.timeInterval) > Date() }
+                    .filter {
+                        $0.dateString
+                            .addingTimeInterval(self.settingsManager.settings.autotuneTuneDays.days.timeInterval) > Date() }
                     .sorted { $0.dateString > $1.dateString } ?? []
                 let glucose = Array(uniqEvents)
                 storage.save(glucose, as: file)

--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -21,6 +21,7 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
     private let processQueue = DispatchQueue(label: "BasePumpHistoryStorage.processQueue")
     @Injected() private var storage: FileStorage!
     @Injected() private var broadcaster: Broadcaster!
+    @Injected() private var settingsManager: SettingsManager!
 
     init(resolver: Resolver) {
         injectServices(resolver)
@@ -183,7 +184,9 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
             self.storage.transaction { storage in
                 storage.append(events, to: file, uniqBy: \.id)
                 uniqEvents = storage.retrieve(file, as: [PumpHistoryEvent].self)?
-                    .filter { $0.timestamp.addingTimeInterval(1.days.timeInterval) > Date() }
+                    .filter {
+                        $0.timestamp
+                            .addingTimeInterval(self.settingsManager.settings.autotuneTuneDays.days.timeInterval) > Date() }
                     .sorted { $0.timestamp > $1.timestamp } ?? []
                 storage.save(Array(uniqEvents), as: file)
             }

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -46,6 +46,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var displayFatAndProteinOnWatch: Bool = false
     var confirmBolusFaster: Bool = false
     var onlyAutotuneBasals: Bool = false
+    var autotuneTuneDays: Int = 1
     var overrideFactor: Decimal = 0.8
     var useCalc: Bool = false
     var fattyMeals: Bool = false
@@ -263,6 +264,10 @@ extension FreeAPSSettings: Decodable {
 
         if let onlyAutotuneBasals = try? container.decode(Bool.self, forKey: .onlyAutotuneBasals) {
             settings.onlyAutotuneBasals = onlyAutotuneBasals
+        }
+
+        if let autotuneTuneDays = try? container.decode(Int.self, forKey: .autotuneTuneDays) {
+            settings.autotuneTuneDays = autotuneTuneDays
         }
 
         if let displayPredictions = try? container.decode(Bool.self, forKey: .displayPredictions) {

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
@@ -8,6 +8,7 @@ extension AutotuneConfig {
         @Injected() private var storage: FileStorage!
         @Published var useAutotune = false
         @Published var onlyAutotuneBasals = false
+        @Published var autotuneTuneDays: Decimal = 1
         @Published var autotune: Autotune?
         private(set) var units: GlucoseUnits = .mmolL
         @Published var publishedDate = Date()
@@ -25,6 +26,13 @@ extension AutotuneConfig {
             useAutotune = settingsManager.settings.useAutotune
             publishedDate = lastAutotuneDate
             subscribeSetting(\.onlyAutotuneBasals, on: $onlyAutotuneBasals) { onlyAutotuneBasals = $0 }
+
+            subscribeSetting(\.autotuneTuneDays, on: $autotuneTuneDays.map(Int.init), initial: {
+                let value = max(min($0, 14), 1)
+                autotuneTuneDays = Decimal(value)
+            }, map: {
+                $0
+            })
 
             $useAutotune
                 .removeDuplicates()

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -14,6 +14,13 @@ extension AutotuneConfig {
             return formatter
         }
 
+        private var carbsFormatter: NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 0
+            return formatter
+        }
+
         private var rateFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
@@ -34,6 +41,12 @@ extension AutotuneConfig {
                     Toggle("Use Autotune", isOn: $state.useAutotune)
                     if state.useAutotune {
                         Toggle("Only Autotune Basal Insulin", isOn: $state.onlyAutotuneBasals)
+                        HStack {
+                            Text("Tune Days")
+                            Spacer()
+                            DecimalTextField("1", value: $state.autotuneTuneDays, formatter: carbsFormatter)
+                            Text("hours").foregroundColor(.secondary)
+                        }
                     }
                 }
 

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -45,7 +45,7 @@ extension AutotuneConfig {
                             Text("Tune Days")
                             Spacer()
                             DecimalTextField("1", value: $state.autotuneTuneDays, formatter: carbsFormatter)
-                            Text("hours").foregroundColor(.secondary)
+                            Text("days").foregroundColor(.secondary)
                         }
                     }
                 }


### PR DESCRIPTION
    Add variable autotuneTuneDays to FreeAPSSettings.swift
    Move CarbsStorage.swift under Sources/APS/Storage
    Use autotuneTuneDays in:
      * storeCarbs()
      * storeGlucose()
      * storeEvents()
    Fix CarbsStorage.swift to match other *Storage.swift, by using settingsManager instead of settings

    All Changes are cosmetic ... default for autotuneTuneDays is still 1 day, this just cleans up the code
    a bit before moving to an adjustable autotuneTuneDays