### PR TITLE
Back port various Omnipod related fixes from Loop

### DIFF
--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/OmniBLEPumpManager.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/OmniBLEPumpManager.swift
@@ -868,16 +868,12 @@ extension OmniBLEPumpManager {
             }
         }
 
-        let needsPairing = setStateWithResult({ (state) -> Bool in
-            guard let podState = state.podState else {
-                return true // Needs pairing
-            }
-
-            // Return true if not yet paired
-            return podState.setupProgress.isPaired == false
-        })
-
-        if needsPairing {
+        // For a restart in the middle of pod setup, the pod can only continue
+        // if interruption happened after pod was completely paired.
+        // Unfortunately podState.setupProgress.isPaired can’t be relied on upon
+        // for some restarts. This code enables user to continue if they have a
+        // fully paired pod.
+        if self.state.podState == nil {
             guard let insulinType = insulinType else {
                 completion(.failure(.configuration(OmniBLEPumpManagerError.insulinTypeNotConfigured)))
                 return
@@ -2506,7 +2502,8 @@ extension OmniBLEPumpManager: AlertSoundVendor {
 extension OmniBLEPumpManager {
     public func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) {
         guard self.hasActivePod else {
-            completion(OmniBLEPumpManagerError.noPodPaired)
+            log.default("Skipping alert acknowledgements with no active pod")
+            completion(nil)
             return
         }
 

--- a/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManager/PodCommsSession.swift
@@ -74,6 +74,9 @@ extension PodCommsError: LocalizedError {
             let faultDescription = String(describing: fault.faultEventCode)
             return String(format: LocalizedString("Pod Fault: %1$@", comment: "Format string for pod fault code"), faultDescription)
         case .commsError(let error):
+            if isVerboseBluetoothCommsError(error) {
+                return LocalizedString("Possible Bluetooth issue", comment: "Error description for possible bluetooth issue")
+            }
             return error.localizedDescription
         case .unacknowledgedMessage(_, let error):
             return error.localizedDescription
@@ -136,7 +139,10 @@ extension PodCommsError: LocalizedError {
             return LocalizedString("Resume delivery", comment: "Recovery suggestion when pod is suspended")
         case .podFault:
             return nil
-        case .commsError:
+        case .commsError(let error):
+            if isVerboseBluetoothCommsError(error) {
+                return LocalizedString("Try adjusting pod position or toggle Bluetooth off and then on in iPhone Settings.", comment: "Recovery suggestion for possible bluetooth issue")
+            }
             return nil
         case .unacknowledgedMessage:
             return nil
@@ -172,6 +178,28 @@ extension PodCommsError: LocalizedError {
         default:
             return false
         }
+    }
+
+    public func isVerboseBluetoothCommsError(_ error: Error) -> Bool {
+        if let peripheralManagerError = error as? PeripheralManagerError {
+            switch peripheralManagerError {
+            case .cbPeripheralError:
+                print("### Verbose Bluetooth comms error: \(peripheralManagerError.localizedDescription)")
+                return true
+            default:
+                break
+            }
+        }
+        if let podProtocolError = error as? PodProtocolError {
+            switch podProtocolError {
+            case .invalidLTKKey, .pairingException, .messageIOException, .couldNotParseMessageException:
+                print("### Verbose Bluetooth comms error: \(podProtocolError.localizedDescription)")
+                return true
+            default:
+                break
+            }
+        }
+        return false
     }
 }
 
@@ -247,7 +275,9 @@ public class PodCommsSession {
     ///     - PodCommsError.unexpectedResponse
     ///     - PodCommsError.rejectedMessage
     ///     - PodCommsError.nonceResyncFailed
-    ///     - MessageError
+    ///     - PodCommsError.commsError.MessageError
+    ///     - PodCommsError.commsError.PeripheralManagerError
+    ///     - PodCommsError.commsError.PodProtocolError
     func send<T: MessageBlock>(_ messageBlocks: [MessageBlock], beepBlock: MessageBlock? = nil, expectFollowOnMessage: Bool = false) throws -> T {
         
         var triesRemaining = 2  // Retries only happen for nonce resync

--- a/Dependencies/OmniBLE/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
+++ b/Dependencies/OmniBLE/OmniBLE/PumpManagerUI/ViewModels/PairPodViewModel.swift
@@ -192,7 +192,10 @@ class PairPodViewModel: ObservableObject, Identifiable {
             DispatchQueue.main.async {
                 switch status {
                 case .failure(let error):
-                    if self.autoRetryAttempted {
+                    if self.podPairer.podCommState == .noPod {
+                        let pairAndPrimeError = DashPairingError.pumpManagerError(error)
+                        self.state = .error(pairAndPrimeError)
+                    } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
                         let pairAndPrimeError = DashPairingError.pumpManagerError(error)
                         self.state = .error(pairAndPrimeError)

--- a/Dependencies/OmniKit/OmniKit/PumpManager/OmnipodPumpManager.swift
+++ b/Dependencies/OmniKit/OmniKit/PumpManager/OmnipodPumpManager.swift
@@ -2483,7 +2483,8 @@ extension OmnipodPumpManager: PodCommsDelegate {
 extension OmnipodPumpManager {
     public func acknowledgeAlert(alertIdentifier: Alert.AlertIdentifier, completion: @escaping (Error?) -> Void) {
         guard self.hasActivePod else {
-            completion(OmnipodPumpManagerError.noPodPaired)
+            log.default("Skipping alert acknowledgements with no active pod")
+            completion(nil)
             return
         }
 

--- a/Dependencies/OmniKit/OmniKitUI/ViewModels/PairPodViewModel.swift
+++ b/Dependencies/OmniKit/OmniKitUI/ViewModels/PairPodViewModel.swift
@@ -193,7 +193,10 @@ class PairPodViewModel: ObservableObject, Identifiable {
             DispatchQueue.main.async {
                 switch status {
                 case .failure(let error):
-                    if self.autoRetryAttempted {
+                    if self.podPairer.podCommState == .noPod {
+                        let pairAndPrimeError = OmnipodPairingError.pumpManagerError(error)
+                        self.state = .error(pairAndPrimeError)
+                    } else if self.autoRetryAttempted {
                         self.autoRetryAttempted = false // allow for an auto retry on the next user attempt
                         let pairAndPrimeError = OmnipodPairingError.pumpManagerError(error)
                         self.state = .error(pairAndPrimeError)


### PR DESCRIPTION
+ OmniBLE PR122 Prevent hang following restart if Pod Setup was interrupted
+ OmniBLE PR121 Improved Pod Pairing error message
+ OmniBLE PR119 & OmniKit PR33 fix pairing issue introduced with auto pairing retry
+ Skip alert acknowledgements with faulted pod or no active pod (commit within OmniBLE PR118 & OmniKit PR32)