### PR TITLE
fix for carbs text field showing 0 after selecting a saved meal

### DIFF
--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -96,7 +96,8 @@ public struct DecimalTextField: UIViewRepresentable {
     }
 
     public func updateUIView(_ textField: UITextField, context: Context) {
-        if !context.coordinator.isEditing {
+        if !context.coordinator.isEditing || context.coordinator.previousSeenValue != value {
+            context.coordinator.previousSeenValue = value
             let newText = valueAsText()
             if textField.text != newText {
                 textField.text = newText
@@ -128,6 +129,7 @@ public struct DecimalTextField: UIViewRepresentable {
         var didBecomeFirstResponder = false
         let decimalFormatter: NumberFormatter
         var isEditing: Bool = false
+        var previousSeenValue: Decimal = 0
 
         init(_ parent: DecimalTextField, maxLength: Int?) {
             self.parent = parent


### PR DESCRIPTION
If the value changes outside of the decimal text field, `textField.text` will get replaced with the new value **even when the user is editing** .