### PR TITLE
Allow setting Bundle Id

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -18,12 +18,6 @@ env:
   ALIVE_BRANCH: alive
 
 jobs:
-  set_env_variables:
-    name: Sets env vars for release
-    run: |
-      echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
-    if: vars.APP_IDENTIFIER != NULL
-
   validate:
     name: Validate
     uses: ./.github/workflows/validate_secrets.yml
@@ -141,6 +135,11 @@ jobs:
           (vars.SCHEDULED_SYNC == 'true' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
         )
     steps:
+      - name: Set special variables
+        run: |
+          echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+        if: vars.APP_IDENTIFIER != NULL
+
       - name: Select Xcode version
         run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
       

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -16,6 +16,7 @@ env:
   UPSTREAM_BRANCH: ${{ github.ref_name }} # branch on upstream repository to sync from (replace with specific branch name if needed)
   TARGET_BRANCH: ${{ github.ref_name }} # target branch on fork to be kept in sync, and target branch on upstream to be kept alive (replace with specific branch name if needed)
   ALIVE_BRANCH: alive
+  APP_IDENTIFIER: ${{ vars.APP_IDENTIFIER }}
 
 jobs:
   validate:

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -16,9 +16,14 @@ env:
   UPSTREAM_BRANCH: ${{ github.ref_name }} # branch on upstream repository to sync from (replace with specific branch name if needed)
   TARGET_BRANCH: ${{ github.ref_name }} # target branch on fork to be kept in sync, and target branch on upstream to be kept alive (replace with specific branch name if needed)
   ALIVE_BRANCH: alive
-  APP_IDENTIFIER: ${{ vars.APP_IDENTIFIER }}
 
 jobs:
+  set_env_variables:
+    name: Sets env vars for release
+    run: |
+      echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+    if: vars.APP_IDENTIFIER != NULL
+
   validate:
     name: Validate
     uses: ./.github/workflows/validate_secrets.yml

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -137,8 +137,9 @@ jobs:
     steps:
       - name: Set special variables
         run: |
-          echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
-        if: vars.APP_IDENTIFIER != NULL
+          if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
+            echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+          fi
 
       - name: Select Xcode version
         run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-if (defined?(ENV["APP_IDENTIFIER"])).nil? || ENV["APP_IDENTIFIER"] == '' # will now return true or false
+if (defined?(ENV["APP_IDENTIFIER"])).nil? || (ENV["APP_IDENTIFIER"]).length == 0 # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,7 @@ ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 APP_IDENTIFIER = ENV.fetch('APP_IDENTIFIER') { "ru.artpancreas.#{TEAMID}.FreeAPS" }
 
 if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
-  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
+  File.write('../ConfigOverride.xcconfig', "BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}", mode: 'a')
 end
 printf "APP_IDENTIFIER => [%s]\n\n", "#{APP_IDENTIFIER}"
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,8 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-if (defined?(ENV["APP_IDENTIFIER"])).nil? || (ENV["APP_IDENTIFIER"]).length == 0 # will now return true or false
+#if (defined?(ENV["APP_IDENTIFIER"])).nil? || (ENV["APP_IDENTIFIER"]).length == 0 # will now return true or false
+if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,13 +23,15 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
-  APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
-else
-  printf "\nAPP_IDENTIFIER(env) => [%s] [%d]\n\n", ENV["APP_IDENTIFIER"], ENV["APP_IDENTIFIER"].length
-  APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
-  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
-end
+APP_IDENTIFIER = ENV.fetch('APP_IDENTIFIER') { "ru.artpancreas.#{TEAMID}.FreeAPS" }
+
+#if ENV["APP_IDENTIFIER"].nil? # will now return true or false
+#  APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
+#else
+#  printf "\nAPP_IDENTIFIER(env) => [%s] [%d]\n\n", ENV["APP_IDENTIFIER"], ENV["APP_IDENTIFIER"].length
+#  APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
+#  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
+#end
 printf "APP_IDENTIFIER => [%s]\n\n", "#{APP_IDENTIFIER}"
     
 platform :ios do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,7 +30,7 @@ platform :ios do
     setup_ci if ENV['CI']
 
     puts "[#{APP_IDENTIFIER}]"
