### PR TITLE
Insulin and TDD details.

### DIFF
--- a/FreeAPS/Resources/javascript/prepare/determine-basal.js
+++ b/FreeAPS/Resources/javascript/prepare/determine-basal.js
@@ -224,7 +224,7 @@ function dynisf(profile, autosens_data, dynamicVariables, glucose) {
     // Basal Adjustment
     if (profile.tddAdjBasal && dynISFenabled) {
         profile.current_basal *= tdd_factor;
-        console.log("Dynamic ISF. Basal adjusted with TDD factor: " + round(tdd_factor, 1));
+        console.log("Dynamic ISF. Basal adjusted with TDD factor: " + round(tdd_factor, 2));
     }
 }
 

--- a/FreeAPS/Resources/javascript/prepare/determine-basal.js
+++ b/FreeAPS/Resources/javascript/prepare/determine-basal.js
@@ -158,7 +158,7 @@ function dynisf(profile, autosens_data, dynamicVariables, glucose) {
     }
 
     // Account for TDD of insulin. Compare last 2 hours with total data (up to 10 days)
-    const tdd_factor = weighted_average / average14; // weighted average TDD / total data average TDD
+    var tdd_factor = weighted_average / average14; // weighted average TDD / total data average TDD
     
     const enable_sigmoid = profile.sigmoid;
     var newRatio = 1;
@@ -202,7 +202,7 @@ function dynisf(profile, autosens_data, dynamicVariables, glucose) {
         console.log(", Dynamic ISF limited by autosens_max setting to: " + autosens_max + ", from: " + newRatio);
         newRatio = autosens_max;
     } else if (newRatio < autosens_min) {
-        console.log("Dynamic ISF limited by autosens_min setting to: " + autosens_min + ", from: " + newRatio);
+        console.log(", Dynamic ISF limited by autosens_min setting to: " + autosens_min + ", from: " + newRatio);
         newRatio = autosens_min;
     }
 

--- a/FreeAPS/Resources/javascript/prepare/middleware.js
+++ b/FreeAPS/Resources/javascript/prepare/middleware.js
@@ -11,9 +11,16 @@ function generate(iob, currenttemp, glucose, profile, autosens = null, meal = nu
     };
         
     if (profile.tddAdjBasal && dynamicVariables.average_total_data != 0) {
-        profile.tdd_factor = Math.round((dynamicVariables.weightedAverage / dynamicVariables.average_total_data) * 100) / 100;
+        profile.tdd_factor = Math.round( (dynamicVariables.weightedAverage / dynamicVariables.average_total_data) * 100) / 100;
+                                          
+        const adjusted = Math.min(Math.max(profile.autosens_min, profile.tdd_factor), profile.autosens_max);
+        
+        if (profile.tdd_factor != adjusted) {
+            console.log("Dynamic basal adjustment limited by your autosens_min/max settings to: " + adjusted);
+            profile.tdd_factor = adjusted;
+        }
     }
