### PR TITLE
Statically select Xcode 16.3 in GitHub Actions

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -78,9 +78,8 @@ jobs:
             echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
           fi
 
-        # Uncomment to manually select Xcode version
-        #- name: Select Xcode version
-        #run: "sudo xcode-select --switch /Applications/Xcode_15.3.app/Contents/Developer"
+      - name: Select Xcode version
+        run: "sudo xcode-select --switch /Applications/Xcode_16.3.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |


### PR DESCRIPTION
Manually sets the Xcode version because Xcode 16.0 is selected by default, which is not compatible and causes the build to fail.