### PR TITLE
statically select Xcode 16.3 in GitHub Actions

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -80,7 +80,7 @@ jobs:
 
         # Uncomment to manually select Xcode version
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode_16.3.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -79,8 +79,8 @@ jobs:
           fi
 
         # Uncomment to manually select Xcode version
-        #- name: Select Xcode version
-        #run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
+      - name: Select Xcode version
+        run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |


### PR DESCRIPTION
Manually sets the Xcode version because Xcode 16.0 is selected by default, which is not compatible and causes the build to fail.