### PR TITLE
Auto sync for with upstream

### DIFF
--- a/.github/workflows/syncUpstreamRepo.yml
+++ b/.github/workflows/syncUpstreamRepo.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: GitHub Sync to Upstream Repository
-        uses: Artificial-Pancreas/sync-upstream-repo
+        uses: Artificial-Pancreas/sync-upstream-repo@master
         with:
           upstream_repo: ${{ env.UPSTREAM_URL }}
           upstream_branch: ${{ env.UPSTREAM_BRANCH }}

--- a/.github/workflows/syncUpstreamRepo.yml
+++ b/.github/workflows/syncUpstreamRepo.yml
@@ -1,19 +1,4 @@
-#
-# before going to main, occurances of dev 
-# should be renamed to ${{ github.ref_name }}
-#
-# there are *two* occurances:
-#  - name:
-#  - UPSTREAM_BRANCH variable
-#
-# this will allow using the same script, like
-# the build_iAPS.yml script, across different
-# branches, so someone could auto-sync the 'dana'
-# branch if they wanted
-#
-# for testing purposes, we need to hardcode the
-# branch.
-#
+
 name: 5. Sync Upstream ( ${{ github.ref_name }} )
 
 env:

--- a/.github/workflows/syncUpstreamRepo.yml
+++ b/.github/workflows/syncUpstreamRepo.yml
@@ -14,13 +14,13 @@
 # for testing purposes, we need to hardcode the
 # branch.
 #
-name: 5. Sync Upstream ( dev )
+name: 5. Sync Upstream ( ${{ github.ref_name }} )
 
 env:
   UPSTREAM_URL: "https://github.com/Artificial-Pancreas/iAPS.git"
   WORKFLOW_TOKEN: ${{ secrets.GH_PAT }}
-  UPSTREAM_BRANCH: "dev"
-  DOWNSTREAM_BRANCH: "dev"
+  UPSTREAM_BRANCH: "${{ github.ref_name }}"
+  DOWNSTREAM_BRANCH: "${{ github.ref_name }}"
   # Optional fetch arguments
   FETCH_ARGS: ""
   # Optional merge arguments

--- a/.github/workflows/syncUpstreamRepo.yml
+++ b/.github/workflows/syncUpstreamRepo.yml
@@ -20,6 +20,7 @@ env:
   UPSTREAM_URL: "https://github.com/Artificial-Pancreas/iAPS.git"
   WORKFLOW_TOKEN: ${{ secrets.GH_PAT }}
   UPSTREAM_BRANCH: "dev"
+  DOWNSTREAM_BRANCH: "dev"
   # Optional fetch arguments
   FETCH_ARGS: ""
   # Optional merge arguments

--- a/.github/workflows/syncUpstreamRepo.yml
+++ b/.github/workflows/syncUpstreamRepo.yml
@@ -1,0 +1,53 @@
+#
+# before going to main, occurances of dev 
+# should be renamed to ${{ github.ref_name }}
+#
+# there are *two* occurances:
+#  - name:
+#  - UPSTREAM_BRANCH variable
+#
+# this will allow using the same script, like
+# the build_iAPS.yml script, across different
+# branches, so someone could auto-sync the 'dana'
+# branch if they wanted
+#
+# for testing purposes, we need to hardcode the
+# branch.
+#
+name: 5. Sync Upstream ( dev )
+
+env:
+  UPSTREAM_URL: "https://github.com/Artificial-Pancreas/iAPS.git"
+  WORKFLOW_TOKEN: ${{ secrets.GH_PAT }}
+  UPSTREAM_BRANCH: "dev"
+  # Optional fetch arguments
+  FETCH_ARGS: ""
+  # Optional merge arguments
+  MERGE_ARGS: ""
+  # Optional push arguments
+  PUSH_ARGS: ""
+  # Optional toggle to spawn time logs (keeps action active)
+  SPAWN_LOGS: "false" # "true" or "false"
+
+on: 
+
+  schedule:
+    - cron: '0 * * * *'             # scheduled to run hourly
+
+  workflow_dispatch:                # trigger manually
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: GitHub Sync to Upstream Repository
+        uses: dabreadman/sync-upstream-repo@v1.3.0
+        with:
+          upstream_repo: ${{ env.UPSTREAM_URL }}
+          upstream_branch: ${{ env.UPSTREAM_BRANCH }}
+          downstream_branch: ${{ env.DOWNSTREAM_BRANCH }}
+          token: ${{ env.WORKFLOW_TOKEN }}
+          fetch_args: ${{ env.FETCH_ARGS }}
+          merge_args: ${{ env.MERGE_ARGS }}
+          push_args: ${{ env.PUSH_ARGS }}
+          spawn_logs: ${{ env.SPAWN_LOGS }}