-    if !defined?(ENV["APP_IDENTIFIER"]).nil? # will now return true or false
+    if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
       APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
       File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-if ( ENV["APP_IDENTIFIER"].length == 0 # will now return true or false
+if ENV["APP_IDENTIFIER"].length == 0 # will now return true or false
 #if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,7 +22,6 @@ FASTLANE_KEY = ENV["FASTLANE_KEY"]
 DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
-APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 
 platform :ios do
   desc "Build iAPS"
@@ -31,6 +30,8 @@ platform :ios do
 
     puts "[#{APP_IDENTIFIER}]"
     if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+      APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
+    else
       APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
       File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,7 @@ platform :ios do
   lane :build_iAPS do
     setup_ci if ENV['CI']
 
-    if !defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+    if !defined?(ENV["APP_IDENTIFIER"]).nil? # will now return true or false
       APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
       File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,13 +25,9 @@ ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
 APP_IDENTIFIER = ENV.fetch('APP_IDENTIFIER') { "ru.artpancreas.#{TEAMID}.FreeAPS" }
 
-#if ENV["APP_IDENTIFIER"].nil? # will now return true or false
-#  APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
-#else
-#  printf "\nAPP_IDENTIFIER(env) => [%s] [%d]\n\n", ENV["APP_IDENTIFIER"], ENV["APP_IDENTIFIER"].length
-#  APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
-#  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
-#end
+if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
+  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
+end
 printf "APP_IDENTIFIER => [%s]\n\n", "#{APP_IDENTIFIER}"
     
 platform :ios do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,16 +23,13 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-before_all do
-  puts "[#{APP_IDENTIFIER}]"
-  if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
-    APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
-  else
-    APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
-    File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
-  end
-  puts "[#{APP_IDENTIFIER}]"
+if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+  APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
+else
+  APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
+  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
 end
+puts "[#{APP_IDENTIFIER}]"
     
 platform :ios do
   desc "Build iAPS"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,14 +23,14 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-if ENV["APP_IDENTIFIER"].length == 0 # will now return true or false
-#if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else
+  printf "APP_IDENTIFIER(env) => [%s]", ENV["APP_IDENTIFIER"]
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
   File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
 end
-puts "[#{APP_IDENTIFIER}]"
+printf "APP_IDENTIFIER => [%s]", #{APP_IDENTIFIER}
     
 platform :ios do
   desc "Build iAPS"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,7 +23,7 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+if (defined?(ENV["APP_IDENTIFIER"])).nil? || ENV["APP_IDENTIFIER"] == '' # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,7 +30,7 @@ else
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
   File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
 end
-printf "APP_IDENTIFIER => [%s]", #{APP_IDENTIFIER}
+printf "APP_IDENTIFIER => [%s]", "#{APP_IDENTIFIER}"
     
 platform :ios do
   desc "Build iAPS"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,11 @@ platform :ios do
   desc "Build iAPS"
   lane :build_iAPS do
     setup_ci if ENV['CI']
+
+    if !defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+      APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
+      File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
+    end
     
     update_project_team(
       path: "#{GITHUB_WORKSPACE}/FreeAPS.xcodeproj",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,10 +29,12 @@ platform :ios do
   lane :build_iAPS do
     setup_ci if ENV['CI']
 
+    puts "[#{APP_IDENTIFIER}]"
     if !defined?(ENV["APP_IDENTIFIER"]).nil? # will now return true or false
       APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
       File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
     end
+    puts "[#{APP_IDENTIFIER}]"
     
     update_project_team(
       path: "#{GITHUB_WORKSPACE}/FreeAPS.xcodeproj",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,14 +23,16 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-puts "[#{APP_IDENTIFIER}]"
-if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
-  APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
-else
-  APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
-  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
+before_all do
+  puts "[#{APP_IDENTIFIER}]"
+  if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+    APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
+  else
+    APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
+    File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
+  end
+  puts "[#{APP_IDENTIFIER}]"
 end
-puts "[#{APP_IDENTIFIER}]"
     
 platform :ios do
   desc "Build iAPS"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,20 +23,20 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
+puts "[#{APP_IDENTIFIER}]"
+if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+  APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
+else
+  APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
+  File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
+end
+puts "[#{APP_IDENTIFIER}]"
+    
 platform :ios do
   desc "Build iAPS"
   lane :build_iAPS do
     setup_ci if ENV['CI']
 
-    puts "[#{APP_IDENTIFIER}]"
-    if !(defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
-      APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
-    else
-      APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
-      File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
-    end
-    puts "[#{APP_IDENTIFIER}]"
-    
     update_project_team(
       path: "#{GITHUB_WORKSPACE}/FreeAPS.xcodeproj",
       teamid: "#{TEAMID}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,11 +26,11 @@ ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else
-  printf "APP_IDENTIFIER(env) => [%s]", ENV["APP_IDENTIFIER"]
+  printf "\nAPP_IDENTIFIER(env) => [%s] [%d]\n\n", ENV["APP_IDENTIFIER"], ENV["APP_IDENTIFIER"].length
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]
   File.write('../ConfigOverride.xcconfig', 'BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}', mode: 'a')
 end
-printf "APP_IDENTIFIER => [%s]", "#{APP_IDENTIFIER}"
+printf "APP_IDENTIFIER => [%s]\n\n", "#{APP_IDENTIFIER}"
     
 platform :ios do
   desc "Build iAPS"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,8 +23,8 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-#if (defined?(ENV["APP_IDENTIFIER"])).nil? || (ENV["APP_IDENTIFIER"]).length == 0 # will now return true or false
-if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
+if ( ENV["APP_IDENTIFIER"].length == 0 # will now return true or false
+#if (defined?(ENV["APP_IDENTIFIER"])).nil? # will now return true or false
   APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
 else
   APP_IDENTIFIER = ENV["APP_IDENTIFIER"]


### PR DESCRIPTION
Tested with both APP_IDENTIFIER set and not set

To test, go into Settings -> Secrets and Variables -> Actions -> Variables tab -> New Repository Variable

Name: APP_IDENTIFIER
Value: <whatever>

The code creates an appropriate ConfigOverride.xcconfig file in the work directory for the build 

This code can easily be extended for anything else that would be useful to be in that file