### PR TITLE
Use any repo name

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -56,7 +56,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        if [[ "$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository_owner }}/iAPS/branches | jq --raw-output 'any(.name=="alive")')" == "true" ]]; then
+        if [[ "$(gh api -H "Accept: application/vnd.github+json" /repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/branches | jq --raw-output 'any(.name=="alive")')" == "true" ]]; then
           echo "Branch 'alive' exists."
           echo "ALIVE_BRANCH_EXISTS=true" >> $GITHUB_ENV # Set ALIVE_BRANCH_EXISTS to true
         else
@@ -80,7 +80,7 @@ jobs:
           --method POST \
           -H "Authorization: token $GITHUB_TOKEN" \
           -H "Accept: application/vnd.github.v3+json" \
-          /repos/${{ github.repository_owner }}/iAPS/git/refs \
+          /repos/${{ github.repository_owner }}/${{ github.event.repository.name }}/git/refs \
           -f ref='refs/heads/alive' \
           -f sha=$SHA
   


### PR DESCRIPTION
Prevents GitHub build errors due to your iAPS fork repo name. Allows you to choose any repo name for your iAPS fork when building with GitHub.