--- a/.github/workflows/syncUpstreamRepo.yml
+++ b/.github/workflows/syncUpstreamRepo.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: GitHub Sync to Upstream Repository
-        uses: dabreadman/sync-upstream-repo@v1.3.0
+        uses: Artificial-Pancreas/sync-upstream-repo
         with:
           upstream_repo: ${{ env.UPSTREAM_URL }}
           upstream_branch: ${{ env.UPSTREAM_BRANCH }}

--- a/fastlane/docs/github.md
+++ b/fastlane/docs/github.md
@@ -1,0 +1,44 @@
+## Setup Github iAPS repository
+
+### Generate Personal Access Token
+
+>    If you have previously created a Personal Access Token ( PAT ), you can re-use it,
+>    and skip this step.
+>
+>    **NOTE:** GitHub doesn't provide a means to view a previously created token, it only 
+>    allows you to regenerate it.  Regenerating the token invalidates the old one, so
+>    if you already have one in use and do not know what it is, create a new one.
+>
+>    * Enter a name for your token. Something like "FastLane Access Token".
+>    * The default Expiration time is 30 days - but you should select `No Expiration`
+>    * Select the `repo` permission scope.
+>    * Click "Generate token".
+>    * Copy the token and record it. It will be used below as `GH_PAT`.
+
+### Fork iAPS Repository
+
+>   **NOTE:** If you already have a fork of iAPS in GitHub, you can't make another one. You can continue to work with your existing fork, or delete that from GitHub and fork a new >   copy.
+>
+>   1. Fork https://github.com/Artificial-Pancreas/iAPS into your account.
+>   2. In the forked iAPS repo, go to Settings -> Secrets and Variables -> Actions
+>   3. For each of the following secrets, tap on "New repository secret", then add the name of the secret, along with the value you recorded for it:
+>      * `TEAMID`
+>      * `FASTLANE_KEY_ID`
+>      * `FASTLANE_ISSUER_ID`
+>      * `FASTLANE_KEY`
+>      * `GH_PAT`
+>      * `MATCH_PASSWORD` - just make up a password for this
+>     
+
+### Keep Fork Up to Date
+
+>   1. Click on the "Actions" tab of your iAPS repository.
+>   2. Select "5. Sync Upstream".
+>   3. Click "Run Workflow", Select Branch to Maintain, and tap the green button.
+>
+>   Although most people will only need to sync one branch, the above can be repeated
+>   on any branch where these workflows are available.
+>
+>   Currently the Action is scheduled to run at midnight daily, but can be manually
+>   triggered at any time.
+

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -35,23 +35,8 @@ This is also a common step for all "browser builds", do this step only once
 1. Create a [new empty repository](https://github.com/new) titled `Match-Secrets`. It should be private.
 
 ## Setup Github iAPS repository
-1. Fork https://github.com/Artificial-Pancreas/iAPS into your account. If you already have a fork of iAPS in GitHub, you can't make another one. You can continue to work with your existing fork, or delete that from GitHub and then and fork https://github.com/Artificial-Pancreas/iAPS.
 
-If you have previously built Loop or another app using the "browser build" method, you can can re-use your previous personal access token (`GH_PAT`) and skip ahead to `step 2`.
-1. Create a [new personal access token](https://github.com/settings/tokens/new):
-    * Enter a name for your token. Something like "FastLane Access Token".
-    * The default Expiration time is 30 days - but you should select `No Expiration`
-    * Select the `repo` permission scope.
-    * Click "Generate token".
-    * Copy the token and record it. It will be used below as `GH_PAT`.
-1. In the forked iAPS repo, go to Settings -> Secrets -> Actions.
-1. For each of the following secrets, tap on "New repository secret", then add the name of the secret, along with the value you recorded for it:
-    * `TEAMID`
-    * `FASTLANE_KEY_ID`
-    * `FASTLANE_ISSUER_ID`
-    * `FASTLANE_KEY`
-    * `GH_PAT`
-    * `MATCH_PASSWORD` - just make up a password for this
+>    [Click here](docs/github.md)
 
 ## Validate repository secrets
 


### PR DESCRIPTION
Once tested, I will extend the docs to add a section to enable.

Its essentially the same instructions as build_iAPS, but until this is in dev, the code is hard coded so that it can run out a separate default branch for testing.

Once tested and in dev, I will change the references to dev to be ${{ github.ref_name }}, and add docs.

Basically, I don't want to advertise until we've confirmed it, *but*, it has to be in dev for us to properly test it ...

sort of a chicken and egg situation.