### PR TITLE
Extend middleware function

### DIFF
--- a/FreeAPS/Resources/javascript/prepare/determine-basal.js
+++ b/FreeAPS/Resources/javascript/prepare/determine-basal.js
@@ -87,6 +87,11 @@ function generate(iob, currenttemp, glucose, profile, autosens = null, meal = nu
     }
     var glucose_status = freeaps_glucoseGetLast(glucose);
     
+    // In case Basal Rate been set in midleware
+    if (profile.set_basal && profile.basal_rate) {
+        console.log("Basal Rate set by middleware to " + profile.basal_rate + " U/h.");
+    }
+    
     return freeaps_determineBasal(glucose_status, currenttemp, iob, profile, autosens_data, meal_data, freeaps_basalSetTemp, microbolusAllowed, reservoir_data, clock);
 }
 

--- a/FreeAPS/Resources/javascript/prepare/profile.js
+++ b/FreeAPS/Resources/javascript/prepare/profile.js
@@ -82,6 +82,8 @@ function generate(pumpsettings_data, bgtargets_data, isf_data, basalprofile_data
     }
     
     var tdd_factor = { };
+    var set_basal = false;
+    var basal_rate = { };
 
     var inputs = { };
     //add all preferences to the inputs
@@ -108,6 +110,8 @@ function generate(pumpsettings_data, bgtargets_data, isf_data, basalprofile_data
     inputs.model = model_data;
     inputs.autotune = autotune_data;
     inputs.tddFactor = tdd_factor;
+    inputs.set_basal = set_basal;
+    inputs.basal_rate = basal_rate;
     
     if (autotune_data) {
         if (autotune_data.basalprofile) { inputs.basals = autotune_data.basalprofile; }

--- a/FreeAPS/Sources/Models/Suggestion.swift
+++ b/FreeAPS/Sources/Models/Suggestion.swift
@@ -6,8 +6,8 @@ struct Suggestion: JSON, Equatable {
     let insulinReq: Decimal?
     let eventualBG: Int?
     let sensitivityRatio: Decimal?
-    let rate: Decimal?
-    let duration: Int?
+    var rate: Decimal?
+    var duration: Int?
     let iob: Decimal?
     let cob: Decimal?
     var predictions: Predictions?

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -255,7 +255,7 @@ struct MainChartView: View {
                     }
                 }
             }
-            .padding(.bottom, 10)
+            .padding(.bottom, 7)
         }
     }
 

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -255,7 +255,7 @@ struct MainChartView: View {
                     }
                 }
             }
