### PR TITLE
Hypo treatments

### DIFF
--- a/FreeAPS/Sources/APS/OpenAPS/TotalDailyDose.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/TotalDailyDose.swift
@@ -49,7 +49,6 @@ final class TotalDailyDose {
 
     func insulinToday(_ data: [PumpHistoryEvent], increment: Double) -> (bolus: Decimal, basal: Decimal, hours: Double) {
         let filtered = data.filter({ $0.timestamp > Calendar.current.startOfDay(for: Date()) })
-        
         return totalDailyDose(filtered, increment: increment)
     }
 

--- a/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
@@ -252,11 +252,10 @@ extension AddCarbs {
 
             os.overrideFromPreset(override, UUID().uuidString)
             // Upload to Nightscout
-            let currentActiveOveride = os.fetchLatestOverride().first
             nightscoutManager.uploadOverride(
                 "📉",
                 Double(45),
-                currentActiveOveride?.date ?? Date.now
+                override.date ?? Date.now
             )
         }
     }

--- a/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
@@ -7,6 +7,8 @@ extension AddCarbs {
         @Injected() var carbsStorage: CarbsStorage!
         @Injected() var apsManager: APSManager!
         @Injected() var settings: SettingsManager!
+        @Injected() var nightscoutManager: NightscoutManager!
+
         @Published var carbs: Decimal = 0
         @Published var date = Date()
         @Published var protein: Decimal = 0
@@ -21,10 +23,12 @@ extension AddCarbs {
         @Published var id_: String = ""
         @Published var summary: String = ""
         @Published var skipBolus: Bool = false
+        @Published var hypoTreatment: Bool = false
 
         let now = Date.now
 
         let coredataContext = CoreDataStack.shared.persistentContainer.viewContext
+        let coredataContextBackground = CoreDataStack.shared.persistentContainer.newBackgroundContext()
 
         override func subscribe() {
             carbsRequired = provider.suggestion?.carbsReq
@@ -54,7 +58,9 @@ extension AddCarbs {
             )]
             carbsStorage.storeCarbs(carbsToStore)
 
-            if skipBolus, !continue_, !fetch {
+            if hypoTreatment { hypo() }
+
+            if (skipBolus && !continue_ && !fetch) || hypoTreatment {
                 apsManager.determineBasalSync()
                 showModal(for: nil)
             } else if carbs > 0 {
@@ -206,6 +212,52 @@ extension AddCarbs {
                 }
                 print("meals 1: ID: " + (save.id ?? "").description + " FPU ID: " + (save.fpuID ?? "").description)
             }
+        }
+
+        private func hypo() {
+            let os = OverrideStorage()
+
+            // Cancel any eventual Other Override already active
+            if let activeOveride = os.fetchLatestOverride().first {
+                let presetName = os.isPresetName()
+                // Is the Override a Preset?
+                if let preset = presetName {
+                    if let duration = os.cancelProfile() {
+                        // Update in Nightscout
+                        nightscoutManager.editOverride(preset, duration, activeOveride.date ?? Date.now)
+                    }
+                } else if activeOveride.isPreset { // Because hard coded Hypo treatment isn't actually a preset
+                    if let duration = os.cancelProfile() {
+                        nightscoutManager.editOverride("📉", duration, activeOveride.date ?? Date.now)
+                    }
+                } else {
+                    let nsString = activeOveride.percentage.formatted() != "100" ? activeOveride.percentage
+                        .formatted() + " %" : "Custom"
+                    if let duration = os.cancelProfile() {
+                        nightscoutManager.editOverride(nsString, duration, activeOveride.date ?? Date.now)
+                    }
+                }
+            }
+
+            // Enable New Override
+            let override = OverridePresets(context: coredataContextBackground)
+            override.percentage = 90
+            override.smbIsOff = true
+            override.duration = 45
+            override.name = "📉"
+            override.advancedSettings = true
+            override.target = 117
+            override.date = Date.now
+            override.indefinite = false
+
+            os.overrideFromPreset(override, UUID().uuidString)
+            // Upload to Nightscout
+            let currentActiveOveride = os.fetchLatestOverride().first
+            nightscoutManager.uploadOverride(
+                "📉",
+                Double(45),
+                currentActiveOveride?.date ?? Date.now
+            )
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -75,7 +75,6 @@ extension AddCarbs {
 
                     // Time
                     HStack {
-                        let now = Date.now
                         Text("Time")
                         Spacer()
                         if !pushed {
@@ -111,6 +110,11 @@ extension AddCarbs {
                     .popover(isPresented: $isPromptPresented) {
                         presetPopover
                     }
+
+                    // Optional Hypo Treatment
+                    if state.carbs > 0 {
+                        Toggle("Hypo Treatment", isOn: $state.hypoTreatment)
+                    }
                 }
 
                 Section {
@@ -118,11 +122,20 @@ extension AddCarbs {
                         button.toggle()
                         if button { state.add(override, fetch: editMode) }
                     }
-                    label: { Text(((state.skipBolus && !override && !editMode) || state.carbs <= 0) ? "Save" : "Continue") }
+                    label: {
+                        Text(
+                            ((state.skipBolus && !override && !editMode) || state.carbs <= 0 || state.hypoTreatment) ? "Save" :
+                                "Continue"
+                        ) }
                         .disabled(empty)
                         .frame(maxWidth: .infinity, alignment: .center)
-                }.listRowBackground(!empty ? Color(.systemBlue) : Color(.systemGray4))
-                    .tint(.white)
+                }
+                footer: {
+                    state.hypoTreatment ? Text("Skipping Bolus View because of hypo")
+                        .frame(maxWidth: .infinity, alignment: .center) : nil
+                }
+                .listRowBackground(!empty ? Color(.systemBlue) : Color(.systemGray4))
+                .tint(.white)
 
                 Section {
                     mealPresets

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -274,6 +274,10 @@ extension Home {
                         // Update in Nightscout
                         nightscoutManager.editOverride(preset, duration, activeOveride.date ?? Date.now)
                     }
+                } else if activeOveride.isPreset { // Because hard coded Hypo treatment isn't actually a preset
+                    if let duration = os.cancelProfile() {
+                        nightscoutManager.editOverride("📉", duration, activeOveride.date ?? Date.now)
+                    }
                 } else {
                     let nsString = activeOveride.percentage.formatted() != "100" ? activeOveride.percentage
                         .formatted() + " %" : "Custom"

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -528,7 +528,7 @@ extension Home {
                                         Text(name).font(.statusFont).foregroundStyle(.secondary)
                                     }
                                 }
-                            }
+                            } else { Text("📉") } // Hypo Treatment is not actually a preset
                         } else if override.percentage != 100 {
                             Text(override.percentage.formatted() + " %").font(.statusFont).foregroundStyle(.secondary)
                         } else if override.smbIsOff, !override.smbIsAlwaysOff {

--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/OverrideProfilesStateModel.swift
@@ -57,7 +57,7 @@ extension OverrideProfilesConfig {
                     ns.editOverride(preset, duration, last?.date ?? Date.now)
                 } else if let duration = OverrideStorage().cancelProfile() {
                     let nsString = active.percentage.formatted() != "100" ? active.percentage
-                        .formatted() + " %" : "Custom"
+                        .formatted() + " %" : active.isPreset ? "📉" : "Custom"
                     ns.editOverride(nsString, duration, last?.date ?? Date.now)
                 }
             }
@@ -162,7 +162,7 @@ extension OverrideProfilesConfig {
             let lastPreset = OverrideStorage().isPresetName()
             if let alreadyActive = last, alreadyActive.enabled, let duration = OverrideStorage().cancelProfile() {
                 ns.editOverride(
-                    (last?.isPreset ?? false) ? (lastPreset ?? "Override") : "Custom",
+                    (last?.isPreset ?? false) ? (lastPreset ?? "📉") : "Custom",
                     duration,
                     alreadyActive.date ?? Date.now
                 )

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -96,13 +96,13 @@ extension Settings {
                             }
 
                             // Test code
-                            /*HStack {
+                            HStack {
                                 Text("Delete All NS Overrides")
                                 Button("Delete") { state.deleteOverrides() }
                                     .frame(maxWidth: .infinity, alignment: .trailing)
                                     .buttonStyle(.borderedProminent)
                                     .tint(.red)
-                            }*/
+                            }
 
                             HStack {
                                 Toggle("Ignore flat CGM readings", isOn: $state.disableCGMError)

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -94,14 +94,15 @@ extension Settings {
                                     .frame(maxWidth: .infinity, alignment: .trailing)
                                     .buttonStyle(.borderedProminent)
                             }
-                            /*
-                             HStack {
-                                 Text("Delete All NS Overrides")
-                                 Button("Delete") { state.deleteOverrides() }
-                                     .frame(maxWidth: .infinity, alignment: .trailing)
-                                     .buttonStyle(.borderedProminent)
-                                     .tint(.red)
-                             }*/
+
+                            // Test code
+                            /*HStack {
+                                Text("Delete All NS Overrides")
+                                Button("Delete") { state.deleteOverrides() }
+                                    .frame(maxWidth: .infinity, alignment: .trailing)
+                                    .buttonStyle(.borderedProminent)
+                                    .tint(.red)
+                            }*/
 
                             HStack {
                                 Toggle("Ignore flat CGM readings", isOn: $state.disableCGMError)

--- a/FreeAPS/Sources/Shortcuts/Overrides/OverrideShortcuts.swift
+++ b/FreeAPS/Sources/Shortcuts/Overrides/OverrideShortcuts.swift
@@ -219,6 +219,10 @@ enum OverrideIntentError: Error {
                     // Update in Nightscout
                     nightscoutManager.editOverride(preset, duration, activeOveride.date ?? Date.now)
                 }
+            } else if activeOveride.isPreset {
+                if let duration = overrideStorage.cancelProfile() {
+                    nightscoutManager.editOverride("📉", duration, activeOveride.date ?? Date.now)
+                }
             } else {
                 let nsString = activeOveride.percentage.formatted() != "100" ? activeOveride.percentage
                     .formatted() + " %" : "Custom"


### PR DESCRIPTION
Activate a hypo treatment override preset when selecting Hypo Treatment in the meals View. The activated override: 45 min, SMBs off, 90%, 6.5 mmol/l target.

This will also skip the Bolus View.

Make the necessary updates to update the override/s in Nightscout.