### PR TITLE
New Bolus Calculator options

### DIFF
--- a/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
+++ b/FreeAPS/Resources/json/defaults/freeaps/freeaps_settings.json
@@ -106,5 +106,6 @@
   "anubis": false,
   "fpus": true,
   "fpuAmounts": false,
-  "lightMode": LightMode.auto
+  "lightMode": LightMode.auto,
+  "normalRatios": false
 }

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -1855,6 +1855,18 @@ Enact a temp Basal or a temp target */
 /* Add insulin without bolusing alert */
 " without bolusing" = " without bolusing";
 
+/* */
+"Neglect all eventual Overrides, Temp targets, Auto ISF and Dynamic adjustments." = "Neglect all eventual Overrides, Temp targets, Auto ISF and Dynamic adjustments.";
+
+/* */
+"Use Normal ISF and CR" = "Use Normal ISF and CR";
+
+/* */
+"Use Scheduled ISF and CR" = "Use Scheduled ISF and CR";
+
+/* */
+"Don't use 15 min trend" = "Don't use 15 min trend";
+
 /* -------------------------------------------------------------------------------------------
   DASH strings
 */

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -1865,7 +1865,10 @@ Enact a temp Basal or a temp target */
 "Use Scheduled ISF and CR" = "Use Scheduled ISF and CR";
 
 /* */
