### PR TITLE
Add ONE+ to the display name

### DIFF
--- a/Dependencies/CGMBLEKit/CGMBLEKitG6Plugin/Info.plist
+++ b/Dependencies/CGMBLEKit/CGMBLEKitG6Plugin/Info.plist
@@ -23,7 +23,7 @@
 	<key>NSPrincipalClass</key>
 	<string>CGMBLEKitG6Plugin</string>
 	<key>com.loopkit.Loop.CGMManagerDisplayName</key>
-	<string>Dexcom G6</string>
+	<string>Dexcom G6 & ONE</string>
 	<key>com.loopkit.Loop.CGMManagerIdentifier</key>
 	<string>DexG6Transmitter</string>
 </dict>

--- a/Dependencies/G7SensorKit/G7SensorPlugin/Info.plist
+++ b/Dependencies/G7SensorKit/G7SensorPlugin/Info.plist
@@ -23,7 +23,7 @@
 	<key>NSPrincipalClass</key>
 	<string>G7SensorPlugin</string>
 	<key>com.loopkit.Loop.CGMManagerDisplayName</key>
-	<string>Dexcom G7 + ONE+</string>
+	<string>Dexcom G7 & ONE+</string>
 	<key>com.loopkit.Loop.CGMManagerIdentifier</key>
 	<string>G7CGMManager</string>
 </dict>

--- a/Dependencies/G7SensorKit/G7SensorPlugin/Info.plist
+++ b/Dependencies/G7SensorKit/G7SensorPlugin/Info.plist
@@ -23,7 +23,7 @@
 	<key>NSPrincipalClass</key>
 	<string>G7SensorPlugin</string>
 	<key>com.loopkit.Loop.CGMManagerDisplayName</key>
-	<string>Dexcom G7</string>
+	<string>Dexcom G7 + ONE+</string>
 	<key>com.loopkit.Loop.CGMManagerIdentifier</key>
 	<string>G7CGMManager</string>
 </dict>


### PR DESCRIPTION
This PR simply updates the name of Dexcom G7 to "Dexcom G7 + ONE+" in the CGM selection menu, making it clearer for Dexcom ONE+ users to identify the correct option.