### PR TITLE
Complete the carbs -> bolus flow before enacting any eventual auto bolus (SMB) or any auto temp basal.

### DIFF
--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -43,6 +43,9 @@ enum APSError: LocalizedError {
     case apsError(message: String)
     case deviceSyncError(message: String)
     case manualBasalTemp(message: String)
+    case activeBolusViewBolus
+    case activeBolusViewBasal
+    case activeBolusViewBasalandBolus
 
     var errorDescription: String? {
         switch self {
@@ -60,6 +63,12 @@ enum APSError: LocalizedError {
             return "Sync error: \(message)"
         case let .manualBasalTemp(message):
             return "Manual Basal Temp : \(message)"
+        case .activeBolusViewBolus:
+            return "Suggested SMB not enacted while in Bolus View"
+        case .activeBolusViewBasal:
+            return "Suggested Temp Basal (when > 0) not enacted while in Bolus View"
+        case .activeBolusViewBasalandBolus:
+            return "Suggested Temp Basal (when > 0) and SMB not enacted while in Bolus View"
         }
     }
 }
@@ -552,6 +561,13 @@ final class BaseAPSManager: APSManager, Injectable {
                 processError(error)
                 return
             }
+
+            guard !activeBolusView() else {
+                debug(.apsManager, "Not enacting while in Bolus View")
+                processError(APSError.activeBolusViewBolus)
+                return
+            }
+
             let roundedAmount = pump.roundToSupportedBolusVolume(units: Double(amount))
             pump.enactBolus(units: roundedAmount, activationType: .manualRecommendationAccepted) { error in
                 if let error = error {
@@ -614,6 +630,13 @@ final class BaseAPSManager: APSManager, Injectable {
                 processError(error)
                 return
             }
+
+            guard !activeBolusView() || (activeBolusView() && rate == 0) else {
+                debug(.apsManager, "Not enacting while in Bolus View")
+                processError(APSError.activeBolusViewBasal)
+                return
+            }
+
             // unable to do temp basal during manual temp basal 😁
             if isManualTempBasal {
                 processError(APSError.manualBasalTemp(message: "Loop not possible during the manual basal temp"))
@@ -753,6 +776,14 @@ final class BaseAPSManager: APSManager, Injectable {
                 return Just(()).setFailureType(to: Error.self)
                     .eraseToAnyPublisher()
             }
+
+            guard !self.activeBolusView() || (self.activeBolusView() && rate == 0) else {
+                if let units = suggested.units {
+                    return Fail(error: APSError.activeBolusViewBasalandBolus).eraseToAnyPublisher()
+                }
+                return Fail(error: APSError.activeBolusViewBasal).eraseToAnyPublisher()
+            }
+
             return pump.enactTempBasal(unitsPerHour: Double(rate), for: TimeInterval(duration * 60)).map { _ in
                 let temp = TempBasal(duration: duration, rate: rate, temp: .absolute, timestamp: Date())
                 self.storage.save(temp, as: OpenAPS.Monitor.tempBasal)
@@ -765,12 +796,18 @@ final class BaseAPSManager: APSManager, Injectable {
             if let error = self.verifyStatus() {
                 return Fail(error: error).eraseToAnyPublisher()
             }
+
             guard let units = suggested.units else {
                 // It is OK, no bolus required
                 debug(.apsManager, "No bolus required")
                 return Just(()).setFailureType(to: Error.self)
                     .eraseToAnyPublisher()
             }
+
+            guard !self.activeBolusView() else {
+                return Fail(error: APSError.activeBolusViewBolus).eraseToAnyPublisher()
+            }
+
             return pump.enactBolus(units: Double(units), automatic: true).map { _ in
                 self.bolusProgress.send(0)
                 self.bolusAmount.send(units)
@@ -1240,6 +1277,11 @@ final class BaseAPSManager: APSManager, Injectable {
                 nightscout.fetchVersion()
             }
         }
+    }
+
+    private func activeBolusView() -> Bool {
+        let defaults = UserDefaults.standard
+        return defaults.bool(forKey: IAPSconfig.inBolusView)
     }
 
     private func branch() -> String {

--- a/FreeAPS/Sources/Application/FreeAPSApp.swift
+++ b/FreeAPS/Sources/Application/FreeAPSApp.swift
@@ -85,6 +85,7 @@ import Swinject
     private func isNewVersion() {
         let userDefaults = UserDefaults.standard
         var version = userDefaults.string(forKey: IAPSconfig.version) ?? ""
+        userDefaults.set(false, forKey: IAPSconfig.inBolusView)
 
         guard version.count > 1, version == (Bundle.main.releaseVersionNumber ?? "") else {
             version = Bundle.main.releaseVersionNumber ?? ""

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -46,6 +46,9 @@
 /* Button */
 "Done" = "Done";
 
+/* Bolus View footer */
+"Last loop %@ minutes ago. Complete or cancel this meal/bolus transaction to allow for next loop cycle to run" = "Last loop %@ minutes ago. Complete or cancel this meal/bolus transaction to allow for next loop cycle to run";
+
 /* Calender Option */
 "Display Emojis as Labels" = "Display Emojis as Labels";
 

--- a/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
@@ -46,6 +46,9 @@
 /* Button */
 "Done" = "Klar";
 
+/* Bolus View footer */
+"Last loop %@ minutes ago. Complete or cancel this meal/bolus transaction to allow for next loop cycle to run" = "Senaste loop kördes för %@ minuter sedan. Gör färdigt detta steg eller avbryt/stäng denna vy för att låta nästa loop kunna köras";
+
 /* Calender Option */
 "Display Emojis as Labels" = "Visa Emojis";
 

--- a/FreeAPS/Sources/Models/Configs.swift
+++ b/FreeAPS/Sources/Models/Configs.swift
@@ -25,6 +25,7 @@ public enum IAPSconfig {
     static let id = "iAPS.identifier"
     static let version = "iAPS.version"
     static let newVersion = "iAPS.newVersion"
+    static let inBolusView = "iAPS.inBolusView"
     static let statURL = URL(string: "https://submit.open-iaps.app")!
 }
 

--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -307,13 +307,13 @@ extension Bolus {
         func notActive() {
             let defaults = UserDefaults.standard
             defaults.set(false, forKey: IAPSconfig.inBolusView)
-            print("Active: NO") // For testing
+            //print("Active: NO") // For testing
         }
 
         func viewActive() {
             let defaults = UserDefaults.standard
             defaults.set(true, forKey: IAPSconfig.inBolusView)
-            print("Active: YES") // For testing
+            //print("Active: YES") // For testing
         }
 
         private func prepareData() {
@@ -359,7 +359,7 @@ extension Bolus.StateModel: SuggestionObserver {
         setupInsulinRequired()
         loopDate = apsManager.lastLoopDate
 
-        if abs(now.timeIntervalSinceNow / 60) > loopReminder * 1.5 {
+        if abs(loopDate.timeIntervalSinceNow / 60) > loopReminder * 1.5 {
             hideModal()
             notActive()
             debug(.apsManager, "Force Closing Bolus View", printToConsole: true)

--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -358,5 +358,11 @@ extension Bolus.StateModel: SuggestionObserver {
         }
         setupInsulinRequired()
         loopDate = apsManager.lastLoopDate
+
+        if abs(now.timeIntervalSinceNow / 60) > loopReminder * 1.5 {
+            hideModal()
+            notActive()
+            debug(.apsManager, "Force Closing Bolus View", printToConsole: true)
+        }
     }
 }

--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -289,6 +289,18 @@ extension Bolus {
             return nil
         }
 
+        func notActive() {
+            let defaults = UserDefaults.standard
+            defaults.set(false, forKey: IAPSconfig.inBolusView)
+            print("Active: NO") // For testing
+        }
+
+        func viewActive() {
+            let defaults = UserDefaults.standard
+            defaults.set(true, forKey: IAPSconfig.inBolusView)
+            print("Active: YES") // For testing
+        }
+
         private func prepareData() {
             if !eventualBG {
                 var prepareData = [

--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -204,11 +204,15 @@ extension Bolus {
                         Text("Meal")
                     }
                 },
-                trailing: Button { state.hideModal() }
+                trailing: Button {
+                    state.hideModal()
+                    state.notActive()
+                }
                 label: { Text("Cancel") }
             )
             .onAppear {
                 configureView {
+                    state.viewActive()
                     state.waitForSuggestionInitial = waitForSuggestion
                     state.waitForSuggestion = waitForSuggestion
                     state.insulinCalculated = state.calculateInsulin()

--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -168,6 +168,13 @@ extension Bolus {
                             .listRowBackground(!disabled ? Color(.systemBlue) : Color(.systemGray4))
                             .tint(.white)
                     }
+                    footer: {
+                        if (-1 * state.loopDate.timeIntervalSinceNow / 60) > state.loopReminder, let string = state.lastLoop() {
+                            Text(NSLocalizedString(string, comment: "Bolus View footer"))
+                                .padding(.top, 20).multilineTextAlignment(.center)
+                                .foregroundStyle(.orange)
+                        }
+                    }
                 }
 
                 if state.amount <= 0 {
@@ -184,6 +191,13 @@ extension Bolus {
                         .frame(maxWidth: .infinity, alignment: .center)
                         .listRowBackground(Color(.systemBlue))
                         .tint(.white)
+                    }
+                    footer: {
+                        if (-1 * state.loopDate.timeIntervalSinceNow / 60) > state.loopReminder, let string = state.lastLoop() {
+                            Text(NSLocalizedString(string, comment: "Bolus View footer"))
+                                .padding(.top, 20).multilineTextAlignment(.center)
+                                .foregroundStyle(.orange)
+                        }
                     }
                 }
             }

--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -33,6 +33,11 @@ extension Bolus {
                         meal: meal,
                         mealEntries: mealEntries
                     )
+                    .onDisappear {
+                        if state.eventualBG {
+                            state.notActive()
+                        }
+                    }
                 } else {
                     AlternativeBolusCalcRootView(
                         resolver: resolver,
@@ -42,6 +47,11 @@ extension Bolus {
                         meal: meal,
                         mealEntries: mealEntries
                     )
+                    .onDisappear {
+                        if !state.eventualBG {
+                            state.notActive()
+                        }
+                    }
                 }
             } else {
                 cleanBolusView
@@ -99,6 +109,9 @@ extension Bolus {
                     state.delete(deleteTwice: true, meal: meal)
                 } else if fetch, !keepForNextWiew, !state.useCalc {
                     state.delete(deleteTwice: false, meal: meal)
+                }
+                if !state.useCalc {
+                    state.notActive()
                 }
             }
             .dynamicTypeSize(...DynamicTypeSize.xxLarge)

--- a/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
@@ -31,6 +31,13 @@ extension Bolus {
             return formatter
         }
 
+        private var loopFormatter: NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 0
+            return formatter
+        }
+
         private var glucoseFormatter: NumberFormatter {
             let formatter = NumberFormatter()
             formatter.numberStyle = .decimal
@@ -129,6 +136,13 @@ extension Bolus {
                             .listRowBackground(!disabled ? Color(.systemBlue) : Color(.systemGray4))
                             .tint(.white)
                     }
+                    footer: {
+                        if (-1 * state.loopDate.timeIntervalSinceNow / 60) > state.loopReminder, let string = state.lastLoop() {
+                            Text(NSLocalizedString(string, comment: "Bolus View footer"))
+                                .padding(.top, 20).multilineTextAlignment(.center)
+                                .foregroundStyle(.orange)
+                        }
+                    }
                     .alert(isPresented: $isRemoteBolusAlertPresented) {
                         remoteBolusAlert!
                     }
@@ -147,6 +161,13 @@ extension Bolus {
                             .frame(maxWidth: .infinity, alignment: .center)
                             .listRowBackground(Color(.systemBlue))
                             .tint(.white)
+                    }
+                    footer: {
+                        if abs(state.loopDate.timeIntervalSinceNow / 60) > state.loopReminder, let string = state.lastLoop() {
+                            Text(NSLocalizedString(string, comment: "Bolus View footer"))
+                                .padding(.top, 20).multilineTextAlignment(.center)
+                                .foregroundStyle(.orange)
+                        }
                     }
                 }
             }

--- a/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
@@ -154,6 +154,7 @@ extension Bolus {
             .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             .onAppear {
                 configureView {
+                    state.viewActive()
                     state.waitForSuggestionInitial = waitForSuggestion
                     state.waitForSuggestion = waitForSuggestion
                 }
@@ -179,7 +180,10 @@ extension Bolus {
                         Text("Meal")
                     }
                 },
-                trailing: Button { state.hideModal() }
+                trailing: Button {
+                    state.hideModal()
+                    state.notActive()
+                }
                 label: { Text("Cancel") }
             )
             .popup(isPresented: presentInfo, alignment: .bottom, direction: .bottom, type: .default) {

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -487,9 +487,6 @@ extension Home {
                         ($0.timestamp ?? .distantFuture) <= Date().addingTimeInterval(-24.hours.timeInterval)
                     })?.tdd ?? 0) as Decimal
                     tddChange = ((tdds.first?.tdd ?? 0) as Decimal) - yesterday
-
-                    print("Yesterday: \(yesterday)")
-                    print("Today: \((tdds.first?.tdd ?? 0) as Decimal)")
                 }
             }
         }


### PR DESCRIPTION
This will prevent SMBs while entering carbs or while being in bolus view looking at recommendation/predictions, considering doing a manual bolus.

Objective: prevent double boli and prevent any SMBs/basals while testing/viewing/thinking/learning/showing