### PR TITLE
basal chart rendering - make more resilient to corrupted data

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -917,7 +917,7 @@ extension MainChartView {
                 fullSize: fullSize,
                 autotuned: false
             )
-            let tempBasalPoints = firstRegularBasalPoints + data.tempBasals.chunks(ofCount: 2).map { chunk -> [CGPoint] in
+            let tempBasalPoints = firstRegularBasalPoints + data.tempBasals.windows(ofCount: 2).map { chunk -> [CGPoint] in
                 let chunk = Array(chunk)
                 guard chunk.count == 2, chunk[0].type == .tempBasal, chunk[1].type == .tempBasalDuration else { return [] }
                 let timeBegin = chunk[0].timestamp.timeIntervalSince1970


### PR DESCRIPTION
A problem reported in Discord turned out to be caused by the following corruption of pump history:
* a `TempBasalDuration` history record without the corresponding `TempBasal` record
* this causes all subsequent TBRs to be missing from the main chart

The reason:
* the `data.tempBasals.chunks` splits the history in chunks of two, expecting each pair to be exactly a `TempBasal` record followed by `TempBasalDuration`, every other pair is ignored
* an orphan `TempBasalDuration` record breaks this expectation completely - the order in the pairs becomes reverted 

The fix:
* to use the `window` function instead of `chunks`, making the procedure resilient to this type of corruption