### PR TITLE
Allow for non-default Bundle ID

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -135,6 +135,12 @@ jobs:
           (vars.SCHEDULED_SYNC == 'true' && needs.check_latest_from_upstream.outputs.NEW_COMMITS == 'true' )
         )
     steps:
+      - name: Set special variables
+        run: |
+          if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
+            echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+          fi
+
       - name: Select Xcode version
         run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
       

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -22,13 +22,18 @@ FASTLANE_KEY = ENV["FASTLANE_KEY"]
 DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
-APP_IDENTIFIER = "ru.artpancreas.#{TEAMID}.FreeAPS"
+
+APP_IDENTIFIER = ENV.fetch('APP_IDENTIFIER') { "ru.artpancreas.#{TEAMID}.FreeAPS" }
+
+if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
+  File.write('../ConfigOverride.xcconfig', "BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}", mode: 'a')
+end
 
 platform :ios do
   desc "Build iAPS"
   lane :build_iAPS do
     setup_ci if ENV['CI']
-    
+
     update_project_team(
       path: "#{GITHUB_WORKSPACE}/FreeAPS.xcodeproj",
       teamid: "#{TEAMID}"


### PR DESCRIPTION
Tested with both APP_IDENTIFIER set and not set

To test, go into Settings -> Secrets and Variables -> Actions -> Variables tab -> New Repository Variable

Name: APP_IDENTIFIER
Value: new bundle id

The code creates an appropriate ConfigOverride.xcconfig file in the work directory for the build

This code can easily be extended for anything else that would be useful to be in that file