### PR TITLE
More loop statistics.

### DIFF
--- a/Core_Data.xcdatamodeld/Core_Data.xcdatamodel/contents
+++ b/Core_Data.xcdatamodeld/Core_Data.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="ActiveProfile" representedClassName="ActiveProfile" syncable="YES" codeGenerationType="class">
         <attribute name="active" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -57,6 +57,7 @@
     <entity name="LoopStatRecord" representedClassName="LoopStatRecord" syncable="YES" codeGenerationType="class">
         <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="end" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="error" optional="YES" attributeType="String"/>
         <attribute name="interval" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="loopStatus" optional="YES" attributeType="String"/>
         <attribute name="start" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -292,7 +292,7 @@ final class BaseAPSManager: APSManager, Injectable {
             lastError.send(nil)
         }
 
-        loopStats(loopStatRecord: loopStatRecord)
+        loopStats(loopStatRecord: loopStatRecord, error: error)
 
         if settings.closedLoop {
             reportEnacted(received: error == nil)
@@ -1304,7 +1304,7 @@ final class BaseAPSManager: APSManager, Injectable {
         return branch
     }
 
-    private func loopStats(loopStatRecord: LoopStats) {
+    private func loopStats(loopStatRecord: LoopStats, error: Error?) {
         coredataContext.perform {
             let nLS = LoopStatRecord(context: self.coredataContext)
 
@@ -1313,6 +1313,10 @@ final class BaseAPSManager: APSManager, Injectable {
             nLS.loopStatus = loopStatRecord.loopStatus
             nLS.duration = loopStatRecord.duration ?? 0.0
             nLS.interval = loopStatRecord.interval ?? 0.0
+
+            if let error = error {
+                nLS.error = error.localizedDescription.string
+            }
 
             try? self.coredataContext.save()
         }

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -1881,10 +1881,10 @@ Enact a temp Basal or a temp target */
 "Errors" = "Errors";
 
 /* Loop Statistics pop-up description */
-"Success = Started / Completed (Loops)" = "Success = Started / Completed (Loops)";
+"Success = Started / Completed (loops)" = "Success = Started / Completed (loops)";
 
 /* Loop Statistics pop-up */
-"Most Frequent Error:" = "Most Frequent Error:";
+"Most Frequent Error" = "Most Frequent Error";
 
 /* Loop Statistics pop-up */
 "Non-completed Loops" = "Non-completed Loops";

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -1880,6 +1880,15 @@ Enact a temp Basal or a temp target */
 /* Loop Errors in statPanel */
 "Errors" = "Errors";
 
+/* Loop Statistics pop-up description */
+"Success = Started / Completed (Loops)" = "Success = Started / Completed (Loops)";
+
+/* Loop Statistics pop-up */
+"Most Frequent Error:" = "Most Frequent Error:";
+
+/* Loop Statistics pop-up */
+"Non-completed Loops" = "Non-completed Loops";
+
 /* Average loop interval */
 "Interval" = "Interval";
 

--- a/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
@@ -1878,10 +1878,10 @@ Enact a temp Basal or a temp target */
 "Errors" = "Fel";
 
 /* Loop Statistics pop-up description */
-"Success = Started / Completed (Loops)" = "Lyckades = Påbörjade / Avslutade (loopar)";
+"Success = Started / Completed (loops)" = "Lyckades = Påbörjade / Avslutade (loopar)";
 
 /* Loop Statistics pop-up */
-"Most Frequent Error:" = "Vanligaste fel:";
+"Most Frequent Error" = "Vanligaste fel";
 
 /* Loop Statistics pop-up */
 "Non-completed Loops" = "ej avslutade loopar";

--- a/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/sv.lproj/Localizable.strings
@@ -1877,6 +1877,15 @@ Enact a temp Basal or a temp target */
 /* Loop Errors in statPanel */
 "Errors" = "Fel";
 
+/* Loop Statistics pop-up description */
+"Success = Started / Completed (Loops)" = "Lyckades = Påbörjade / Avslutade (loopar)";
+
+/* Loop Statistics pop-up */
+"Most Frequent Error:" = "Vanligaste fel:";
+
+/* Loop Statistics pop-up */
+"Non-completed Loops" = "ej avslutade loopar";
+
 /* Average loop interval */
 "Interval" = "Intervall";
 

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -16,6 +16,9 @@ extension Home {
         @State var triggerUpdate = false
         @State var display = false
         @State var displayGlucose = false
+        @State var animateLoop = Date.distantPast
+        @State var animateTIR = Date.distantPast
+
         let buttonFont = Font.custom("TimeButtonFont", size: 14)
         let viewPadding: CGFloat = 5
 
@@ -478,8 +481,15 @@ extension Home {
                 .clipShape(RoundedRectangle(cornerRadius: 15))
                 .addShadows()
                 .padding(.horizontal, 10)
+                .blur(radius: animateTIRView ? 2 : 0)
                 .onTapGesture {
+                    timeIsNowTIR()
                     state.showModal(for: .statistics)
+                }
+                .overlay {
+                    if animateTIRView {
+                        animation.asAny()
+                    }
                 }
         }
 
@@ -536,8 +546,15 @@ extension Home {
                 .clipShape(RoundedRectangle(cornerRadius: 15))
                 .addShadows()
                 .padding(.horizontal, 10)
+                .blur(radius: animateLoopView ? 2.5 : 0)
                 .onTapGesture {
+                    timeIsNowLoop()
                     state.showModal(for: .statistics)
+                }
+                .overlay {
+                    if animateLoopView {
+                        animation.asAny()
+                    }
                 }
         }
 
@@ -700,6 +717,26 @@ extension Home {
             .font(.timeSettingFont)
             .padding(.vertical, 15)
             .background(TimeEllipse(characters: string.count))
+        }
+
+        private var animateLoopView: Bool {
+            -1 * animateLoop.timeIntervalSinceNow < 1.5
+        }
+
+        private var animateTIRView: Bool {
+            -1 * animateTIR.timeIntervalSinceNow < 1.5
+        }
+
+        private func timeIsNowLoop() {
+            animateLoop = Date.now
+        }
+
+        private func timeIsNowTIR() {
+            animateTIR = Date.now
+        }
+
+        private var animation: any View {
+            ActivityIndicator(isAnimating: .constant(true), style: .large)
         }
 
         var body: some View {

--- a/FreeAPS/Sources/Modules/Stat/View/StatRootView.swift
+++ b/FreeAPS/Sources/Modules/Stat/View/StatRootView.swift
@@ -146,7 +146,7 @@ extension Stat {
                 .pickerStyle(.segmented).background(.cyan.opacity(0.2))
                 stats()
             }
-            .dynamicTypeSize(...DynamicTypeSize.xxLarge)
+            .dynamicTypeSize(...DynamicTypeSize.xLarge)
             .onAppear(perform: configureView)
             .navigationBarTitle("Statistics")
             .navigationBarTitleDisplayMode(.inline)

--- a/FreeAPS/Sources/Modules/Stat/View/StatsView.swift
+++ b/FreeAPS/Sources/Modules/Stat/View/StatsView.swift
@@ -144,27 +144,31 @@ struct StatsView: View {
                     let mostFrequentCount = errors.filter({ $0 == mostFrequent }).count
                     RoundedRectangle(cornerRadius: 6)
                         .fill(Color(.systemGray2))
-                        .frame(width: 380, height: 250)
+                        .frame(width: 380, height: 200)
                         .shadow(radius: 5)
                         .overlay {
-                            VStack(alignment: .leading) {
-                                Text("Success = Started / Completed (Loops)")
+                            ZStack {
+                                Text("Success = Started / Completed (loops)")
                                     .padding(.horizontal, 5)
-                                    .padding(.top, 5)
-                                    .padding(.bottom, 3)
+                                    .padding(.top, 20)
                                     .foregroundStyle(.secondary)
-                                HStack {
-                                    Text("\(nonCompleted)").bold()
-                                    Text("Non-completed Loops")
-                                }
-                                .padding(.horizontal, 5).padding(.bottom, 10)
-                                Text("Most Frequent Error (\(mostFrequentCount)):")
-                                    .padding(.horizontal, 5)
+                                    .frame(maxHeight: .infinity, alignment: .top)
+                                VStack {
+                                    Text(
+                                        NSLocalizedString("Most Frequent Error", comment: "Loop Statistics pop-up") +
+                                            " (\(mostFrequentCount) " +
+                                            NSLocalizedString("of", comment: "") +
+                                            " \(nonCompleted)):"
+                                    )
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                                     .padding(.vertical, 3)
                                     .bold()
-                                Text(mostFrequent)
-                                    .padding(.horizontal, 5)
-                                    .padding(.bottom, 5)
+                                    Text(mostFrequent)
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+                                .frame(maxHeight: .infinity, alignment: .bottom)
+                                .padding(.horizontal, 20)
+                                .padding(.bottom, 20)
                             }
                         }
                 }

--- a/FreeAPS/Sources/Modules/Stat/View/StatsView.swift
+++ b/FreeAPS/Sources/Modules/Stat/View/StatsView.swift
@@ -155,7 +155,7 @@ struct StatsView: View {
                                     Text("\(nonCompleted)").bold()
                                     Text("Non-completed Loops")
                                 }
-                                .padding(.horizontal, 8).padding(.bottom, 10)
+                                .padding(.horizontal, 5).padding(.bottom, 10)
                                 Text("Most Frequent Error:")
                                     .padding(.horizontal, 5)
                                     .padding(.vertical, 3)

--- a/FreeAPS/Sources/Modules/Stat/View/StatsView.swift
+++ b/FreeAPS/Sources/Modules/Stat/View/StatsView.swift
@@ -141,6 +141,7 @@ struct StatsView: View {
                 let errors = fetchRequest.compactMap(\.error)
                 if errors.isNotEmpty {
                     let mostFrequent = errors.mostFrequent()?.description ?? ""
+                    let mostFrequentCount = errors.filter({ $0 == mostFrequent }).count
                     RoundedRectangle(cornerRadius: 6)
                         .fill(Color(.systemGray2))
                         .frame(width: 380, height: 250)
@@ -151,12 +152,13 @@ struct StatsView: View {
                                     .padding(.horizontal, 5)
                                     .padding(.top, 5)
                                     .padding(.bottom, 3)
+                                    .foregroundStyle(.secondary)
                                 HStack {
                                     Text("\(nonCompleted)").bold()
                                     Text("Non-completed Loops")
                                 }
                                 .padding(.horizontal, 5).padding(.bottom, 10)
-                                Text("Most Frequent Error:")
+                                Text("Most Frequent Error (\(mostFrequentCount)):")
                                     .padding(.horizontal, 5)
                                     .padding(.vertical, 3)
                                     .bold()


### PR DESCRIPTION
Add description pop-up of success rate in statistics View. 
Display number of errors and most frequent cause of loop error in pop-up. 
Display the count of the most frequent loop error.
Save errors with CoreData.
Add localization (new strings to translate).
Animate the LoopsView and the PreviewChart (TIR) while opening the full statistics View.