-            .padding(.bottom, 7)
+            .padding(.bottom, 8)
         }
     }
 

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -279,20 +279,6 @@ extension Home {
                 let isOverride = fetchedPercent.first?.enabled ?? false
                 let isTarget = (state.tempTarget != nil)
                 HStack {
-                    /* Button { state.showModal(for: .dataTable) }
-                     label: {
-                         ZStack(alignment: Alignment(horizontal: .leading, vertical: .bottom)) {
-                             Image(systemName: "book")
-                                 .symbolRenderingMode(.hierarchical)
-                                 .resizable()
-                                 .frame(
-                                     width: IAPSconfig.buttonSize * 0.85,
-                                     height: IAPSconfig.buttonSize * 0.9
-                                 )
-                                 .foregroundColor(.gray)
-                         }
-                     }.buttonStyle(.borderless)
-                     Spacer() */
                     Button { state.showModal(for: .addCarbs(editMode: false, override: false)) }
                     label: {
                         ZStack(alignment: Alignment(horizontal: .trailing, vertical: .bottom)) {
@@ -312,6 +298,31 @@ extension Home {
                         }
                     }.buttonStyle(.borderless)
                     Spacer()
+                    Button {
+                        state.showModal(for: .bolus(
+                            waitForSuggestion: state.useCalc ? true : false,
+                            fetch: false
+                        ))
+                    }
+                    label: {
+                        Image(systemName: "syringe")
+                            .renderingMode(.template)
+                            .font(.custom("Buttons", size: 24))
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundColor(.insulin)
+                    Spacer()
+                    if state.allowManualTemp {
+                        Button { state.showModal(for: .manualTempBasal) }
+                        label: {
+                            Image("bolus1")
+                                .renderingMode(.template)
+                                .resizable()
+                                .frame(width: IAPSconfig.buttonSize, height: IAPSconfig.buttonSize, alignment: .bottom)
+                        }
+                        .foregroundColor(.insulin)
+                        Spacer()
+                    }
                     ZStack(alignment: Alignment(horizontal: .trailing, vertical: .bottom)) {
                         Image(systemName: isOverride ? "person.fill" : "person")
                             .symbolRenderingMode(.palette)
@@ -352,31 +363,6 @@ extension Home {
                             }
                     }
                     Spacer()
-                    Button {
-                        state.showModal(for: .bolus(
-                            waitForSuggestion: state.useCalc ? true : false,
-                            fetch: false
-                        ))
-                    }
-                    label: {
-                        Image(systemName: "syringe")
-                            .renderingMode(.template)
-                            .font(.custom("Buttons", size: 24))
-                    }
-                    .buttonStyle(.borderless)
-                    .foregroundColor(.insulin)
-                    Spacer()
-                    if state.allowManualTemp {
-                        Button { state.showModal(for: .manualTempBasal) }
-                        label: {
-                            Image("bolus1")
-                                .renderingMode(.template)
-                                .resizable()
-                                .frame(width: IAPSconfig.buttonSize, height: IAPSconfig.buttonSize, alignment: .bottom)
-                        }
-                        .foregroundColor(.insulin)
-                        Spacer()
-                    }
                     Button { state.showModal(for: .settings) }
                     label: {
                         Image(systemName: "gear")

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -279,20 +279,20 @@ extension Home {
                 let isOverride = fetchedPercent.first?.enabled ?? false
                 let isTarget = (state.tempTarget != nil)
                 HStack {
-                    Button { state.showModal(for: .dataTable) }
-                    label: {
-                        ZStack(alignment: Alignment(horizontal: .leading, vertical: .bottom)) {
-                            Image(systemName: "book")
-                                .symbolRenderingMode(.hierarchical)
-                                .resizable()
-                                .frame(
-                                    width: IAPSconfig.buttonSize * 0.85,
-                                    height: IAPSconfig.buttonSize * 0.9
-                                )
-                                .foregroundColor(.gray)
-                        }
-                    }.buttonStyle(.borderless)
-                    Spacer()
+                    /* Button { state.showModal(for: .dataTable) }
+                     label: {
+                         ZStack(alignment: Alignment(horizontal: .leading, vertical: .bottom)) {
+                             Image(systemName: "book")
+                                 .symbolRenderingMode(.hierarchical)
+                                 .resizable()
+                                 .frame(
+                                     width: IAPSconfig.buttonSize * 0.85,
+                                     height: IAPSconfig.buttonSize * 0.9
+                                 )
+                                 .foregroundColor(.gray)
+                         }
+                     }.buttonStyle(.borderless)
+                     Spacer() */
                     Button { state.showModal(for: .addCarbs(editMode: false, override: false)) }
                     label: {
                         ZStack(alignment: Alignment(horizontal: .trailing, vertical: .bottom)) {


### PR DESCRIPTION
Enact a basal rate in middleware. This will be very useful when doing prolonged exercises etc.
New basal rate will be displayed both in pop-up (iAPS pill and in OpenAPS NS pill) and in all other views.


![image](https://github.com/Artificial-Pancreas/iAPS/assets/53905247/ec150a03-07e4-4f1a-8a98-f78b38daedb4)



Some UI updates: remove the history button (tapping chart displays history as before) to make more room in button panel.