### PR TITLE
DecimalTextField - only save when the user is done editing

### DIFF
--- a/FreeAPS/Sources/Models/BloodGlucose.swift
+++ b/FreeAPS/Sources/Models/BloodGlucose.swift
@@ -137,8 +137,11 @@ extension Decimal {
         self / GlucoseUnits.exchangeRate
     }
 
-    var rounded: Decimal {
-        Decimal(round(Double(self)))
+    func rounded(to scale: Int, roundingMode: NSDecimalNumber.RoundingMode = .bankers) -> Decimal {
+        var result = Decimal()
+        var localCopy = self
+        NSDecimalRound(&result, &localCopy, scale, roundingMode)
+        return result
     }
 }
 

--- a/FreeAPS/Sources/Views/BGTextField.swift
+++ b/FreeAPS/Sources/Views/BGTextField.swift
@@ -21,7 +21,6 @@ struct BGTextField: View {
     private var mmolLFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.decimalSeparator = "."
         formatter.maximumFractionDigits = 1
         return formatter
     }
@@ -30,7 +29,6 @@ struct BGTextField: View {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.maximumFractionDigits = 0
-        formatter.decimalSeparator = "."
         return formatter
     }
 

--- a/FreeAPS/Sources/Views/BGTextField.swift
+++ b/FreeAPS/Sources/Views/BGTextField.swift
@@ -21,7 +21,7 @@ struct BGTextField: View {
     private var mmolLFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.minimumFractionDigits = 1
+        formatter.decimalSeparator = "."
         formatter.maximumFractionDigits = 1
         return formatter
     }
@@ -30,13 +30,14 @@ struct BGTextField: View {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
         formatter.maximumFractionDigits = 0
+        formatter.decimalSeparator = "."
         return formatter
     }
 
     private var displayValue: Binding<Decimal> {
         Binding(
             get: { units == .mmolL ? mgdlValue.asMmolL : mgdlValue },
-            set: { newValue in mgdlValue = units == .mmolL ? newValue.asMgdL : newValue }
+            set: { newValue in mgdlValue = units == .mmolL ? newValue.rounded(to: 1).asMgdL : newValue.rounded(to: 0) }
         )
     }
 

--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -180,7 +180,7 @@ extension DecimalTextField.Coordinator: UITextFieldDelegate {
         if let text = textField.text {
             let newText = (text as NSString).replacingCharacters(in: range, with: string)
 
-            let decimalSeparatorCount = newText.count(where: { $0 == parent.formatter.decimalSeparator.first })
+            let decimalSeparatorCount = newText.count(where: { $0 == (parent.formatter.decimalSeparator.first ?? ".") })
             if decimalSeparatorCount > 1 {
                 return false
             }

--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -177,18 +177,12 @@ extension DecimalTextField.Coordinator: UITextFieldDelegate {
         let isAllowed = allowedCharacters.isSuperset(of: CharacterSet(charactersIn: string))
         if !isAllowed { return false }
 
-        // enforce the decimal separator to match the formatter
-        let adjustedString = string
-            .replacingOccurrences(of: ".", with: parent.formatter.decimalSeparator)
-            .replacingOccurrences(of: ",", with: parent.formatter.decimalSeparator)
+        if let text = textField.text {
+            let newText = (text as NSString).replacingCharacters(in: range, with: string)
 
-        if let text = textField.text, text != adjustedString {
-            let newText = (text as NSString).replacingCharacters(in: range, with: adjustedString)
-
-            // Check if there's more than one occurrence of the decimal separator
             let decimalSeparatorCount = newText.count(where: { $0 == parent.formatter.decimalSeparator.first })
             if decimalSeparatorCount > 1 {
-                return false // Reject input if more than one decimal separator is found
+                return false
             }
 
             textField.text = newText

--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -180,7 +180,7 @@ extension DecimalTextField.Coordinator: UITextFieldDelegate {
         if let text = textField.text {
             let newText = (text as NSString).replacingCharacters(in: range, with: string)
 
-            let decimalSeparatorCount = newText.count(where: { $0 == (parent.formatter.decimalSeparator.first ?? ".") })
+            let decimalSeparatorCount = newText.filter({ $0 == (parent.formatter.decimalSeparator.first ?? ".") }).count
             if decimalSeparatorCount > 1 {
                 return false
             }


### PR DESCRIPTION
This changes the way `DecimalTextField` functions:

* it doesn't save the value until the user is done editing (navigate away, switch to other input/control, tap the "Done" button in the toolbar, etc)
* it doesn't mess with what the user is typing (no reformatting, etc)
* it only allows the user to input digits, and at most one decimal separator
* if the final value is not a valid decimal - it will not be saved and the input will reset to the initial value 

Also added the "Cancel" button to the toolbar - it will reset the value to the initial and stop editing.

Should resolve all the issues reported in Discord. Also should improve editing performance - no more lag caused by constant saving into storage.

