### PR TITLE
Resolve oref0 warning

### DIFF
--- a/FreeAPS/Sources/Models/TempBasal.swift
+++ b/FreeAPS/Sources/Models/TempBasal.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct TempBasal: JSON {
     let duration: Int
-    let rate: Decimal
+    var rate: Decimal
     let temp: TempType
     let timestamp: Date
 }


### PR DESCRIPTION
due to pump rate ≠ pump history rate
Resolved issue https://github.com/Artificial-Pancreas/iAPS/issues/1160

Round adjusted temp basals before saving. 