### PR TITLE
removing some unused code in OpenAPS.swift

### DIFF
--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -313,7 +313,7 @@ final class OpenAPS {
 
                     now = Date.now
                     let (pumpProfile, profile) = await (
-                        self.makeProfileAsync(
+                        self.makeProfile(
                             preferences: preferences,
                             pumpSettings: pumpSettings,
                             bgTargets: bgTargets,
@@ -327,7 +327,7 @@ final class OpenAPS {
                             dynamicVariables: dynamicVariables,
                             settings: settings
                         ),
-                        self.makeProfileAsync(
+                        self.makeProfile(
                             preferences: preferences,
                             pumpSettings: pumpSettings,
                             bgTargets: bgTargets,
@@ -1166,40 +1166,6 @@ final class OpenAPS {
         autotune: JSON,
         freeaps: JSON,
         dynamicVariables: DynamicVariables,
-        settings: JSON
-    ) async -> RawJSON {
-        // dispatchPrecondition(condition: .onQueue(processQueue))
-        await scriptExecutor.call(
-            name: OpenAPS.Prepare.profile,
-            with: [
-                pumpSettings,
-                bgTargets,
-                isf,
-                basalProfile,
-                preferences,
-                carbRatio,
-                tempTargets,
-                model,
-                autotune,
-                freeaps,
-                dynamicVariables,
-                settings
-            ]
-        )
-    }
-
-    private func makeProfileAsync(
-        preferences: JSON,
-        pumpSettings: JSON,
-        bgTargets: JSON,
-        basalProfile: JSON,
-        isf: JSON,
-        carbRatio: JSON,
-        tempTargets: JSON,
-        model: JSON,
-        autotune: JSON,
-        freeaps: JSON,
-        dynamicVariables: JSON,
         settings: JSON
     ) async -> RawJSON {
         // dispatchPrecondition(condition: .onQueue(processQueue))


### PR DESCRIPTION
* removing the unused JavaScriptWorker from OpenAPS
`jsWorker` was only used in one private function - `exportDefaultPreferences`, and this function is not called from anywhere

* also removing the `makeProfileAsync` function - it was a duplicate of `makeProfile`
