### PR TITLE
Export BUILD_GROUP variable from Github Settings -> Fastlane

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -77,6 +77,9 @@ jobs:
           if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
             echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
           fi
+          if [ ! -z ${{ vars.BUILD_GROUP }}  ]; then
+            echo "BUILD_GROUP=${{ vars.BUILD_GROUP }}" >> $GITHUB_ENV
+          fi
 
       - name: Select Xcode version
         run: "sudo xcode-select --switch /Applications/Xcode_16.3.app/Contents/Developer"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,7 +34,7 @@ if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
   File.write('../ConfigOverride.xcconfig', "BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}\n", mode: 'a')
 end
 
-if File.exist?(file_path)
+if File.exist?('../ConfigOverride.xcconfig')
   contents = File.read('../ConfigOverride.xcconfig')
   puts "=== File Contents: ../ConfigOverride.xcconfig ==="
   puts contents

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -23,11 +23,10 @@ DEVICE_NAME = ENV["DEVICE_NAME"]
 DEVICE_ID = ENV["DEVICE_ID"]
 ENV["FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT"] = "120"
 
-BUILD_GROUP = ENV.fetch('BUILD_GROUP') { "" }
 APP_IDENTIFIER = ENV.fetch('APP_IDENTIFIER') { "ru.artpancreas.#{TEAMID}.FreeAPS" }
 
-if #{BUILD_GROUP} != ""
-  File.write('../ConfigOverride.xcconfig', "COPYRIGHT_NOTICE = #{BUILD_GROUP}\n", mode: 'a')
+if ENV['BUILD_GROUP']
+  File.write('../ConfigOverride.xcconfig', "COPYRIGHT_NOTICE = #{ENV['BUILD_GROUP']}\n", mode: 'a')
 end
 
 if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,7 +35,7 @@ if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
 end
 
 if File.exist?(file_path)
-  contents = File.read('../ConfigOverride.xcconfig'))
+  contents = File.read('../ConfigOverride.xcconfig')
   puts "=== File Contents: ../ConfigOverride.xcconfig ==="
   puts contents
   puts "====================="

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,6 +34,13 @@ if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
   File.write('../ConfigOverride.xcconfig', "BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}\n", mode: 'a')
 end
 
+if File.exist?(file_path)
+  contents = File.read('../ConfigOverride.xcconfig'))
+  puts "=== File Contents: ../ConfigOverride.xcconfig ==="
+  puts contents
+  puts "====================="
+end
+
 platform :ios do
   desc "Build iAPS"
   lane :build_iAPS do


### PR DESCRIPTION
I had written the code months ago to allow setting COPYRIGHT_NOTICE via a BUILD_GROUP variable in Github Actions, but failed to export that variable so that Fastlane could use of it.

This corrects that, and adds an output of ConfigOverride.xcconfig step so that its easier to debug going forward
