### PR TITLE
live editing in all profile override fields

### DIFF
--- a/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
+++ b/FreeAPS/Sources/Modules/OverrideProfilesConfig/View/OverrideProfilesRootView.swift
@@ -126,7 +126,7 @@ extension OverrideProfilesConfig {
                     if !state._indefinite {
                         HStack {
                             Text("Duration")
-                            DecimalTextField("0", value: $state.duration, formatter: formatter)
+                            DecimalTextField("0", value: $state.duration, formatter: formatter, liveEditing: true)
                             Text("minutes").foregroundColor(.secondary)
                         }
                     }
@@ -142,7 +142,7 @@ extension OverrideProfilesConfig {
                     if state.override_target {
                         HStack {
                             Text("Target Glucose")
-                            DecimalTextField("0", value: $state.target, formatter: glucoseFormatter)
+                            DecimalTextField("0", value: $state.target, formatter: glucoseFormatter, liveEditing: true)
                             Text(state.units.rawValue).foregroundColor(.secondary)
                         }
                     }
@@ -170,12 +170,12 @@ extension OverrideProfilesConfig {
                         if state.smbIsAlwaysOff {
                             HStack {
                                 Text("First Hour SMBs are Off (24 hours)")
-                                DecimalTextField("0", value: $state.start, formatter: formatter)
+                                DecimalTextField("0", value: $state.start, formatter: formatter, liveEditing: true)
                                 Text("hour").foregroundColor(.secondary)
                             }
                             HStack {
                                 Text("Last Hour SMBs are Off (24 hours)")
-                                DecimalTextField("0", value: $state.end, formatter: formatter)
+                                DecimalTextField("0", value: $state.end, formatter: formatter, liveEditing: true)
                                 Text("hour").foregroundColor(.secondary)
                             }
                         }
@@ -201,7 +201,8 @@ extension OverrideProfilesConfig {
                             DecimalTextField(
                                 "0",
                                 value: $state.smbMinutes,
-                                formatter: formatter
+                                formatter: formatter,
+                                liveEditing: true
                             )
                             Text("minutes").foregroundColor(.secondary)
                         }
@@ -210,7 +211,8 @@ extension OverrideProfilesConfig {
                             DecimalTextField(
                                 "0",
                                 value: $state.uamMinutes,
-                                formatter: formatter
+                                formatter: formatter,
+                                liveEditing: true
                             )
                             Text("minutes").foregroundColor(.secondary)
                         }
@@ -227,7 +229,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.maxIOB,
-                                    formatter: insulinFormatter
+                                    formatter: insulinFormatter,
+                                    liveEditing: true
                                 )
                                 Text("U").foregroundColor(.secondary)
                             }
@@ -256,7 +259,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.autoisf_min,
-                                    formatter: insulinFormatter
+                                    formatter: insulinFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -265,7 +269,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.autoisf_max,
-                                    formatter: insulinFormatter
+                                    formatter: insulinFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -274,7 +279,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.smbDeliveryRatioMin,
-                                    formatter: insulinFormatter
+                                    formatter: insulinFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -283,7 +289,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.smbDeliveryRatioMax,
-                                    formatter: insulinFormatter
+                                    formatter: insulinFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -293,7 +300,8 @@ extension OverrideProfilesConfig {
                                     "0",
                                     mgdlValue: $state.autoISFsettings.smbDeliveryRatioBGrange,
                                     units: $state.units,
-                                    isDisabled: false
+                                    isDisabled: false,
+                                    liveEditing: true
                                 )
                             }
 
@@ -302,7 +310,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.autoISFhourlyChange,
-                                    formatter: insulinFormatter
+                                    formatter: insulinFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -311,7 +320,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.higherISFrangeWeight,
-                                    formatter: higherPrecisionFormatter
+                                    formatter: higherPrecisionFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -320,7 +330,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.lowerISFrangeWeight,
-                                    formatter: higherPrecisionFormatter
+                                    formatter: higherPrecisionFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -329,7 +340,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.postMealISFweight,
-                                    formatter: higherPrecisionFormatter
+                                    formatter: higherPrecisionFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -338,7 +350,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.bgAccelISFweight,
-                                    formatter: higherPrecisionFormatter
+                                    formatter: higherPrecisionFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -347,7 +360,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.bgBrakeISFweight,
-                                    formatter: higherPrecisionFormatter
+                                    formatter: higherPrecisionFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -356,7 +370,8 @@ extension OverrideProfilesConfig {
                                 DecimalTextField(
                                     "0",
                                     value: $state.autoISFsettings.iobThresholdPercent,
-                                    formatter: insulinFormatter
+                                    formatter: insulinFormatter,
+                                    liveEditing: true
                                 )
                             }
 
