### PR TITLE
disable autoisf completely when it's disabled by middleware

### DIFF
--- a/FreeAPS/Resources/javascript/autoisf/autoisf.js
+++ b/FreeAPS/Resources/javascript/autoisf/autoisf.js
@@ -14,15 +14,15 @@ function generate(iob, profile, autosens, glucose, clock, pumpHistory) {
           }
         }
         profile.iaps = overrides;
-
-        if (!profile.iaps.autoisf) {
-            console.log("Auto ISF Disabled by Override");
-            profile.autoISFreasons = "Auto ISF Disabled by Override"
-            profile.iaps.autoisf = false;
-            return profile
-        }
     }
-    
+
+    if (!profile.iaps.autoisf) {
+        console.log("Auto ISF Disabled (by override or middleware)");
+        profile.autoISFreasons = "Auto ISF Disabled"
+        profile.iaps.autoisf = false;
+        return profile
+    }
+
     // Auto ISF
     const glucose_status = getLastGlucose(glucose);
     aisf(iob, profile, autosens_data, dynamicVariables, glucose_status, clock, pumpHistory);


### PR DESCRIPTION
Currently, if autoisf is disabled in middleware, the autoisf code is still executed (unless there is ALSO an override active), which causes the `SMB Delivery Ratio` to reset to default `0.5` (ignoring the profile settings).

This PR prevents autoisf from executing when `profile.iaps.autoisf` is set to `false`, regardless if it's disabled by middleware or an override.