### PR TITLE
pump history storage - fix bolus de-duplication [fixes #1416]

### DIFF
--- a/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/PumpHistoryStorage.swift
@@ -50,7 +50,8 @@ final class BasePumpHistoryStorage: PumpHistoryStorage, Injectable {
 
                     let minutes = Int((dose.endDate - dose.startDate).timeInterval / 60)
                     if let duplicatedEvent = storedEvents
-                        .first(where: { x in Int(x.timestamp.timeIntervalSince1970) == Int(event.date.timeIntervalSince1970) })
+                        .first(where: { x in
+                            Int(x.timestamp.timeIntervalSince1970) == Int(event.date.timeIntervalSince1970) && x.type == .bolus })
                     {
                         return [PumpHistoryEvent(
                             id: duplicatedEvent.id,


### PR DESCRIPTION
Fixes #1416

The issue was introduced in this commit (May 2025) - https://github.com/Artificial-Pancreas/iAPS/commit/6279502fbde30523c0a0d535b039522660e43745 (part of this PR: https://github.com/Artificial-Pancreas/iAPS/pull/1348)

The de-duplication logic looks for an existing bolus entry at the exact same timestamp and, if found, replaces it instead of creating a new record. 

The problem is the code is not looking at the type of the existing record and can replace other events instead of boluses - like TBR rate/duration when the timestamp matches exactly. 

I'm not sure if this is possible when using a real pump, but it does happen with the pump simulator (as described in the issue and on Discord).

This PR adds a check such that we only look at "bolus" events when de-duplicating (so the timestamp has to match and the type has to be "bolus").

(related to https://github.com/Artificial-Pancreas/iAPS/pull/1414)