-                                         
+
     if (profile.useNewFormula && profile.temptargetSet && (profile.high_temptarget_raises_sensitivity || profile.exercise_mode || dynamicVariables.isEnabled) && profile.min_bg >= 118) {
             profile.useNewFormula = false;
             console.log("Dynamic ISF disabled due to an active exercise ");

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -441,8 +441,23 @@ final class OpenAPS {
             // Temp Target
             let tempTargetsArray = cd.fetchTempTargets()
 
-            let total = uniqueEvents.compactMap({ each in each.tdd as? Decimal ?? 0 }).reduce(0, +)
-            var indeces = uniqueEvents.count
+            // Time adjusted average
+            var time = uniqueEvents.first?.timestamp ?? .distantPast
+            var data_ = [tddData(date: time, tdd: (uniqueEvents.first?.tdd ?? 0) as Decimal)]
+
+            for a in uniqueEvents {
+                if a.timestamp ?? .distantFuture <= time.addingTimeInterval(-24.hours.timeInterval) {
+                    let b = tddData(
+                        date: a.timestamp ?? .distantFuture,
+                        tdd: (a.tdd ?? 0) as Decimal
+                    )
+                    data_.append(b)
+                    time = a.timestamp ?? .distantPast
+                }
+            }
+            let total = data_.map(\.tdd).reduce(0, +)
+            let indeces = data_.count
+
             // Only fetch once. Use same (previous) fetch
             let twoHoursArray = uniqueEvents
                 .filter({ ($0.timestamp ?? Date()) >= Date.now.addingTimeInterval(-2.hours.timeInterval) })
@@ -459,9 +474,6 @@ final class OpenAPS {
             let overrideMaxIOB = overrideArray.first?.overrideMaxIOB ?? false
             let maxIOB = overrideArray.first?.maxIOB ?? (preferences?.maxIOB ?? 0) as NSDecimalNumber
 
-            if indeces == 0 {
-                indeces = 1
-            }
             if nrOfIndeces == 0 {
                 nrOfIndeces = 1
             }

--- a/FreeAPS/Sources/Models/Charts.swift
+++ b/FreeAPS/Sources/Models/Charts.swift
@@ -59,3 +59,8 @@ struct IOBData: Identifiable {
     var cob: Decimal
     var id = UUID()
 }
+
+struct tddData {
+    var date: Date
+    var tdd: Decimal
+}

--- a/FreeAPS/Sources/Modules/Home/HomeProvider.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeProvider.swift
@@ -15,6 +15,10 @@ extension Home {
             storage.retrieve(OpenAPS.Enact.suggested, as: Suggestion.self)
         }
 
+        var dynamicVariables: DynamicVariables? {
+            storage.retrieve(OpenAPS.Monitor.dynamicVariables, as: DynamicVariables.self)
+        }
+
         let overrideStorage = OverrideStorage()
 
         func overrides() -> [Override] {

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -16,6 +16,7 @@ extension Home {
         @Published var isManual: [BloodGlucose] = []
         @Published var announcement: [Announcement] = []
         @Published var suggestion: Suggestion?
+        @Published var dynamicVariables: DynamicVariables?
         @Published var uploadStats = false
         @Published var enactedSuggestion: Suggestion?
         @Published var recentGlucose: BloodGlucose?
@@ -82,6 +83,11 @@ extension Home {
         @Published var iobData: [IOBData] = []
         @Published var neg: Int = 0
         @Published var tddChange: Decimal = 0
+        @Published var tddAverage: Decimal = 0
+        @Published var tddYesterday: Decimal = 0
+        @Published var tdd2DaysAgo: Decimal = 0
+        @Published var tdd3DaysAgo: Decimal = 0
+        @Published var tddActualAverage: Decimal = 0
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
 
@@ -104,6 +110,7 @@ extension Home {
 
             // iobData = provider.reasons()
             suggestion = provider.suggestion
+            dynamicVariables = provider.dynamicVariables
             overrideHistory = provider.overrideHistory()
             uploadStats = settingsManager.settings.uploadStats
             enactedSuggestion = provider.enactedSuggestion
@@ -482,14 +489,26 @@ extension Home {
                 if let data = self.provider.reasons() {
                     self.iobData = data
                     neg = data.filter({ $0.iob < 0 }).count * 5
-                    let tdds = CoreDataStorage().fetchTDD(interval: DateFilter().twoDays)
+                    let tdds = CoreDataStorage().fetchTDD(interval: DateFilter().tenDays)
                     let yesterday = (tdds.first(where: {
                         ($0.timestamp ?? .distantFuture) <= Date().addingTimeInterval(-24.hours.timeInterval)
                     })?.tdd ?? 0) as Decimal
+                    let oneDaysAgo = CoreDataStorage().fetchTDD(interval: DateFilter().today).last
                     tddChange = ((tdds.first?.tdd ?? 0) as Decimal) - yesterday
+                    tddYesterday = (oneDaysAgo?.tdd ?? 0) as Decimal
+                    tdd2DaysAgo = (tdds.first(where: {
+                        ($0.timestamp ?? .distantFuture) <= (oneDaysAgo?.timestamp ?? .distantPast)
+                            .addingTimeInterval(-1.days.timeInterval)
+                    })?.tdd ?? 0) as Decimal
+                    tdd3DaysAgo = (tdds.first(where: {
+                        ($0.timestamp ?? .distantFuture) <= (oneDaysAgo?.timestamp ?? .distantPast)
+                            .addingTimeInterval(-2.days.timeInterval)
+                    })?.tdd ?? 0) as Decimal
 
-                    print("Yesterday: \(yesterday)")
-                    print("Today: \((tdds.first?.tdd ?? 0) as Decimal)")
+                    if let tdds_ = self.provider.dynamicVariables {
+                        tddAverage = ((tdds.first?.tdd ?? 0) as Decimal) - tdds_.average_total_data
+                        tddActualAverage = tdds_.average_total_data
+                    }
                 }
             }
         }

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -487,9 +487,18 @@ extension Home {
 
         var activeIOBView: some View {
             addBackground()
-                .frame(minHeight: 340)
+                .frame(minHeight: 410)
                 .overlay {
-                    ActiveIOBView(data: $state.iobData, neg: $state.neg, tddChange: $state.tddChange)
+                    ActiveIOBView(
+                        data: $state.iobData,
+                        neg: $state.neg,
+                        tddChange: $state.tddChange,
+                        tddAverage: $state.tddAverage,
+                        tddYesterday: $state.tddYesterday,
+                        tdd2DaysAgo: $state.tdd2DaysAgo,
+                        tdd3DaysAgo: $state.tdd3DaysAgo,
+                        tddActualAverage: $state.tddActualAverage
+                    )
                 }
                 .clipShape(RoundedRectangle(cornerRadius: 15))
                 .addShadows()

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -487,7 +487,7 @@ extension Home {
 
         var activeIOBView: some View {
             addBackground()
-                .frame(minHeight: 410)
+                .frame(minHeight: 500)
                 .overlay {
                     ActiveIOBView(
                         data: $state.iobData,

--- a/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
@@ -5,13 +5,25 @@ struct ActiveIOBView: View {
     @Binding var data: [IOBData]
     @Binding var neg: Int
     @Binding var tddChange: Decimal
+    @Binding var tddAverage: Decimal
+    @Binding var tddYesterday: Decimal
+    @Binding var tdd2DaysAgo: Decimal
+    @Binding var tdd3DaysAgo: Decimal
+    @Binding var tddActualAverage: Decimal
 
     private var formatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 1
         formatter.negativePrefix = formatter.minusSign
         formatter.positivePrefix = formatter.plusSign
+        return formatter
+    }
+
+    private var tddFormatter: NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.maximumFractionDigits = 1
         return formatter
     }
 
@@ -19,7 +31,7 @@ struct ActiveIOBView: View {
         VStack {
             Text("Active Insulin").font(.previewHeadline).padding(.top, 20)
             iobView().frame(maxHeight: 200).padding(.horizontal, 20)
-            sumView().frame(maxHeight: 100).padding(.vertical, 20)
+            sumView().frame(maxHeight: 170).padding(.vertical, 20)
         }.dynamicTypeSize(...DynamicTypeSize.medium)
     }
 
@@ -63,23 +75,72 @@ struct ActiveIOBView: View {
                 color: .red
             ),
             BolusSummary(
-                variable: NSLocalizedString("TDD compared to yesterday", comment: ""),
+                variable: NSLocalizedString("Insulin compared to yesterday", comment: ""),
                 formula: NSLocalizedString(" U", comment: ""),
                 insulin: tddChange,
                 color: Color(.insulin)
+            ),
+            BolusSummary(
+                variable: NSLocalizedString("Insulin compared to average", comment: ""),
+                formula: NSLocalizedString(" U", comment: ""),
+                insulin: tddAverage,
+                color: Color(.insulin)
+            ),
+            BolusSummary(
+                variable: NSLocalizedString("Average Insulin past 24h", comment: ""),
+                formula: NSLocalizedString(" U", comment: ""),
+                insulin: tddActualAverage,
+                color: .secondary
+            ),
+            BolusSummary(
+                variable: "",
+                formula: "",
+                insulin: .zero,
+                color: Color(.clear)
+            ),
+            BolusSummary(
+                variable: NSLocalizedString("TDD yesterday", comment: ""),
+                formula: NSLocalizedString(" U", comment: ""),
+                insulin: tddYesterday,
+                color: .secondary
+            ),
+            BolusSummary(
+                variable: NSLocalizedString("TDD 2 days ago", comment: ""),
+                formula: NSLocalizedString(" U", comment: ""),
+                insulin: tdd2DaysAgo,
+                color: .secondary
+            ),
+            BolusSummary(
+                variable: NSLocalizedString("TDD 3 days ago", comment: ""),
+                formula: NSLocalizedString(" U", comment: ""),
+                insulin: tdd3DaysAgo,
+                color: .secondary
             )
         ]
 
+        let insulinData = useData(entries)
+
         Grid {
-            ForEach(tddChange == 0 ? entries.dropLast() : entries) { entry in
+            ForEach(insulinData) { entry in
                 GridRow(alignment: .firstTextBaseline) {
                     Text(entry.variable).foregroundStyle(.secondary).frame(maxWidth: .infinity, alignment: .leading)
                     Text("")
-                    Text((formatter.string(for: entry.insulin) ?? "") + entry.formula)
+                    Text(((isTDD(entry.insulin) ? tddFormatter : formatter).string(for: entry.insulin) ?? "") + entry.formula)
                         .bold(entry == entries.first).foregroundStyle(entry.color)
                 }
             }
         }
         .padding(.horizontal, 20)
+    }
+
+    private func isTDD(_ insulin: Decimal) -> Bool {
+        insulin == tddYesterday || insulin == tdd2DaysAgo || insulin == tdd3DaysAgo || insulin == tddActualAverage
+    }
+
+    private func useData(_ data: [BolusSummary]) -> [BolusSummary] {
+        if neg == 0 {
+            return data.dropFirst().map({ a -> BolusSummary in a })
+        }
+        return data
     }
 }

--- a/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
@@ -132,14 +132,14 @@ struct ActiveIOBView: View {
                 GridRow(alignment: .firstTextBaseline) {
                     Text(entry.variable).foregroundStyle(.secondary).frame(maxWidth: .infinity, alignment: .leading)
                     Text("")
-                    if entry.insulin > 0 {
+                    if entry.insulin != 0 {
                         Text(
                             ((isTDD(entry.insulin) ? tddFormatter : formatter).string(for: entry.insulin) ?? "") + entry
                                 .formula
                         )
                         .bold(entry == entries.first).foregroundStyle(entry.color)
                     } else if entry.variable != "" {
-                        Text("--").foregroundStyle(.secondary)
+                        Text("0").foregroundStyle(.secondary)
                     }
                 }
             }

--- a/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
@@ -31,7 +31,7 @@ struct ActiveIOBView: View {
         VStack {
             Text("Active Insulin").font(.previewHeadline).padding(.top, 20)
             iobView().frame(maxHeight: 200).padding(.horizontal, 20)
-            sumView().frame(maxHeight: 170).padding(.vertical, 20)
+            sumView().frame(maxHeight: 250).padding(.vertical, 30)
         }.dynamicTypeSize(...DynamicTypeSize.medium)
     }
 
@@ -85,6 +85,12 @@ struct ActiveIOBView: View {
                 formula: NSLocalizedString(" U", comment: ""),
                 insulin: tddAverage,
                 color: Color(.insulin)
+            ),
+            BolusSummary(
+                variable: "",
+                formula: "",
+                insulin: .zero,
+                color: Color(.clear)
             ),
             BolusSummary(
                 variable: NSLocalizedString("Average Insulin past 24h", comment: ""),

--- a/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Previews/ActiveIOBView.swift
@@ -128,11 +128,19 @@ struct ActiveIOBView: View {
 
         Grid {
             ForEach(insulinData) { entry in
+
                 GridRow(alignment: .firstTextBaseline) {
                     Text(entry.variable).foregroundStyle(.secondary).frame(maxWidth: .infinity, alignment: .leading)
                     Text("")
-                    Text(((isTDD(entry.insulin) ? tddFormatter : formatter).string(for: entry.insulin) ?? "") + entry.formula)
+                    if entry.insulin > 0 {
+                        Text(
+                            ((isTDD(entry.insulin) ? tddFormatter : formatter).string(for: entry.insulin) ?? "") + entry
+                                .formula
+                        )
                         .bold(entry == entries.first).foregroundStyle(entry.color)
+                    } else if entry.variable != "" {
+                        Text("--").foregroundStyle(.secondary)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Display insulin analysis in IOB View.

Use the autosens.min/max limits to limit any eventual dynamic basal adjustments.

Use a time adjusted TDD average (real average) for dynamic ISF, to avoid any eventual skewness. 
Example: if current  time is 15:15, your average insulin past 24h (used in dynamic ISF and displayed in IOB View) is the average of all the insulin past 24h entries at this time of day  [today 15:15, yesterday 15:15, day before yesterday 15:15, ... ].