### PR TITLE
Fix birthDate default / typo

### DIFF
--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -62,5 +62,5 @@
   "minimumSMB": 0.3,
   "useInsulinBars": false,
   "uploadVersion": true,
-  "birtDate": new Date()
+  "birthDate": Date.distantPast
 }

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -1207,7 +1207,7 @@ final class BaseAPSManager: APSManager, Injectable {
                     Variance: variance
                 ),
                 id: getIdentifier(),
-                dob: settingsManager.settings.birtDate,
+                dob: settingsManager.settings.birthDate,
                 sex: settingsManager.settings.sexSetting
             )
             storage.save(dailystat, as: file)

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -64,7 +64,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var useInsulinBars: Bool = false
     var disableCGMError: Bool = true
     var uploadVersion: Bool = true
-    var birtDate = Date.now
+    var birthDate = Date.distantPast
     // var sex: Sex = .secret
     var sexSetting: Int = 3
 }
@@ -332,8 +332,8 @@ extension FreeAPSSettings: Decodable {
             settings.uploadVersion = uploadVersion
         }
 
-        if let birtDate = try? container.decode(Date.self, forKey: .birtDate) {
-            settings.birtDate = birtDate
+        if let birthDate = try? container.decode(Date.self, forKey: .birthDate) {
+            settings.birthDate = birthDate
         }
 
         if let sexSetting = try? container.decode(Int.self, forKey: .sexSetting) {

--- a/FreeAPS/Sources/Modules/Sharing/SharingStateModel.swift
+++ b/FreeAPS/Sources/Modules/Sharing/SharingStateModel.swift
@@ -7,7 +7,7 @@ extension Sharing {
 
         @Published var uploadStats: Bool = false
         @Published var identfier: String = ""
-        @Published var birtDate = Date()
+        @Published var birthDate = Date.distantPast
         @Published var uploadVersion: Bool = true
         @Published var sexSetting: Int = 3
         @Published var sex: Sex = .secret
@@ -16,7 +16,7 @@ extension Sharing {
             uploadStats = settingsManager.settings.uploadStats
             subscribeSetting(\.uploadStats, on: $uploadStats) { uploadStats = $0 }
             subscribeSetting(\.uploadVersion, on: $uploadVersion) { uploadVersion = $0 }
-            subscribeSetting(\.birtDate, on: $birtDate) { birtDate = $0 }
+            subscribeSetting(\.birthDate, on: $birthDate) { birthDate = $0 }
             subscribeSetting(\.sexSetting, on: $sexSetting) { sexSetting = $0 }
             identfier = getIdentifier()
         }

--- a/FreeAPS/Sources/Modules/Sharing/View/SharingRootView.swift
+++ b/FreeAPS/Sources/Modules/Sharing/View/SharingRootView.swift
@@ -42,7 +42,7 @@ extension Sharing {
                             state.saveSetting()
                         }
                         HStack {
-                            DatePicker("Birth Date", selection: $state.birtDate, in: dateRange, displayedComponents: [.date])
+                            DatePicker("Birth Date", selection: $state.birthDate, in: dateRange, displayedComponents: [.date])
                                 .datePickerStyle(.compact)
                         }
                     }


### PR DESCRIPTION

* Fix Typo: birtDate -> birthDate
* Set default birthDate to distantPast ( current default is "today", making everyone an infant )

I tried using distantFuture, but on my simulator, that ended up being May 1, 2024 ... which is the past, not future, which made no sense as the one thing I found online seemed to indicate it should be something like year 4001 ... but the docs themselves show that distant{Past,Future} should both be 'off by centuries', so how it came with this year, no clue.

distantPast is slightly better ... it comes to Jan 1, 1920 ... still not "centuries in the past", but hopefully that is a fixed number, and not floating, so I can filter for that date, with a hopefully pretty good certainty that there aren't a lot of 104 year old users or older that is using iAPS that I am eliminating ... can't say for sure, but I think odds are pretty good ...