### PR TITLE
[minor tweak] simplifying SMB-off schedule logic

### DIFF
--- a/FreeAPS/Resources/javascript/prepare/determine-basal.js
+++ b/FreeAPS/Resources/javascript/prepare/determine-basal.js
@@ -65,7 +65,7 @@ function generate(iob, currenttemp, glucose, profile, autosens = null, meal = nu
         }
         
             //SMBs
-        if (disableSMBs(dynamicVariables)) {
+        if (disableSMBs(dynamicVariables, clock)) {
             microbolusAllowed = false;
             console.error("SMBs disabled by Override");
         }
@@ -269,20 +269,19 @@ function exercising(profile, dynamicVariables) {
     return false
 }
 
-function disableSMBs(dynamicVariables) {
+function disableSMBs(dynamicVariables, now) {
     if (dynamicVariables.smbIsOff) {
-        if (!dynamicVariables.smbIsAlwaysOff) {
-            return true;
-        }
-        const hour = new Date().getHours();
-        if (dynamicVariables.end < dynamicVariables.start && hour < 24 && hour > dynamicVariables.start) {
-            dynamicVariables.end += 24;
-        }
-        if (hour >= dynamicVariables.start && hour <= dynamicVariables.end) {
-            return true;
-        }
-        if (dynamicVariables.end < dynamicVariables.start && hour < dynamicVariables.end) {
-            return true;
+        // smbIsAlwaysOff=true means "SMB are scheduled, NOT always off"
+        if (!dynamicVariables.smbIsAlwaysOff) { return true; }
+
+        var start = dynamicVariables.start;
+        var end = dynamicVariables.end;
+        var hour = now.getHours();
+
+        if (start <= end) {
+            return hour >= start && hour <= end;
+        } else {
+            return hour >= start || hour <= end;
         }
     }
     return false


### PR DESCRIPTION
Just simplifying the `disableSMBs()` logic.
Also using the clock that's used in the main determine-basal function.