### PR TITLE
contact image: fix for saving updates into storage

### DIFF
--- a/FreeAPS/Sources/Modules/ContactTrick/ContactTrickProvider.swift
+++ b/FreeAPS/Sources/Modules/ContactTrick/ContactTrickProvider.swift
@@ -6,9 +6,7 @@ extension ContactTrick {
         private let processQueue = DispatchQueue(label: "ContactTrickProvider.processQueue")
 
         var contacts: [ContactTrickEntry] {
-            storage.retrieve(OpenAPS.Settings.contactTrick, as: [ContactTrickEntry].self)
-                ?? [ContactTrickEntry](from: OpenAPS.defaults(for: OpenAPS.Settings.contactTrick))
-                ?? []
+            contactTrickManager.currentContacts
         }
 
         func saveContacts(_ contacts: [ContactTrickEntry]) -> AnyPublisher<[ContactTrickEntry], Error> {


### PR DESCRIPTION
Currently, the contacts are only saved into storage when there is a new contact, for which we create an actual contact in the phone Contacts (we store the ID and this triggers the saving into storage).

The bug is this: when an existing contact is edited - the ID is already defined, so the saving into storage does not get triggered.

Here I'm adding a `forceSave: Bool` parameter which is set to `true` when an update is requested from the settings UI.

---
Another small refactoring: removed reading from `storage` from the `ContactTrickProvider` - it now asks the `ContactTrickManager` instead. This makes saving/loading of contacts localized in one place (the manager).