### PR TITLE
autoisf: report bg_isf more precisely (when < 1)

### DIFF
--- a/FreeAPS/Resources/javascript/autoisf/autoisf.js
+++ b/FreeAPS/Resources/javascript/autoisf/autoisf.js
@@ -256,11 +256,11 @@ function aisf_ratio(profile, glucose_status, currentTime, autosens_data, normalT
     }
 
     bg_ISF = 1 + interpolate(100 - bg_off, profile, "bg");
-    bg_ISF = round(bg_ISF, 2)
-    console.log("BG_ISF adaptation: " + bg_ISF);
+    console.log("BG_ISF adaptation: " + round(bg_ISF, 4));
     let liftISF = 1;
 
     if (bg_ISF < 1) {
+        addMessage("BG-ISF < 1");
         if (acce_ISF > 1) {
             liftISF = bg_ISF * acce_ISF;
             console.log("BG-ISF adaptation lifted to " + round(liftISF, 2) + ", as BG accelerates already");
@@ -280,7 +280,7 @@ function aisf_ratio(profile, glucose_status, currentTime, autosens_data, normalT
         return round(final_ISF,2);
     } else if (bg_ISF > 1) {
         sens_modified = true;
-        console.log("BG-ISF adaption ratio: " + bg_ISF);
+        console.log("BG-ISF adaption ratio: " + round(bg_ISF, 2));
     }
 
     const bg_delta = glucose_status.delta;
@@ -432,6 +432,12 @@ function round(value, digits) {
     return Math.round(value * scale) / scale;
 }
 
+function floor(value, digits) {
+    if (! digits) { digits = 0; }
+    const scale = Math.pow(10, digits);
+    return Math.floor(value * scale) / scale;
+}
+
 function exercising(profile, dynamicVariables) {
     // One of two exercise settings (they share the same purpose).
     if (profile.high_temptarget_raises_sensitivity || profile.exercise_mode || dynamicVariables.isEnabled) {
@@ -572,7 +578,11 @@ function iob_max(iob, dynamicVariables, profile) {
 // Reasons for iAPS pop-up
 function reasons(profile, acce_ISF, bg_ISF, dura_ISF, pp_ISF) {
     addReason("acce: " + round(acce_ISF, 2));
-    addReason("bg: " + round(bg_ISF, 2));
+    let roundedBg = round(bg_ISF, 2);
+    if (roundedBg === 1 && bg_ISF < 1) {
+        roundedBg = floor(bg_ISF, 3);
+    }
+    addReason("bg: " + roundedBg);
     addReason("dura: " + round(dura_ISF, 2));
     addReason("pp: " + round(pp_ISF, 2));
 }

--- a/FreeAPS/Resources/javascript/autoisf/autoisf.js
+++ b/FreeAPS/Resources/javascript/autoisf/autoisf.js
@@ -256,7 +256,7 @@ function aisf_ratio(profile, glucose_status, currentTime, autosens_data, normalT
     }
 
     bg_ISF = 1 + interpolate(100 - bg_off, profile, "bg");
-    console.log("BG_ISF adaptation: " + round(bg_ISF, 4));
+    console.log("BG_ISF adaptation: " + bg_ISF);
     let liftISF = 1;
 
     if (bg_ISF < 1) {

--- a/FreeAPS/Resources/javascript/autoisf/autoisf.js
+++ b/FreeAPS/Resources/javascript/autoisf/autoisf.js
@@ -256,16 +256,17 @@ function aisf_ratio(profile, glucose_status, currentTime, autosens_data, normalT
     }
 
     bg_ISF = 1 + interpolate(100 - bg_off, profile, "bg");
-    console.log("BG_ISF adaptation: " + round(bg_ISF, 2));
+    bg_ISF = round(bg_ISF, 2)
+    console.log("BG_ISF adaptation: " + bg_ISF);
     let liftISF = 1;
 
     if (bg_ISF < 1) {
-        liftISF = Math.min(bg_ISF, acce_ISF);
         if (acce_ISF > 1) {
             liftISF = bg_ISF * acce_ISF;
             console.log("BG-ISF adaptation lifted to " + round(liftISF, 2) + ", as BG accelerates already");
             addMessage("BG-ISF adaptation lifted to " + round(liftISF, 2) + " as BG accelerates already");
         } else {
+            liftISF = Math.min(bg_ISF, acce_ISF);
             console.log("liftISF: " + round(liftISF, 2) + "(minimal)");
             addMessage("liftISF: " + round(liftISF, 2) + "(minimal)");
         }
@@ -279,7 +280,7 @@ function aisf_ratio(profile, glucose_status, currentTime, autosens_data, normalT
         return round(final_ISF,2);
     } else if (bg_ISF > 1) {
         sens_modified = true;
-        console.log("BG-ISF adaption ratio: " + round(bg_ISF, 2));
+        console.log("BG-ISF adaption ratio: " + bg_ISF);
     }
 
     const bg_delta = glucose_status.delta;


### PR DESCRIPTION
it seems that sometimes bg_isf is calculated to be very close to 1 but still below it (like 0.999), so in the pill we report `bg: 1`, but the rest of the factors are not evaluated since the code shortcuts on `if (bg_ISF < 1)` - it gets pretty confusing