### PR TITLE
Disable sharing by default

### DIFF
--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -36,7 +36,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var overrideHbA1cUnit: Bool = false
     var high: Decimal = 145
     var low: Decimal = 70
-    var uploadStats: Bool = true
+    var uploadStats: Bool = false
     var hours: Int = 6
     var xGridLines: Bool = true
     var yGridLines: Bool = true


### PR DESCRIPTION
Looks like the intention was to have `Sharing` disabled by default, but currently a fresh install of the dev branch defaults `Sharing` to true

This is an incomplete solution, though, since it doesn't address everyone who's already running iAPS and didn't even realize sharing was already defaulted to on. Or they left it on because they never shared their NS with the stats collection website so didn't think it would matter.

Essentially, I think it would be better to rename this setting to fully guarantee anyone sharing their information with the new website is fully aware and doing so intentionally.

(side note: I haven't dug into it much, but from what's been posted, I like the idea for the new way you're collecting stats)