### PR TITLE
Test/Attempt to adress and possible fix bug with duplicate carbs..

### DIFF
--- a/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
@@ -33,8 +33,17 @@ extension DataTable {
             broadcaster.register(GlucoseObserver.self, observer: self)
         }
 
+        private let processQueue =
+            DispatchQueue(label: "setupTreatments.processQueue") // Ensure that only one instance of this function can execute at a time
+
         private func setupTreatments() {
-            DispatchQueue.global().async {
+            // Log that the function is starting for testing purposes
+            debug(.service, "setupTreatments() started")
+
+            // DispatchQueue.global().async { // Original code with global concurrent queue
+
+            // Ensure that only one instance of this function can execute at a time by using a serial queue
+            processQueue.async {
                 let units = self.settingsManager.settings.units
                 var date = Date.now
                 let carbs = self.provider.carbs()


### PR DESCRIPTION
entries in data table and apple health.

- Use default dispatchqueue instead of global to see if this prevents potential race conditions/conflicts

**NOTE!** 
This is just a first test/attempt to adress the reported issue #450 
The bug is very hard to reproduce since it appears intermittently under certain circumstances not yet fully identified. 

More testing is needed to find out if this particular change in queue handling helps or not. ie this PR may or may not solve the issue completely, or only partly if other still unidentified root causes causes the reported bug.