@@ -370,7 +385,8 @@ extension OverrideProfilesConfig {
                                     DecimalTextField(
                                         "0",
                                         value: $state.autoISFsettings.iTime_Start_Bolus,
-                                        formatter: insulinFormatter
+                                        formatter: insulinFormatter,
+                                        liveEditing: true
                                     )
                                 }
 
@@ -380,7 +396,8 @@ extension OverrideProfilesConfig {
                                         "0",
                                         mgdlValue: $state.autoISFsettings.b30targetLevel,
                                         units: $state.units,
-                                        isDisabled: false
+                                        isDisabled: false,
+                                        liveEditing: true
                                     )
                                 }
 
@@ -390,7 +407,8 @@ extension OverrideProfilesConfig {
                                         "0",
                                         mgdlValue: $state.autoISFsettings.b30upperLimit,
                                         units: $state.units,
-                                        isDisabled: false
+                                        isDisabled: false,
+                                        liveEditing: true
                                     )
                                 }
 
@@ -400,7 +418,8 @@ extension OverrideProfilesConfig {
                                         "0",
                                         mgdlValue: $state.autoISFsettings.b30upperdelta,
                                         units: $state.units,
-                                        isDisabled: false
+                                        isDisabled: false,
+                                        liveEditing: true
                                     )
                                 }
 
@@ -409,7 +428,8 @@ extension OverrideProfilesConfig {
                                     DecimalTextField(
                                         "0",
                                         value: $state.autoISFsettings.b30factor,
-                                        formatter: insulinFormatter
+                                        formatter: insulinFormatter,
+                                        liveEditing: true
                                     )
                                 }
 
@@ -418,7 +438,8 @@ extension OverrideProfilesConfig {
                                     DecimalTextField(
                                         "0",
                                         value: $state.autoISFsettings.b30_duration,
-                                        formatter: insulinFormatter
+                                        formatter: insulinFormatter,
+                                        liveEditing: true
                                     )
                                 }
                             }
@@ -438,7 +459,8 @@ extension OverrideProfilesConfig {
                                         DecimalTextField(
                                             "0",
                                             value: $state.autoISFsettings.ketoProtectBasalPercent,
-                                            formatter: insulinFormatter
+                                            formatter: insulinFormatter,
+                                            liveEditing: true
                                         )
                                     }
                                 } else {
@@ -451,7 +473,8 @@ extension OverrideProfilesConfig {
                                             DecimalTextField(
                                                 "0",
                                                 value: $state.autoISFsettings.ketoProtectBasalAbsolut,
-                                                formatter: higherPrecisionFormatter
+                                                formatter: higherPrecisionFormatter,
+                                                liveEditing: true
                                             )
                                         }
                                     }

--- a/FreeAPS/Sources/Views/BGTextField.swift
+++ b/FreeAPS/Sources/Views/BGTextField.swift
@@ -5,17 +5,20 @@ struct BGTextField: View {
     @Binding var mgdlValue: Decimal
     @Binding var units: GlucoseUnits
     var isDisabled: Bool
+    var liveEditing: Bool // when true: update the value as the user types; when false: only update the value when the user finishes typing (closes the keyboard)
 
     init(
         _ placeholder: String,
         mgdlValue: Binding<Decimal>,
         units: Binding<GlucoseUnits>,
-        isDisabled: Bool
+        isDisabled: Bool,
+        liveEditing: Bool = false
     ) {
         self.placeholder = placeholder
         _mgdlValue = mgdlValue
         _units = units
         self.isDisabled = isDisabled
+        self.liveEditing = liveEditing
     }
 
     private var mmolLFormatter: NumberFormatter {
@@ -42,10 +45,10 @@ struct BGTextField: View {
     var body: some View {
         HStack {
             if units == .mmolL {
-                DecimalTextField(placeholder, value: displayValue, formatter: mmolLFormatter)
+                DecimalTextField(placeholder, value: displayValue, formatter: mmolLFormatter, liveEditing: liveEditing)
                     .disabled(isDisabled)
             } else {
-                DecimalTextField(placeholder, value: displayValue, formatter: mgdLFormatter)
+                DecimalTextField(placeholder, value: displayValue, formatter: mgdLFormatter, liveEditing: liveEditing)
                     .disabled(isDisabled)
             }
 

--- a/FreeAPS/Sources/Views/DecimalTextField.swift
+++ b/FreeAPS/Sources/Views/DecimalTextField.swift
@@ -180,6 +180,7 @@ public struct DecimalTextField: UIViewRepresentable {
             if let number = parent.formatter.number(from: proposedText) {
                 let decimalNumber = number.decimalValue
                 parent.value = decimalNumber
+                previousSeenValue = decimalNumber
             } else {
                 // invalid input, set value to 0
                 parent.value = 0


### PR DESCRIPTION
The user can tap the "Start" button without leaving the text field they're editing which can (potentially) be a problem:
*  the user will think they changed the value, but it will not be saved

