### PR TITLE
Fix(PumpManager): Use pump limit from pumpManager instead of UI

### DIFF
--- a/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorProvider.swift
+++ b/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorProvider.swift
@@ -19,7 +19,7 @@ extension PumpSettingsEditor {
         }
 
         func save(settings: PumpSettings) -> AnyPublisher<Void, Error> {
-            func save() {
+            func save(_ settings: PumpSettings) {
                 storage.save(settings, as: OpenAPS.Settings.settings)
                 processQueue.async {
                     self.broadcaster.notify(PumpSettingsObserver.self, on: self.processQueue) {
@@ -29,7 +29,7 @@ extension PumpSettingsEditor {
             }
 
             guard let pump = deviceManager?.pumpManager else {
-                save()
+                save(settings)
                 return Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
             }
             // Don't ask why 🤦‍♂️
@@ -44,8 +44,21 @@ extension PumpSettingsEditor {
                 self.processQueue.async {
                     pump.syncDeliveryLimits(limits: limits) { result in
                         switch result {
-                        case .success:
-                            save()
+                        case let .success(actual):
+                            // Store the limits from the pumpManager to ensure the correct values
+                            // Example: Dana pumps don't allow to set these limits, only to fetch them
+                            // This will ensure we always have the correct values stored
+                            save(PumpSettings(
+                                insulinActionCurve: settings.insulinActionCurve,
+                                maxBolus: Decimal(
+                                    actual.maximumBolus?
+                                        .doubleValue(for: .internationalUnit()) ?? Double(settings.maxBolus)
+                                ),
+                                maxBasal: Decimal(
+                                    actual.maximumBasalRate?
+                                        .doubleValue(for: .internationalUnitsPerHour) ?? Double(settings.maxBasal)
+                                )
+                            ))
                             promise(.success(()))
                         case let .failure(error):
                             promise(.failure(error))

--- a/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PumpSettingsEditor/PumpSettingsEditorStateModel.swift
@@ -27,7 +27,11 @@ extension PumpSettingsEditor {
             provider.save(settings: settings)
                 .receive(on: DispatchQueue.main)
                 .sink { _ in
+                    let settings = self.provider.settings()
+
                     self.syncInProgress = false
+                    self.maxBasal = settings.maxBasal
+                    self.maxBolus = settings.maxBolus
 
                 } receiveValue: {}
                 .store(in: &lifetime)


### PR DESCRIPTION
### What is the problem
I will start by saying: `This is mainly a Dana pump problem`, but the problem is the following:

The LoopKit `syncDeliveryLimits` allows the PumpManager to return DeliveryLimits which are also provided by the parameters. When using Loop (v3.3.0, but this behaviour is since v1.1.0), a dev could return a different then provided and the returned will be stored instead of the provided one. iAPS doesn't do that currently.

Code proof of this behaviour: https://github.com/LoopKit/LoopKit/blob/dev/LoopKitUI/Views/Settings%20Editors/DeliveryLimitsEditor.swift#L348

### Why do we need it 
We need this, because Dana pumps don't allow delivery limits to be set, only to be retrieved. This means that the DanaKit should either:
- Reject every `syncDeliveryLimits` command (which leads to an invalid maxBolus and maxBasal since there are never stored)
- Or ignore the provided parameters and just fetch the actual limits from the pump and return those

The last one gives the user the best UX :)

### What is the impact
Nothing (or at least the behaviour is the same as with Loop). The code has been tested on the Dana branch (#719)

When looking at the code from OmniBLE and OmniKit ([link](https://github.com/LoopKit/OmniBLE/blob/dev/OmniBLE/PumpManager/OmniBLEPumpManager.swift#L2106)), the parameter is directly returned.

When looking at the code from MinimedKit ([link](https://github.com/LoopKit/MinimedKit/blob/main/MinimedKit/PumpManager/MinimedPumpManager.swift#L1418)), the actual values stored on the pump is (set first and then) returned.
