### PR TITLE
[DanaKit] Progress update 29-05-2024

### DIFF
--- a/Dependencies/DanaKit/DanaKit/Packets/DanaBolusStart.swift
+++ b/Dependencies/DanaKit/DanaKit/Packets/DanaBolusStart.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2023 Randall Knutson. All rights reserved.
 //
 
-import LoopKit
-
 public enum BolusSpeed: UInt8 {
     case speed12 = 0
     case speed30 = 1

--- a/Dependencies/DanaKit/DanaKit/PumpManager/DanaKitPumpManager.swift
+++ b/Dependencies/DanaKit/DanaKit/PumpManager/DanaKitPumpManager.swift
@@ -7,7 +7,6 @@
 //  Copyright © 2021 LoopKit Authors. All rights reserved.
 //
 
-import BackgroundTasks
 import HealthKit
 import LoopKit
 import UserNotifications

--- a/Dependencies/DanaKit/DanaKit/PumpManager/DanaKitPumpManagerError.swift
+++ b/Dependencies/DanaKit/DanaKit/PumpManager/DanaKitPumpManagerError.swift
@@ -16,6 +16,9 @@ public enum DanaKitPumpManagerError {
     case failedBasalAdjustment
     case failedTimeAdjustment
     case unsupportedTempBasal(_ duration: TimeInterval)
+    case bolusTimeoutActive
+    case bolusMaxViolation
+    case bolusInsulinLimitViolation
     case unknown(_ message: String)
 }
 
@@ -41,6 +44,12 @@ extension DanaKitPumpManagerError: LocalizedError {
             return LocalizedString("Failed to adjust pump time", comment: "Error description when pump time failed to sync")
         case .pumpIsBusy:
             return LocalizedString("Action has been canceled, because the pump is busy", comment: "Error description when pump is busy (with bolussing probably)")
+        case .bolusTimeoutActive:
+            return LocalizedString("A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive", comment: "Error description when pump has an active blockage")
+        case .bolusMaxViolation:
+            return LocalizedString("The max bolus limit is reached. Please try a lower amount or increase the limit", comment: "Error description when pump has reached the bolus max")
+        case .bolusInsulinLimitViolation:
+            return LocalizedString("The max daily insulin limit is reached. Please try a lower amount or increase the limit", comment: "Error description when pump has reached the daily max")
         case .unknown(let message):
             return "Unknown error occured: \(message)"
         }

--- a/Dependencies/DanaKit/Localization/ar.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/ar.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "Setting up DanaRS v3" = "إعداد DanaRS v3"
 
 /* Subtext for danars v3 */
-"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3" = "أثناء عملية الاقتران، سيُظهر DanaRS v3 الخاص بك مطالبة الاقتران بينما سيُظهر iPhone الخاص بك مطالبة برمزي الاقتران. على المضخة الخاصة بك، حدد &quot;موافق&quot; واكتب الرمزين على جهاز iPhone الخاص بك. بعد ذلك، يصبح Loop جاهزًا للتواصل مع DanaRS v3"
+"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3" = "أثناء عملية الاقتران، سيُظهر DanaRS v3 الخاص بك مطالبة الاقتران بينما سيُظهر iPhone الخاص بك مطالبة برمزين للاقتران. على المضخة الخاصة بك، حدد &quot;موافق&quot; واكتب الرمزين على جهاز iPhone الخاص بك. بعد ذلك، يصبح Loop جاهزًا للتواصل مع DanaRS v3"
 
 /* Title for dana-i explaination */
 "Setting up Dana-i" = "إعداد دانا ط"
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "تم إلغاء الإجراء، لأن المضخة مشغولة"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "مهلة الجرعة نشطة. لا يمكن إكمال دورة الحلقة حتى تصبح المهلة غير نشطة"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "تم الوصول إلى الحد الأقصى للبلعة. يرجى تجربة مبلغ أقل أو زيادة الحد"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "تم الوصول إلى الحد الأقصى اليومي للأنسولين. يرجى تجربة مبلغ أقل أو زيادة الحد"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "يتم دعم الجرعة التلقائية فقط"

--- a/Dependencies/DanaKit/Localization/cs.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/cs.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Akce byla zrušena, protože čerpadlo je zaneprázdněné"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Je aktivní časový limit bolusu. Cyklus smyčky nelze dokončit, dokud není časový limit neaktivní"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Byl dosažen limit maximálního bolusu. Zkuste prosím nižší částku nebo zvyšte limit"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Je dosažen maximální denní limit inzulínu. Zkuste prosím nižší částku nebo zvyšte limit"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Podporován je pouze automatický bolus"
 
@@ -220,7 +229,7 @@
 "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?" = "Čas na pumpě se liší od aktuálního času. Chcete aktualizovat čas na pumpě na aktuální čas?"
 
 /* description for time change detected notice */
-"The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump." = "Čas na pumpě se liší od aktuálního času. Čas pumpy řídí nastavení naplánované terapie. Přejděte dolů na řádek Čas pumpy, abyste si prohlédli časový rozdíl a nakonfigurovali pumpu.";
+"The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump." = "Čas na pumpě se liší od aktuálního času. Čas pumpy řídí nastavení naplánované terapie. Přejděte dolů na řádek Čas pumpy a zkontrolujte časový rozdíl a nakonfigurujte pumpu.";
 
 /* Button text to confirm pump time sync */
 "Yes, Sync to Current Time" = "Ano, synchronizovat s aktuálním časem"

--- a/Dependencies/DanaKit/Localization/da.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/da.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Handlingen er blevet annulleret, fordi pumpen er optaget"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "En bolus-timeout er aktiv. Sløjfecyklussen kan ikke afsluttes, før timeout er inaktiv"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Den maksimale bolusgrænse er nået. Prøv venligst et lavere beløb eller øg grænsen"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Den maksimale daglige insulingrænse er nået. Prøv venligst et lavere beløb eller øg grænsen"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Kun automatisk bolus understøttes"
 
@@ -256,7 +265,7 @@
 "Save" = "Gemme"
 
 /* Text for 24h display */
-"24h display" = "24 timers visning"
+"24h display" = "24 timers display"
 
 /* Description for 24h display */
 "Should time be display in 12h or 24h" = "Skal tiden vises om 12 timer eller 24 timer"
@@ -370,7 +379,7 @@
 "Unknown error" = "Ukendt fejl"
 
 /* Alert body for unknown */
-"An unknown error has occurred during processing the alert from the pump. Please report this" = "Der er opstået en ukendt fejl under behandlingen af ​​advarslen fra pumpen. Meld venligst dette"
+"An unknown error has occurred during processing the alert from the pump. Please report this" = "Der er opstået en ukendt fejl under behandlingen af ​​advarslen fra pumpen. Rapportér venligst dette"
 
 /* The title of the pump information section in DanaKit settings */
 "Pump information" = "Pumpeoplysninger"

--- a/Dependencies/DanaKit/Localization/de.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/de.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Aktion wurde abgebrochen, da die Pumpe beschäftigt ist"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Ein Bolus-Timeout ist aktiv. Der Loop-Zyklus kann erst abgeschlossen werden, wenn das Timeout inaktiv ist."
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Das maximale Boluslimit ist erreicht. Bitte versuchen Sie es mit einer niedrigeren Menge oder erhöhen Sie das Limit"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Das maximale tägliche Insulinlimit ist erreicht. Bitte versuchen Sie es mit einer niedrigeren Menge oder erhöhen Sie das Limit"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Nur automatischer Bolus wird unterstützt"
 

--- a/Dependencies/DanaKit/Localization/en.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/en.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Action has been canceled, because the pump is busy"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "The max bolus limit is reached. Please try a lower amount or increase the limit"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Only Automatic Bolus is supported"
 

--- a/Dependencies/DanaKit/Localization/es.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/es.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "La acción ha sido cancelada porque la bomba está ocupada."
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Hay un tiempo de espera de bolo activo. El ciclo de bucle no se puede completar hasta que el tiempo de espera esté inactivo"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Se alcanza el límite máximo de bolo. Pruebe con una cantidad menor o aumente el límite"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Se alcanza el límite máximo diario de insulina. Pruebe con una cantidad menor o aumente el límite"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Solo se admite bolo automático"
 

--- a/Dependencies/DanaKit/Localization/fi.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/fi.lproj/Localizable.strings
@@ -101,7 +101,7 @@
 "Checksum failed. Try again" = "Tarkistussumma epäonnistui. Yritä uudelleen"
 
 /* Title for delivery speed */
-"Delivery speed" = "Toimitusnopeus"
+"Delivery speed" = "Toimituksen nopeus"
 
 /* Dana bolus speed 12u per min */
 "12 sec/U" = "12 s/U"
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Toiminto on peruutettu, koska pumppu on varattu"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Boluksen aikakatkaisu on aktiivinen. Silmukkasykliä ei voida suorittaa loppuun ennen kuin aikakatkaisu on passiivinen"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Boluksen enimmäisraja on saavutettu. Kokeile pienempää määrää tai nosta rajaa"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Päivittäinen insuliiniraja on saavutettu. Kokeile pienempää määrää tai nosta rajaa"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Vain automaattinen bolus on tuettu"
@@ -217,7 +226,7 @@
 "Time Change Detected" = "Aikamuutos havaittu"
 
 /* Message for pod sync time action sheet */
-"The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?" = "Pumpun aika eroaa nykyisestä ajasta. Haluatko päivittää pumpun kellonajan nykyiseen aikaan?"
+"The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?" = "Pumpun aika eroaa nykyisestä ajasta. Haluatko päivittää pumpun ajan nykyiseen aikaan?"
 
 /* description for time change detected notice */
 "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump." = "Pumpun aika eroaa nykyisestä ajasta. Pumpun aika ohjaa ajoitettuja hoitoasetuksiasi. Vieritä alas Pumpun aika -riville nähdäksesi aikaeron ja määrittääksesi pumpun.";

--- a/Dependencies/DanaKit/Localization/fr.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/fr.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "L&#39;action a été annulée car la pompe est occupée"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Un délai d&#39;attente de bolus est actif. Le cycle de boucle ne peut pas être terminé tant que le délai d&#39;attente n&#39;est pas inactif"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "La limite maximale du bolus est atteinte. Veuillez essayer un montant inférieur ou augmenter la limite"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "La limite quotidienne maximale d’insuline est atteinte. Veuillez essayer un montant inférieur ou augmenter la limite"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Seul le bolus automatique est pris en charge"
 

--- a/Dependencies/DanaKit/Localization/he.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/he.lproj/Localizable.strings
@@ -20,7 +20,7 @@
 "Setting up DanaRS v1" = "הגדרת DanaRS v1"
 
 /* Subtext for danars v1 */
-"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1" = "במהלך תהליך ההתאמה, ה-DanaRS v3 שלך יציג הנחית התאמה ואילו ה-iPhone שלך ​​יציג הנחיה לקוד התאמה. במשאבה, בחר אישור והקלד את הקוד באייפון. לאחר מכן, Loop מוכן לתקשר עם DanaRS v1 שלך"
+"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1" = "במהלך תהליך ההתאמה, ה-DanaRS v3 שלך יציג הנחית התאמה ואילו ה-iPhone שלך ​​יציג הנחיה לקוד התאמה. במשאבה, בחר אישור והקלד את הקוד באייפון. לאחר מכן, Loop מוכן לתקשר עם ה-DanaRS v1 שלך"
 
 /* check password text for danars v1 */
 "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it" = "לפני שמתחילים בתהליך ההתאמה, מומלץ לבדוק, ובמידת הצורך לעדכן, את סיסמת המשאבה. אתה יכול לעשות זאת על ידי מעבר להגדרות המשאבה -&gt; הגדרות משתמש -&gt; סיסמה. סיסמת ברירת המחדל היא 1234, אם זו הסיסמה שלך, אנא שקול לשנות אותה"
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "הפעולה בוטלה, כי המשאבה תפוסה"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "פסק זמן בולוס פעיל. לא ניתן להשלים את מחזור הלולאה עד שפסק הזמן אינו פעיל"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "הגעת למגבלת הבולוס המקסימלית. אנא נסה סכום נמוך יותר או הגדל את המגבלה"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "הגיעה לגבול האינסולין היומי המקסימלי. אנא נסה סכום נמוך יותר או הגדל את המגבלה"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "רק בולוס אוטומטי נתמך"

--- a/Dependencies/DanaKit/Localization/hi.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/hi.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "कार्रवाई रद्द कर दी गई है, क्योंकि पंप व्यस्त है"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "बोलस टाइमआउट सक्रिय है। जब तक टाइमआउट निष्क्रिय है, लूप चक्र पूरा नहीं हो सकता"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "अधिकतम बोलस सीमा पूरी हो गई है। कृपया कम राशि का प्रयास करें या सीमा बढ़ाएँ"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "अधिकतम दैनिक इंसुलिन सीमा पूरी हो गई है। कृपया कम मात्रा आज़माएँ या सीमा बढ़ाएँ"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "केवल स्वचालित बोलस समर्थित है"
 

--- a/Dependencies/DanaKit/Localization/it.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/it.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "L&#39;azione è stata annullata perché la pompa è occupata"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "È attivo un timeout del bolo. Il ciclo del loop non può essere completato finché il timeout non è inattivo"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "È stato raggiunto il limite massimo del bolo. Prova con un importo inferiore o aumenta il limite"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "È stato raggiunto il limite massimo giornaliero di insulina. Prova con un importo inferiore o aumenta il limite"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "È supportato solo il bolo automatico"
 
@@ -220,7 +229,7 @@
 "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?" = "L&#39;ora visualizzata sul microinfusore è diversa dall&#39;ora corrente. Vuoi aggiornare l&#39;ora del tuo microinfusore all&#39;ora corrente?"
 
 /* description for time change detected notice */
-"The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump." = "L&#39;ora visualizzata sul microinfusore è diversa dall&#39;ora corrente. Il tempo del microinfusore controlla le impostazioni della terapia programmata. Scorri verso il basso fino alla riga Orario pompa per verificare la differenza oraria e configurare la pompa.";
+"The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump." = "L&#39;ora visualizzata sul microinfusore è diversa dall&#39;ora corrente. Il tempo del microinfusore controlla le impostazioni della terapia programmata. Scorri verso il basso fino alla riga Orario pompa per verificare la differenza oraria e configurare la tua pompa.";
 
 /* Button text to confirm pump time sync */
 "Yes, Sync to Current Time" = "Sì, sincronizza con l&#39;ora corrente"

--- a/Dependencies/DanaKit/Localization/ja.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/ja.lproj/Localizable.strings
@@ -17,7 +17,7 @@
 "Dana-i" = "ダナ・イ"
 
 /* Title for danars v1 explaination */
-"Setting up DanaRS v1" = "DanaRS v1 の設定"
+"Setting up DanaRS v1" = "DanaRS v1 のセットアップ"
 
 /* Subtext for danars v1 */
 "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1" = "ペアリングプロセス中、DanaRS v3 にはペアリングプロンプトが表示され、iPhone にはペアリングコードのプロンプトが表示されます。ポンプで [OK] を選択し、iPhone にコードを入力します。その後、Loop は DanaRS v1 と通信する準備が整います。"
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "ポンプがビジー状態のため、アクションはキャンセルされました"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "ボーラスタイムアウトが有効です。タイムアウトが無効になるまでループサイクルは完了しません。"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "最大ボーラス制限に達しました。量を減らすか、制限を増やしてください。"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "1 日のインスリンの上限に達しました。量を減らすか、上限を増やしてください。"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "自動ボーラスのみがサポートされています"

--- a/Dependencies/DanaKit/Localization/nb.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/nb.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Handlingen er avbrutt fordi pumpen er opptatt"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "En bolus-tidsavbrudd er aktiv. Sløyfesyklusen kan ikke fullføres før tidsavbruddet er inaktivt"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Den maksimale bolusgrensen er nådd. Prøv et lavere beløp eller øk grensen"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Den maksimale daglige insulingrensen er nådd. Prøv et lavere beløp eller øk grensen"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Kun automatisk bolus støttes"
 
@@ -188,7 +197,7 @@
 "U/hr" = "U/t";
 
 /* Header for insulin remaining on pod settings screen */
-"Insulin Remaining" = "Insulin gjenværende";
+"Insulin Remaining" = "Insulin som gjenstår";
 
 /* Text for Dana pump name */
 "Pump name" = "Pumpenavn"
@@ -301,7 +310,7 @@
 "Pump battery 0%" = "Pumpebatteri 0 %"
 
 /* Alert body for batteryZeroPercent */
-"Pump battery is empty. Replace it now!" = "Pumpebatteriet er tomt. Bytt den nå!"
+"Pump battery is empty. Replace it now!" = "Pumpebatteriet er tomt. Bytt den ut nå!"
 
 /* Alert title for pumpError */
 "Pump error" = "Pumpefeil"

--- a/Dependencies/DanaKit/Localization/nl.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/nl.lproj/Localizable.strings
@@ -125,7 +125,7 @@
 " is ready to be used!" = " is klaar voor gebruik!"
 
 /* Dana setup SMB setting */
-"Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor" = "Opmerking: Uw Dana-pomp heeft een speciale instelling waarmee u de pieptonen van uw Dana-pomp kunt uitschakelen. Neem contact op met uw Dana-distributeur om dit mogelijk te maken"
+"Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor" = "Opmerking: Uw Dana-pomp heeft een speciale instelling waarmee u de pieptonen van uw Dana-pomp kunt uitschakelen. Neem hiervoor contact op met uw Dana-distributeur"
 
 /* Error description when no dana connected */
 "Failed to make a connection" = "Kan geen verbinding maken"
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Actie is geannuleerd, omdat de pomp bezet is"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Er is een bolustime-out actief. De loop cyclus kan pas worden voltooid als de time-out inactief is"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "De maximale boluslimiet is bereikt. Probeer een lager bedrag of verhoog de limiet"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "De maximale dagelijkse insulinelimiet is bereikt. Probeer een lager bedrag of verhoog de limiet"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Alleen automatische bolus wordt ondersteund"
@@ -301,7 +310,7 @@
 "Pump battery 0%" = "Pompbatterij 0%"
 
 /* Alert body for batteryZeroPercent */
-"Pump battery is empty. Replace it now!" = "Pompbatterij is leeg. Vervang het nu!"
+"Pump battery is empty. Replace it now!" = "Pompbatterij is leeg. Vervang hem nu!"
 
 /* Alert title for pumpError */
 "Pump error" = "Pompfout"

--- a/Dependencies/DanaKit/Localization/pl.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/pl.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Akcja została anulowana, ponieważ pompa jest zajęta"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Aktywny jest limit czasu bolusa. Cykl pętli nie może zostać ukończony, dopóki limit czasu nie będzie nieaktywny"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Osiągnięto maksymalny limit bolusa. Spróbuj użyć niższej kwoty lub zwiększ limit"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Osiągnięto maksymalny dzienny limit insuliny. Spróbuj użyć niższej kwoty lub zwiększ limit"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Obsługiwany jest tylko bolus automatyczny"
 

--- a/Dependencies/DanaKit/Localization/pt-BR.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/pt-BR.lproj/Localizable.strings
@@ -35,7 +35,7 @@
 "Setting up DanaRS v3" = "Configurando o DanaRS v3"
 
 /* Subtext for danars v3 */
-"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3" = "Durante o processo de emparelhamento, seu DanaRS v3 mostrará um aviso de emparelhamento enquanto o seu iPhone mostrará um aviso para dois códigos de emparelhamento. Na sua bomba, selecione OK e digite os dois códigos no seu iPhone. Depois disso, o Loop está pronto para se comunicar com o seu DanaRS v3"
+"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3" = "Durante o processo de emparelhamento, seu DanaRS v3 mostrará um prompt de emparelhamento enquanto seu iPhone mostrará um prompt para dois códigos de emparelhamento. Na sua bomba, selecione OK e digite os dois códigos no seu iPhone. Depois disso, o Loop está pronto para se comunicar com o seu DanaRS v3"
 
 /* Title for dana-i explaination */
 "Setting up Dana-i" = "Configurando Dana-i"
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "A ação foi cancelada porque a bomba está ocupada"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Um tempo limite de bolus está ativo. O ciclo de loop não pode ser concluído até que o tempo limite esteja inativo"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "O limite máximo de bolus foi atingido. Tente um valor menor ou aumente o limite"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "O limite máximo diário de insulina foi atingido. Tente um valor menor ou aumente o limite"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Somente Bolus Automático é suportado"

--- a/Dependencies/DanaKit/Localization/ro.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/ro.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Acțiunea a fost anulată, deoarece pompa este ocupată"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "O perioadă de expirare a bolusului este activă. Ciclul buclei nu poate fi finalizat până când expirarea este inactivă"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Limita maximă a bolusului este atinsă. Vă rugăm să încercați o sumă mai mică sau măriți limita"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Limita maximă zilnică de insulină este atinsă. Vă rugăm să încercați o sumă mai mică sau măriți limita"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Numai Bolus automat este acceptat"
 
@@ -271,7 +280,7 @@
 "12h notation" = "notație 12h"
 
 /* 24h */
-"24h notation" = "Notație 24 de ore"
+"24h notation" = "notație 24 de ore"
 
 /* Text for Scroll function */
 "Scroll function" = "Funcția de defilare"

--- a/Dependencies/DanaKit/Localization/ru.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/ru.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Действие отменено, так как насос занят"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Тайм-аут болюса активен. Цикл цикла не может быть завершен, пока тайм-аут не станет неактивным."
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Достигнут максимальный предел болюса. Попробуйте уменьшить сумму или увеличить лимит."
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Достигнут максимальный дневной лимит инсулина. Попробуйте уменьшить сумму или увеличить лимит."
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Поддерживается только автоматический болюс."
 
@@ -220,7 +229,7 @@
 "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?" = "Время на вашей помпе отличается от текущего времени. Хотите обновить время на помпе до текущего времени?"
 
 /* description for time change detected notice */
-"The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump." = "Время на вашей помпе отличается от текущего времени. Время работы помпы определяет настройки запланированной терапии. Прокрутите вниз до строки «Время помпы», чтобы просмотреть разницу во времени и настроить помпу.";
+"The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump." = "Время на вашей помпе отличается от текущего времени. Время работы помпы управляет настройками запланированной терапии. Прокрутите вниз до строки «Время помпы», чтобы просмотреть разницу во времени и настроить помпу.";
 
 /* Button text to confirm pump time sync */
 "Yes, Sync to Current Time" = "Да, синхронизировать с текущим временем"
@@ -301,7 +310,7 @@
 "Pump battery 0%" = "Батарея насоса 0%"
 
 /* Alert body for batteryZeroPercent */
-"Pump battery is empty. Replace it now!" = "Батарея насоса разряжена. Замените его сейчас!"
+"Pump battery is empty. Replace it now!" = "Аккумулятор насоса разряжен. Замените его сейчас!"
 
 /* Alert title for pumpError */
 "Pump error" = "Ошибка насоса"

--- a/Dependencies/DanaKit/Localization/sk.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/sk.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Akcia bola zrušená, pretože čerpadlo je zaneprázdnené"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Je aktívny časový limit bolusu. Cyklus slučky nie je možné dokončiť, kým časový limit nie je aktívny"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Bol dosiahnutý maximálny bolusový limit. Skúste nižšiu sumu alebo zvýšte limit"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Je dosiahnutý maximálny denný limit inzulínu. Skúste nižšiu sumu alebo zvýšte limit"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Podporovaný je iba automatický bolus"
 

--- a/Dependencies/DanaKit/Localization/sv.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/sv.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Åtgärden har avbrutits eftersom pumpen är upptagen"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "En bolus timeout är aktiv. Slingcykeln kan inte slutföras förrän timeouten är inaktiv"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Den maximala bolusgränsen har uppnåtts. Försök med ett lägre belopp eller höj gränsen"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Den maximala dagliga insulingränsen är nådd. Försök med ett lägre belopp eller höj gränsen"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Endast automatisk bolus stöds"
 
@@ -209,7 +218,7 @@
 "Pump time" = "Pumptid"
 
 /* Label for syncing the time on the pump */
-"Sync Pump time" = "Synk pumptid"
+"Sync Pump time" = "Synkronisera pumptid"
 
 /* Alert content title for timeOffsetChangeDetected pod alert
    Title for pod sync time action sheet.

--- a/Dependencies/DanaKit/Localization/tr.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/tr.lproj/Localizable.strings
@@ -38,7 +38,7 @@
 "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3" = "Eşleştirme işlemi sırasında, DanaRS v3&#39;ünüz bir eşleştirme istemi gösterecek, iPhone&#39;unuz ise iki eşleştirme kodu istemi gösterecektir. Pompanızda Tamam&#39;ı seçin ve iPhone&#39;unuza iki kodu yazın. Bundan sonra Loop, DanaRS v3&#39;ünüzle iletişim kurmaya hazırdır"
 
 /* Title for dana-i explaination */
-"Setting up Dana-i" = "Dana-i&#39;yi kurma"
+"Setting up Dana-i" = "Dana-i&#39;yi ayarlama"
 
 /* General subtext for dana */
 "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with Loop." = "İnsülin tipini ve bolus hızını ayarladıktan sonra bulunan tüm Dana pompalarını içeren bir ekran göreceksiniz. Döngüye bağlamak istediğiniz pompayı seçin."
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Pompa meşgul olduğundan işlem iptal edildi"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Bolus zaman aşımı etkin. Zaman aşımı etkin olmayana kadar döngü döngüsü tamamlanamaz"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Maksimum bolus sınırına ulaşıldı. Lütfen daha düşük bir miktar deneyin veya limiti artırın"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Maksimum günlük insülin sınırına ulaşıldı. Lütfen daha düşük bir miktar deneyin veya limiti artırın"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Yalnızca Otomatik Bolus desteklenir"

--- a/Dependencies/DanaKit/Localization/vi.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/vi.lproj/Localizable.strings
@@ -154,6 +154,15 @@
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "Hành động đã bị hủy vì máy bơm đang bận"
 
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "Thời gian chờ truyền nhanh đang hoạt động. Chu kỳ vòng lặp không thể hoàn thành cho đến khi hết thời gian chờ không hoạt động"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "Đã đạt đến giới hạn bolus tối đa. Vui lòng thử số tiền thấp hơn hoặc tăng giới hạn"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "Đã đạt đến giới hạn insulin tối đa hàng ngày. Vui lòng thử số tiền thấp hơn hoặc tăng giới hạn"
+
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "Chỉ hỗ trợ Bolus tự động"
 

--- a/Dependencies/DanaKit/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Dependencies/DanaKit/Localization/zh-Hans.lproj/Localizable.strings
@@ -20,7 +20,7 @@
 "Setting up DanaRS v1" = "设置 DanaRS v1"
 
 /* Subtext for danars v1 */
-"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1" = "在配对过程中，您的 DanaRS v3 将显示配对提示，而您的 iPhone 将显示配对代码提示。在您的泵上，选择“确定”，然后在您的 iPhone 上输入代码。之后，Loop 即可与您的 DanaRS v1 进行通信"
+"During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1" = "在配对过程中，您的 DanaRS v3 将显示配对提示，而您的 iPhone 将显示配对代码提示。在您的泵上，选择“确定”，然后在您的 iPhone 上输入代码。之后，Loop 即可与您的 DanaRS v1 通信"
 
 /* check password text for danars v1 */
 "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it" = "在开始配对过程之前，建议检查泵密码，如果需要，请更新。您可以通过泵设置 -&gt; 用户设置 -&gt; 密码来执行此操作。默认密码为 1234，如果这是您的密码，请考虑更改它"
@@ -153,6 +153,15 @@
 
 /* Error description when pump is busy (with bolussing probably) */
 "Action has been canceled, because the pump is busy" = "由于泵正忙，操作已取消"
+
+/* Error description when pump has an active blockage */
+"A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive" = "bolus 超时处于活动状态。循环周期无法完成，直到超时处于非活动状态"
+
+/* Error description when pump has reached the bolus max */
+"The max bolus limit is reached. Please try a lower amount or increase the limit" = "已达到最大剂量限制。请尝试降低剂量或增加限制"
+
+/* Error description when pump has reached the daily max */
+"The max daily insulin limit is reached. Please try a lower amount or increase the limit" = "已达到每日胰岛素最高限量。请尝试降低剂量或增加限量"
 
 /* dana AB limitation warning title */
 "Only Automatic Bolus is supported" = "仅支持自动推注"

--- a/Dependencies/LoopKit/MockKit/MockPumpManagerState.swift
+++ b/Dependencies/LoopKit/MockKit/MockPumpManagerState.swift
@@ -14,6 +14,7 @@ public struct MockPumpManagerState: Equatable {
         case omnipod
         case medtronicX22
         case medtronicX23
+        case dana
         case custom
         
         var supportedBolusVolumes: [Double]? {
@@ -32,6 +33,8 @@ public struct MockPumpManagerState: Equatable {
                     let scaledRanges = (range.lowerBound * scale + 1)...(range.upperBound * scale)
                     return scaledRanges.map { Double($0) / Double(scale) }
                 }
+            case .dana:
+                return (1...300).map { Double($0) / 10 }
             case .custom:
                 return nil
             }
@@ -50,6 +53,9 @@ public struct MockPumpManagerState: Equatable {
                 // 0.05 units for rates between 1-9.95 U/h
                 // 0.1 units for rates between 10-25 U/h
                 return "0-1-10-25 by 0.025|0.05|0.1"
+            case .dana:
+                // 0.1 units for volumes between 0.1-25U
+                return "0.1-30 by 0.1"
             case .custom:
                 return nil
             }
@@ -71,6 +77,8 @@ public struct MockPumpManagerState: Equatable {
                 // 0.1 units for rates between 10-35 U/h
                 let rateGroup3 = (100...350).map { Double($0) / 10 }
                 return rateGroup1 + rateGroup2 + rateGroup3
+            case .dana:
+                return (0...300).map { Double($0) / 100 }
             case .custom:
                 return nil
             }
@@ -89,6 +97,9 @@ public struct MockPumpManagerState: Equatable {
                 // 0.05 units for rates between 1-9.95 U/h
                 // 0.1 units for rates between 10-35 U/h
                 return "0-1-10-35 by 0.025|0.05|0.1"
+            case .dana:
+                // 0.01 units for rates between 0.01-3U/hr
+                return "0.01-3 by 0.01"
             case .custom:
                 return nil
             }

--- a/Dependencies/LoopKit/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
+++ b/Dependencies/LoopKit/MockKitUI/View Controllers/MockPumpManagerSettingsViewController.swift
@@ -187,6 +187,8 @@ final class MockPumpManagerSettingsViewController: UITableViewController {
                         return "x22"
                     case .medtronicX23:
                         return "x23"
+                    case .dana:
+                        return "Dana"
                     case .custom:
                         return "Custom"
                     }

--- a/FreeAPS/Resources/Info.plist
+++ b/FreeAPS/Resources/Info.plist
@@ -95,6 +95,7 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
+		<string>audio</string>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
 		<string>processing</string>

--- a/FreeAPS/Resources/Info.plist
+++ b/FreeAPS/Resources/Info.plist
@@ -7,6 +7,7 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.freeapsx.background-task.critical-event-log</string>
+		<string>com.danakit.background-task.connection-timeout</string>
 	</array>
 	<key>CBBundleDisplayName</key>
 	<string>$(APP_DISPLAY_NAME)</string>
@@ -76,6 +77,8 @@
 	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Calendar is used to create a new glucose events.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>To enable the Contact Image feature: to get live updates from iAPS to your Apple Watch Contact complication</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>For authorized acces to bolus</string>
 	<key>NSHealthShareUsageDescription</key>
@@ -115,12 +118,6 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
-	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
-    <key>NSContactsUsageDescription</key>
-    <string>To enable the Contact Image feature: to get live updates from iAPS to your Apple Watch Contact complication</string>
-	<key>LSApplicationCategoryType</key>
-	<string></string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/FreeAPS/Resources/Info.plist
+++ b/FreeAPS/Resources/Info.plist
@@ -7,7 +7,6 @@
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>com.freeapsx.background-task.critical-event-log</string>
-		<string>com.danakit.background-task.connection-timeout</string>
 	</array>
 	<key>CBBundleDisplayName</key>
 	<string>$(APP_DISPLAY_NAME)</string>
@@ -77,8 +76,6 @@
 	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>Calendar is used to create a new glucose events.</string>
-	<key>NSContactsUsageDescription</key>
-	<string>To enable the Contact Image feature: to get live updates from iAPS to your Apple Watch Contact complication</string>
 	<key>NSFaceIDUsageDescription</key>
 	<string>For authorized acces to bolus</string>
 	<key>NSHealthShareUsageDescription</key>
@@ -98,7 +95,6 @@
 	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
-		<string>audio</string>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
 		<string>processing</string>
@@ -118,6 +114,12 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
+    <key>NSContactsUsageDescription</key>
+    <string>To enable the Contact Image feature: to get live updates from iAPS to your Apple Watch Contact complication</string>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorProvider.swift
+++ b/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorProvider.swift
@@ -19,7 +19,7 @@ extension PumpSettingsEditor {
         }
 
         func save(settings: PumpSettings) -> AnyPublisher<Void, Error> {
-            func save() {
+            func save(_ settings: PumpSettings) {
                 storage.save(settings, as: OpenAPS.Settings.settings)
                 processQueue.async {
                     self.broadcaster.notify(PumpSettingsObserver.self, on: self.processQueue) {
@@ -29,7 +29,7 @@ extension PumpSettingsEditor {
             }
 
             guard let pump = deviceManager?.pumpManager else {
-                save()
+                save(settings)
                 return Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
             }
             // Don't ask why 🤦‍♂️
@@ -44,8 +44,21 @@ extension PumpSettingsEditor {
                 self.processQueue.async {
                     pump.syncDeliveryLimits(limits: limits) { result in
                         switch result {
-                        case .success:
-                            save()
+                        case let .success(actual):
+                            // Store the limits from the pumpManager to ensure the correct values
+                            // Example: Dana pumps don't allow to set these limits, only to fetch them
+                            // This will ensure we always have the correct values stored
+                            save(PumpSettings(
+                                insulinActionCurve: settings.insulinActionCurve,
+                                maxBolus: Decimal(
+                                    actual.maximumBolus?
+                                        .doubleValue(for: .internationalUnit()) ?? Double(settings.maxBolus)
+                                ),
+                                maxBasal: Decimal(
+                                    actual.maximumBasalRate?
+                                        .doubleValue(for: .internationalUnitsPerHour) ?? Double(settings.maxBasal)
+                                )
+                            ))
                             promise(.success(()))
                         case let .failure(error):
                             promise(.failure(error))

--- a/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorStateModel.swift
@@ -27,7 +27,11 @@ extension PumpSettingsEditor {
             provider.save(settings: settings)
                 .receive(on: DispatchQueue.main)
                 .sink { _ in
+                    let settings = self.provider.settings()
+
                     self.syncInProgress = false
+                    self.maxBasal = settings.maxBasal
+                    self.maxBolus = settings.maxBolus
 
                 } receiveValue: {}
                 .store(in: &lifetime)


### PR DESCRIPTION
This PR includes several fixes:
- Fix for Loop hang (caused by connection issues)
- Fix for syncing Pump limits (made a separate PR to discuss this fix/feature -> #720)
- fix for switch between basal profile (previously overwrites the profile which is in the pump already)

Features:
- added error messages for failed bolus (daily limit violation or bolus timeout error, i.e.)
- Improved static basal steps (since a Dana pump supports basal steps of 0.01U/hr)
- Optimize connection logic/sync (some data will only be synced during the sync function instead of at every connection)
- Added Dana configuration to in-app pump simulator

Known issues:
- during a bolus, when a connection is lost, the bolus isn't sync correctly in next Loop cycle