### PR TITLE
fix(DanaKit): Reset priming mode after completion

### DIFF
--- a/Dependencies/DanaKit/DanaKit/PumpManager/DanaKitPumpManager.swift
+++ b/Dependencies/DanaKit/DanaKit/PumpManager/DanaKitPumpManager.swift
@@ -715,13 +715,8 @@ extension DanaKitPumpManager: PumpManager {
     public func enactPrime(unit: Double, completion: @escaping (PumpManagerError?) -> Void) {
         isPriming = true
         enactBolus(units: unit, activationType: .manualNoRecommendation) { error in
-            if let error = error {
-                self.isPriming = false
-                completion(error)
-                return
-            }
-
-            completion(nil)
+            self.isPriming = false
+            completion(error)
         }
     }
 


### PR DESCRIPTION
DanaKit has a feature, where you can refill the reservoir and/or replace the cannula of your pump, without using the pump's UI. In order to prevent the priming to be stored as a bolus, DanaKit can be put into priming-mode. Due to a coding error, DanaKit did not switch back to a normal mode after a successful prime causing the issue as describe in #1476 
