### PR TITLE
Refactored timeSetting menu to use localized strings for each hour value

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -690,20 +690,23 @@ extension Home {
         }
 
         var timeSetting: some View {
-            let string = "\(state.hours) " + NSLocalizedString("hours", comment: "") + "   "
-            return Menu(string) {
-                Button(NSLocalizedString("3 hours", comment: ""), action: { state.hours = 3 })
-                Button(NSLocalizedString("6 hours", comment: ""), action: { state.hours = 6 })
-                Button("9 " + NSLocalizedString("hours", comment: ""), action: { state.hours = 9 })
-                Button("12 " + NSLocalizedString("hours", comment: ""), action: { state.hours = 12 })
-                Button("24 " + NSLocalizedString("hours", comment: ""), action: { state.hours = 24 })
-                Button("UI/UX Settings", action: { state.showModal(for: .statisticsConfig) })
+            let hourLabel = NSLocalizedString("\(state.hours) hours", comment: "") + "   "
+
+            return Menu(hourLabel) {
+                ForEach([3, 6, 9, 12, 24], id: \.self) { value in
+                    let label = NSLocalizedString("\(value) hours", comment: "")
+                    Button(label, action: { state.hours = value })
+                }
+
+                Button(NSLocalizedString("UI/UX Settings", comment: ""), action: {
+                    state.showModal(for: .statisticsConfig)
+                })
             }
             .buttonStyle(.borderless)
             .foregroundStyle(.primary)
             .font(.timeSettingFont)
             .padding(.vertical, 15)
-            .background(TimeEllipse(characters: string.count))
+            .background(TimeEllipse(characters: hourLabel.count))
         }
 
         private var isfView: some View {


### PR DESCRIPTION
Translation and label of all hour strings is now handled with the language file

![Screenshot 2025-06-04 at 09 32 27](https://github.com/user-attachments/assets/5c2faa01-6966-4eef-8846-3cb95b43c84b)
![Screenshot 2025-06-04 at 09 32 21](https://github.com/user-attachments/assets/12fd0f14-26e6-43d2-b25a-622dee44d601)
![Screenshot 2025-06-04 at 09 32 18](https://github.com/user-attachments/assets/8f5d0bb8-e5ca-4d2f-8f08-647a0c8754d4)
