### PR TITLE
Cancel bolus from iOS shortcut if the amount exceeds max bolus setting

### DIFF
--- a/FreeAPS/Sources/Shortcuts/Bolus/BolusShortcut.swift
+++ b/FreeAPS/Sources/Shortcuts/Bolus/BolusShortcut.swift
@@ -66,6 +66,10 @@ import Intents
             return NSLocalizedString("too small bolus amount", comment: "")
         }
 
+        guard bolusAmount <= Double(settingsManager.pumpSettings.maxBolus) else {
+            return NSLocalizedString("Max Bolus exceeded!", comment: "")
+        }
+
         let bolus = min(
             max(Decimal(bolusAmount), settingsManager.preferences.bolusIncrement),
             settingsManager.pumpSettings.maxBolus


### PR DESCRIPTION
(And show  alert - reusing already existing localization string "Max Bolus exceeded!")
<img width="444" alt="Skärmavbild 2024-03-11 kl  22 32 24" src="https://github.com/Artificial-Pancreas/iAPS/assets/72826201/ae860d47-1cea-4e3e-bfcf-9c3f49c8a1d3">
