### PR TITLE
Sort carbs by the actual date in oref0

### DIFF
--- a/FreeAPS/Resources/javascript/prepare/meal.js
+++ b/FreeAPS/Resources/javascript/prepare/meal.js
@@ -16,6 +16,7 @@ function generate(pumphistory_data, profile_data, clock_data, glucose_data, basa
         carb_data.forEach( carb => carb.created_at = carb.actualDate ? carb.actualDate : carb.created_at);
         carb_data.forEach( carb => console.log("Carb entry " + carb.created_at + ", carbs: " + carb.carbs + ", entered by: " + carb.enteredBy ));
         carb_data = carb_data.filter((carb) => carb.carbs >= 1);
+        carb_data.sort((a, b) => b.created_at - a.created_at);
     }
 
     if (typeof basalprofile_data[0] === 'undefined') {

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -631,7 +631,7 @@ final class OpenAPS {
         return tdd
     }
 
-    func dynamicVariables(_ preferences: Preferences?) -> RawJSON {
+    func dynamicVariables(_ preferences: Preferences?) -> DynamicVariables {
         coredataContext.performAndWait {
             var hbt_ = preferences?.halfBasalExerciseTarget ?? 160
             let wp = preferences?.weightPercentage ?? 1
@@ -826,7 +826,7 @@ final class OpenAPS {
                 aisfOverridden: useOverride && (overrideArray.first?.overrideAutoISF ?? false)
             )
             storage.save(averages, as: OpenAPS.Monitor.dynamicVariables)
-            return self.loadFileFromStorage(name: Monitor.dynamicVariables)
+            return averages
         }
     }
 
@@ -1010,7 +1010,7 @@ final class OpenAPS {
         model: JSON,
         autotune: JSON,
         freeaps: JSON,
-        dynamicVariables: JSON,
+        dynamicVariables: DynamicVariables,
         settings: JSON
     ) -> RawJSON {
         dispatchPrecondition(condition: .onQueue(processQueue))


### PR DESCRIPTION
In oref0 the carb_data are processed in order of the created_at date, however the added carb equivalents in carb_data object were not sorted by this date property. 

However not certain yet, if it really matters...