-"Don't use 15 min trend" = "Don't use 15 min trend";
+"Don't Use 15 min Trend" = "Don't Use 15 min Trend";
+
+/* */
+"Don't adjust for past 15 minutes glucose trend." = "Don't adjust for past 15 minutes glucose trend.";
 
 /* -------------------------------------------------------------------------------------------
   DASH strings

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -57,6 +57,8 @@ struct FreeAPSSettings: JSON, Equatable {
     var useTargetButton: Bool = false
     var alwaysUseColors: Bool = false
     var timeSettings: Bool = true
+    var normalRatios: Bool = false
+    var disable15MinTrend: Bool = false
     // Sounds
     var hypoSound: String = "Default"
     var hyperSound: String = "Default"
@@ -264,6 +266,14 @@ extension FreeAPSSettings: Decodable {
 
         if let carbsRequiredAlert = try? container.decode(Bool.self, forKey: .carbsRequiredAlert) {
             settings.carbsRequiredAlert = carbsRequiredAlert
+        }
+
+        if let normalRatios = try? container.decode(Bool.self, forKey: .normalRatios) {
+            settings.normalRatios = normalRatios
+        }
+
+        if let disable15MinTrend = try? container.decode(Bool.self, forKey: .disable15MinTrend) {
+            settings.disable15MinTrend = disable15MinTrend
         }
 
         if let fattyMealFactor = try? container.decode(Decimal.self, forKey: .fattyMealFactor) {

--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -74,6 +74,8 @@ extension Bolus {
         @Published var bolus: Decimal = 0
         @Published var carbToStore = [CarbsEntry]()
         @Published var history: [PumpHistoryEvent]?
+        @Published var normalRatios: Bool = false
+        @Published var disable15MinTrend: Bool = false
 
         let loopReminder: CGFloat = 4
         let oldGlucose: TimeInterval = -15
@@ -103,6 +105,8 @@ extension Bolus {
             bolusIncrement = settings.preferences.bolusIncrement
             closedLoop = settings.settings.closedLoop
             loopDate = apsManager.lastLoopDate
+            normalRatios = settings.settings.normalRatios
+            disable15MinTrend = settings.settings.disable15MinTrend
 
             if waitForSuggestionInitial {
                 if waitForCarbs {
@@ -167,7 +171,7 @@ extension Bolus {
             }
 
             // more or less insulin because of bg trend in the last 15 minutes
-            fifteenMinInsulin = isf == 0 ? 0 : (deltaBG * conversion) / isf
+            fifteenMinInsulin = (isf == 0 || disable15MinTrend) ? 0 : (deltaBG * conversion) / isf
             print("fifteenMinInsulin isf: \(isf), deltaBG: \(deltaBG * conversion)")
 
             // determine whole COB for which we want to dose insulin for and then determine insulin for wholeCOB
@@ -287,8 +291,15 @@ extension Bolus {
                    let carbRatio = reasons.cr, let minPredBG = reasons.minPredBG
                 {
                     self.target = target as Decimal
-                    self.isf = isf as Decimal
-                    self.carbRatio = carbRatio as Decimal
+
+                    if let ratio = reasons.ratio, self.normalRatios {
+                        self.isf = isf as Decimal * (ratio as Decimal)
+                        self.carbRatio = carbRatio as Decimal * (ratio as Decimal)
+                    } else {
+                        self.isf = isf as Decimal
+                        self.carbRatio = carbRatio as Decimal
+                    }
+
                     self.minPredBG = minPredBG as Decimal
                 }
 
@@ -378,18 +389,25 @@ extension Bolus {
 
         private func prepareData() {
             if !eventualBG {
-                var prepareData = [
+                var prepareData = !disable15MinTrend ? [
                     InsulinRequired(agent: NSLocalizedString("Carbs", comment: ""), amount: wholeCobInsulin),
                     InsulinRequired(agent: NSLocalizedString("IOB", comment: ""), amount: iobInsulinReduction),
                     InsulinRequired(agent: NSLocalizedString("Glucose", comment: ""), amount: targetDifferenceInsulin),
                     InsulinRequired(agent: NSLocalizedString("Trend", comment: ""), amount: fifteenMinInsulin),
                     InsulinRequired(agent: NSLocalizedString("Factors", comment: ""), amount: 0),
                     InsulinRequired(agent: NSLocalizedString("Amount", comment: ""), amount: insulinCalculated)
-                ]
+                ] :
+                    [
+                        InsulinRequired(agent: NSLocalizedString("Carbs", comment: ""), amount: wholeCobInsulin),
+                        InsulinRequired(agent: NSLocalizedString("IOB", comment: ""), amount: iobInsulinReduction),
+                        InsulinRequired(agent: NSLocalizedString("Glucose", comment: ""), amount: targetDifferenceInsulin),
+                        InsulinRequired(agent: NSLocalizedString("Factors", comment: ""), amount: 0),
+                        InsulinRequired(agent: NSLocalizedString("Amount", comment: ""), amount: insulinCalculated)
+                    ]
                 let total = prepareData.dropLast().map(\.amount).reduce(0, +)
                 if total > 0 {
                     let factor = -1 * (total - insulinCalculated)
-                    prepareData[4].amount = abs(factor) >= bolusIncrement ? factor : 0
+                    prepareData[!disable15MinTrend ? 4 : 3].amount = abs(factor) >= bolusIncrement ? factor : 0
                 }
                 data = prepareData
             }

--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -300,7 +300,6 @@ extension Bolus {
         private func illustrationView() -> some View {
             VStack {
                 IllustrationView(data: $state.data)
-
                 // Hide button
                 VStack {
                     Button { showInfo = false }

--- a/FreeAPS/Sources/Modules/Bolus/View/IllustrationView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/IllustrationView.swift
@@ -51,14 +51,23 @@ struct IllustrationView: View {
             ).foregroundStyle(by: .value("Agent", datapoint.agent))
         }
         .chartForegroundStyleScale(
-            [
-                NSLocalizedString("Carbs", comment: ""): Color(.loopYellow),
-                NSLocalizedString("IOB", comment: ""): Color(.insulin),
-                NSLocalizedString("Glucose", comment: ""): Color(.loopGreen),
-                NSLocalizedString("Trend", comment: ""): Color(.purple),
-                NSLocalizedString("Factors", comment: ""): .gray,
-                "": .clear
-            ]
+            data.count < 6 ?
+                [
+                    NSLocalizedString("Carbs", comment: ""): Color(.loopYellow),
+                    NSLocalizedString("IOB", comment: ""): Color(.insulin),
+                    NSLocalizedString("Glucose", comment: ""): Color(.loopGreen),
+                    NSLocalizedString("Factors", comment: ""): .gray,
+                    "": .clear
+                ]
+                :
+                [
+                    NSLocalizedString("Carbs", comment: ""): Color(.loopYellow),
+                    NSLocalizedString("IOB", comment: ""): Color(.insulin),
+                    NSLocalizedString("Glucose", comment: ""): Color(.loopGreen),
+                    NSLocalizedString("Trend", comment: ""): Color(.purple),
+                    NSLocalizedString("Factors", comment: ""): .gray,
+                    "": .clear
+                ]
         )
         .dynamicTypeSize(...DynamicTypeSize.large)
         .chartYAxisLabel(NSLocalizedString("Insulin", comment: "Insulin unit"))
@@ -81,7 +90,7 @@ struct IllustrationView: View {
     }
 
     @ViewBuilder private func BolusLegend() -> some View {
-        let entries = [
+        let entries = data.count > 5 ? [
             BolusSummary(
                 variable: NSLocalizedString("Carbs", comment: ""),
                 formula: "COB / CR",
@@ -118,7 +127,39 @@ struct IllustrationView: View {
                 insulin: data[5].amount,
                 color: .primary
             )
-        ]
+        ] :
+            [
+                BolusSummary(
+                    variable: NSLocalizedString("Carbs", comment: ""),
+                    formula: "COB / CR",
+                    insulin: data[0].amount,
+                    color: Color(.loopYellow)
+                ),
+                BolusSummary(
+                    variable: NSLocalizedString("IOB", comment: ""),
+                    formula: "- Active Insulin",
+                    insulin: data[1].amount,
+                    color: Color(.insulin)
+                ),
+                BolusSummary(
+                    variable: NSLocalizedString("Glucose", comment: ""),
+                    formula: "(BG - Target) / ISF",
+                    insulin: data[2].amount,
+                    color: Color(.loopGreen)
+                ),
+                BolusSummary(
+                    variable: NSLocalizedString("Factors", comment: ""),
+                    formula: "Ev. adjustments",
+                    insulin: data[3].amount,
+                    color: .gray
+                ),
+                BolusSummary(
+                    variable: "",
+                    formula: "",
+                    insulin: data[4].amount,
+                    color: .primary
+                )
+            ]
 
         Grid {
             ForEach(entries) { entry in
@@ -147,7 +188,7 @@ struct IllustrationView: View {
 // Live Preview
 #Preview {
     // Preview data
-    @State var testData = [
+    @Previewable @State var testData = [
         InsulinRequired(agent: "Carbs", amount: 2),
         InsulinRequired(agent: "IOB", amount: -0.5),
         InsulinRequired(agent: "Glucose", amount: -0.5),

--- a/FreeAPS/Sources/Modules/BolusCalculatorConfig/BolusCalculatorStateModel.swift
+++ b/FreeAPS/Sources/Modules/BolusCalculatorConfig/BolusCalculatorStateModel.swift
@@ -12,8 +12,11 @@ extension BolusCalculatorConfig {
         @Published var allowedRemoteBolusAmount: Decimal = 0
         @Published var eventualBG: Bool = false
         @Published var minumimPrediction: Bool = false
+        @Published var normalRatios: Bool = false
+        @Published var disable15MinTrend: Bool = false
 
         override func subscribe() {
+            disable15MinTrend = settingsManager.settings.disable15MinTrend
             subscribeSetting(\.overrideFactor, on: $overrideFactor, initial: {
                 let value = max(min($0, 2), 0.1)
                 overrideFactor = value
@@ -26,6 +29,8 @@ extension BolusCalculatorConfig {
             subscribeSetting(\.eventualBG, on: $eventualBG) { eventualBG = $0 }
             subscribeSetting(\.minumimPrediction, on: $minumimPrediction) { minumimPrediction = $0 }
             subscribeSetting(\.displayPredictions, on: $displayPredictions) { displayPredictions = $0 }
+            subscribeSetting(\.normalRatios, on: $normalRatios) { normalRatios = $0 }
+            subscribeSetting(\.disable15MinTrend, on: $disable15MinTrend) { disable15MinTrend = $0 }
             subscribeSetting(\.fattyMealFactor, on: $fattyMealFactor, initial: {
                 let value = max(min($0, 1.5), 0.1)
                 fattyMealFactor = value

--- a/FreeAPS/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
@@ -89,7 +89,27 @@ extension BolusCalculatorConfig {
                             "1. Use the OpenAPS eventual glucose prediction for computing the insulin recommended. This setting will enable the \"old\" calculator. On by default.\n\n2. Use the OpenAPS minPredBG prediction as a complementary safety guard rail, not allowing the glucose prediction to descend below your threshold. This setting can be used together with or without the eventual glucose. On by default"
                         )
                     }
+
+                    Section {
+                        Toggle(isOn: $state.normalRatios) {
+                            Text("Use Normal ISF and CR")
+                        }
+                    }
+                    footer: {
+                        Text(
+                            "Neglect all eventual Overrides, Temp targets, Auto ISF and Dynamic adjustments."
+                        )
+                    }
+
+                    Section {
+                        if !state.eventualBG {
+                            Toggle(isOn: $state.disable15MinTrend) {
+                                Text("Don't use 15 min trend")
+                            }
+                        }
+                    }
                 }
+
                 Section {
                     HStack {
                         Toggle(isOn: $state.allowBolusShortcut) {

--- a/FreeAPS/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/BolusCalculatorConfig/View/BolusCalculatorConfigRootView.swift
@@ -100,13 +100,12 @@ extension BolusCalculatorConfig {
                             "Neglect all eventual Overrides, Temp targets, Auto ISF and Dynamic adjustments."
                         )
                     }
-
-                    Section {
-                        if !state.eventualBG {
+                    if !state.eventualBG {
+                        Section {
                             Toggle(isOn: $state.disable15MinTrend) {
-                                Text("Don't use 15 min trend")
+                                Text("Don't Use 15 min Trend")
                             }
-                        }
+                        } footer: { Text("Don't adjust for past 15 minutes glucose trend.") }
                     }
                 }
 


### PR DESCRIPTION
2 new settings (default off).
1: Always use scheduled ISF and CR.
2. Don't use 15 min trend adjustment (per request https://github.com/Artificial-Pancreas/iAPS/issues/1428).
