### PR TITLE
nightscout remote push notifications

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -473,6 +473,7 @@
 		F2159A572BA6239F00A0B716 /* ContactTrickManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2159A562BA6239F00A0B716 /* ContactTrickManager.swift */; };
 		F2159A592BA78B7400A0B716 /* ContactTrickState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2159A582BA78B7400A0B716 /* ContactTrickState.swift */; };
 		F2159A5B2BA7939C00A0B716 /* ContactPicture.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2159A5A2BA7939C00A0B716 /* ContactPicture.swift */; };
+		F226D5212E5EAAC100F8F43C /* RemoteNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F226D51F2E5EAAC100F8F43C /* RemoteNotificationsManager.swift */; };
 		F270F68D2BAE374C00F6D8DD /* FontTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = F270F68C2BAE374C00F6D8DD /* FontTracking.swift */; };
 		F273F9602DE73ABE00BF0FFC /* IOBTick0.swift in Sources */ = {isa = PBXBuildFile; fileRef = F273F95F2DE73ABE00BF0FFC /* IOBTick0.swift */; };
 		F2FEE7042D2DB1A000A91BB2 /* BGTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2FEE7032D2DB1A000A91BB2 /* BGTextField.swift */; };
@@ -1126,6 +1127,7 @@
 		F2159A562BA6239F00A0B716 /* ContactTrickManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTrickManager.swift; sourceTree = "<group>"; };
 		F2159A582BA78B7400A0B716 /* ContactTrickState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactTrickState.swift; sourceTree = "<group>"; };
 		F2159A5A2BA7939C00A0B716 /* ContactPicture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPicture.swift; sourceTree = "<group>"; };
+		F226D51F2E5EAAC100F8F43C /* RemoteNotificationsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteNotificationsManager.swift; sourceTree = "<group>"; };
 		F270F68C2BAE374C00F6D8DD /* FontTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontTracking.swift; sourceTree = "<group>"; };
 		F273F95F2DE73ABE00BF0FFC /* IOBTick0.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IOBTick0.swift; sourceTree = "<group>"; };
 		F2FEE7032D2DB1A000A91BB2 /* BGTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BGTextField.swift; sourceTree = "<group>"; };
@@ -1733,6 +1735,7 @@
 				3811DE9425C9D88200A708ED /* Network */,
 				3811DE9825C9D88300A708ED /* Storage */,
 				3811DEA525C9D88300A708ED /* UnlockManager */,
+				F226D5202E5EAAC100F8F43C /* RemoteNotifications */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -2758,6 +2761,14 @@
 			path = ContactTrick;
 			sourceTree = "<group>";
 		};
+		F226D5202E5EAAC100F8F43C /* RemoteNotifications */ = {
+			isa = PBXGroup;
+			children = (
+				F226D51F2E5EAAC100F8F43C /* RemoteNotificationsManager.swift */,
+			);
+			path = RemoteNotifications;
+			sourceTree = "<group>";
+		};
 		F5DE2E6D7B2133BBD3353DC7 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -3395,6 +3406,7 @@
 				38E8755427561E9800975559 /* DataFlow.swift in Sources */,
 				38E44522274E3DDC00EC9A94 /* NetworkReachabilityManager.swift in Sources */,
 				CE7CA34F2A064973004BE681 /* BaseIntentsRequest.swift in Sources */,
+				F226D5212E5EAAC100F8F43C /* RemoteNotificationsManager.swift in Sources */,
 				A6F097A14CAAE0CE0D11BE1B /* AddCarbsProvider.swift in Sources */,
 				33E198D3039045D98C3DC5D4 /* AddCarbsStateModel.swift in Sources */,
 				28089E07169488CF6DCC2A31 /* AddCarbsRootView.swift in Sources */,

--- a/FreeAPS/Resources/FreeAPS.entitlements
+++ b/FreeAPS/Resources/FreeAPS.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.healthkit</key>
 	<true/>
 	<key>com.apple.developer.healthkit.access</key>

--- a/FreeAPS/Resources/Info.plist
+++ b/FreeAPS/Resources/Info.plist
@@ -101,6 +101,7 @@
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
 		<string>processing</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/FreeAPS/Sources/Application/AppDelegate.swift
+++ b/FreeAPS/Sources/Application/AppDelegate.swift
@@ -1,4 +1,65 @@
 import SwiftUI
 import UIKit
 
-class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject {}
+class AppDelegate: NSObject, UIApplicationDelegate, ObservableObject, UNUserNotificationCenterDelegate {
+    var fetchGlucoseManager: FetchGlucoseManager?
+    var remoteNotificationsManager: RemoteNotificationsManager? {
+        didSet {
+            if let token = deviceToken {
+                remoteNotificationsManager?.setDeviceToken(token)
+            }
+        }
+    }
+
+    private var deviceToken: String?
+
+    func application(
+        _: UIApplication,
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        UNUserNotificationCenter.current().delegate = self
+        DispatchQueue.main.async {
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+        return true
+    }
+
+    func application(
+        _: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+        self.deviceToken = token
+        if let remoteNotificationsManager = self.remoteNotificationsManager {
+            remoteNotificationsManager.setDeviceToken(token)
+        }
+    }
+
+    func application(
+        _: UIApplication,
+        didFailToRegisterForRemoteNotificationsWithError error: Error
+    ) {
+        warning(.service, "APNs registration failed: \(error.localizedDescription)")
+    }
+
+    func application(
+        _: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completion: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        debug(.apsManager, "remote notification: \(userInfo)")
+
+        let since = userInfo["since"] as? String
+
+//        if let since = since,
+//           let date = ISO8601Parsing.parse(since)
+//        {
+        Task {
+            await fetchGlucoseManager?.refreshCGM()
+        }
+//        } else {
+//            warning(.service, "remote notification, invalid date: \(String(describing: since))")
+//        }
+        completion(.noData)
+    }
+}

--- a/FreeAPS/Sources/Application/FreeAPSApp.swift
+++ b/FreeAPS/Sources/Application/FreeAPSApp.swift
@@ -38,7 +38,7 @@ import Swinject
         resolver.resolve(AppearanceManager.self)!.setupGlobalAppearance()
         _ = resolver.resolve(DeviceDataManager.self)!
         _ = resolver.resolve(APSManager.self)!
-        _ = resolver.resolve(FetchGlucoseManager.self)!
+        let fetchGlucoseManager = resolver.resolve(FetchGlucoseManager.self)!
         _ = resolver.resolve(FetchTreatmentsManager.self)!
         _ = resolver.resolve(FetchAnnouncementsManager.self)!
         _ = resolver.resolve(CalendarManager.self)!
@@ -47,6 +47,10 @@ import Swinject
         _ = resolver.resolve(HealthKitManager.self)!
         _ = resolver.resolve(BluetoothStateManager.self)!
         _ = resolver.resolve(LiveActivityBridge.self)!
+        _ = resolver.resolve(RemoteNotificationsManager.self)!
+        let remoteNotificationsManager = resolver.resolve(RemoteNotificationsManager.self)!
+        appDelegate.fetchGlucoseManager = fetchGlucoseManager
+        appDelegate.remoteNotificationsManager = remoteNotificationsManager
     }
 
     init() {
@@ -67,6 +71,9 @@ import Swinject
         }
         .onChange(of: scenePhase) {
             debug(.default, "APPLICATION PHASE: \(scenePhase)")
+            if scenePhase == .active {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
         }
     }
 

--- a/FreeAPS/Sources/Assemblies/ServiceAssembly.swift
+++ b/FreeAPS/Sources/Assemblies/ServiceAssembly.swift
@@ -22,5 +22,6 @@ final class ServiceAssembly: Assembly {
         container.register(GarminManager.self) { r in BaseGarminManager(resolver: r) }
         container.register(ContactTrickManager.self) { r in BaseContactTrickManager(resolver: r) }
         container.register(LiveActivityBridge.self) { r in LiveActivityBridge(resolver: r) }
+        container.register(RemoteNotificationsManager.self) { r in BaseRemoteNotificationsManager(resolver: r) }
     }
 }

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -107,6 +107,9 @@ struct FreeAPSSettings: JSON, Equatable {
     var useCarbBars: Bool = false
     // ColorScheme
     var lightMode: LightMode = .auto
+    // Nightscout remote notifications
+    var nightscountHeartbeatServiceEnabled: Bool = false
+    var nightscountHeartbeatServiceURL: String = ""
     // Auto ISF
     var autoisf: Bool = false
     var smbDeliveryRatioBGrange: Decimal = 0
@@ -336,6 +339,16 @@ extension FreeAPSSettings: Decodable {
 
         if let lightMode = try? container.decode(LightMode.self, forKey: .lightMode) {
             settings.lightMode = lightMode
+        }
+
+        if let nightscountHeartbeatServiceEnabled = try? container
+            .decode(Bool.self, forKey: .nightscountHeartbeatServiceEnabled)
+        {
+            settings.nightscountHeartbeatServiceEnabled = nightscountHeartbeatServiceEnabled
+        }
+
+        if let nightscountHeartbeatServiceURL = try? container.decode(String.self, forKey: .nightscountHeartbeatServiceURL) {
+            settings.nightscountHeartbeatServiceURL = nightscountHeartbeatServiceURL
         }
 
         if let lowGlucose = try? container.decode(Decimal.self, forKey: .lowGlucose) {

--- a/FreeAPS/Sources/Modules/CGM/CGMStateModel.swift
+++ b/FreeAPS/Sources/Modules/CGM/CGMStateModel.swift
@@ -9,6 +9,7 @@ extension CGM {
         @Injected() var libreSource: LibreTransmitterSource!
         @Injected() var cgmManager: FetchGlucoseManager!
         @Injected() var calendarManager: CalendarManager!
+        @Injected() var remoteNotificationsManager: RemoteNotificationsManager!
 
         @Published var setupCGM: Bool = false
         @Published var cgm: CGMType = .nightscout
@@ -23,6 +24,10 @@ extension CGM {
         @Persisted(key: "CalendarManager.currentCalendarID") var storedCalendarID: String? = nil
         @Published var cgmTransmitterDeviceAddress: String? = nil
         @Published var sensorDays: Double = 10
+        // remote notifications
+        @Published var nightscountHeartbeatServiceEnabled = false
+        @Published var nightscountHeartbeatServiceURL = ""
+        @Published var nightscountHeartbeatServiceError: String? = nil
 
         override func subscribe() {
             cgm = settingsManager.settings.cgm
@@ -56,6 +61,11 @@ extension CGM {
             subscribeSetting(\.displayCalendarEmojis, on: $displayCalendarEmojis) { displayCalendarEmojis = $0 }
             subscribeSetting(\.smoothGlucose, on: $smoothGlucose, initial: { smoothGlucose = $0 })
             subscribeSetting(\.sensorDays, on: $sensorDays) { sensorDays = $0 }
+
+            subscribeSetting(\.nightscountHeartbeatServiceEnabled, on: $nightscountHeartbeatServiceEnabled) {
+                nightscountHeartbeatServiceEnabled = $0 }
+            subscribeSetting(\.nightscountHeartbeatServiceURL, on: $nightscountHeartbeatServiceURL) {
+                nightscountHeartbeatServiceURL = $0 }
 
             $cgm
                 .removeDuplicates()

--- a/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
+++ b/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
@@ -70,6 +70,48 @@ extension CGM {
                         }
                     }
 
+                    if state.cgm == .nightscout {
+                        Section(header: Text("Remote notifications")) {
+                            TextField("Server URL", text: $state.nightscountHeartbeatServiceURL)
+                                .disableAutocorrection(true)
+                                .textContentType(.URL)
+                                .autocapitalization(.none)
+                                .keyboardType(.URL)
+                                .disabled(state.nightscountHeartbeatServiceEnabled)
+
+                            if state.nightscountHeartbeatServiceEnabled {
+                                Button("Unsubscribe") {
+                                    Task {
+                                        if let error = await state.remoteNotificationsManager.unsubscribe() {
+                                            state.nightscountHeartbeatServiceError = error
+                                        } else {
+                                            state.nightscountHeartbeatServiceEnabled = false
+                                        }
+                                    }
+                                }
+                            } else {
+                                Button("Subscribe") {
+                                    Task {
+                                        if let error = await state.remoteNotificationsManager.subscribe() {
+                                            state.nightscountHeartbeatServiceError = error
+                                        } else {
+                                            state.nightscountHeartbeatServiceEnabled = true
+                                        }
+                                    }
+                                }
+                                .disabled(
+                                    !(
+                                        state.nightscountHeartbeatServiceURL.starts(with: "http://") ||
+                                            state.nightscountHeartbeatServiceURL.starts(with: "https://")
+                                    )
+                                )
+                            }
+                            if let error = state.nightscountHeartbeatServiceError {
+                                Text(error).foregroundStyle(.red)
+                            }
+                        }
+                    }
+
                     if state.cgm == .libreTransmitter {
                         Button("Configure Libre Transmitter") {
                             state.showModal(for: .libreConfig)

--- a/FreeAPS/Sources/Services/Network/NetworkService.swift
+++ b/FreeAPS/Sources/Services/Network/NetworkService.swift
@@ -2,20 +2,34 @@ import Combine
 import Foundation
 
 enum NetworkError: Error, LocalizedError {
+    case invalidResponse
     case badStatusCode(HTTPResponseStatus)
+    case badStatus(code: Int, body: Data?) // for async version
+    case cancelled
+    case zeroRetries
 
     var errorDescription: String? {
         switch self {
+        case .invalidResponse: return "Invalid HTTP response."
         case let .badStatusCode(code):
             return code.reasonPhrase
+        case let .badStatus(code, _): return HTTPURLResponse.localizedString(forStatusCode: code)
+        case .cancelled: return "Request cancelled."
+        case .zeroRetries: return "Zero retries specified."
         }
     }
 }
 
 struct NetworkService {
+    let session: URLSession
+
+    init(session: URLSession = .shared) {
+        self.session = session
+    }
+
     func run(_ request: URLRequest) -> AnyPublisher<Data, Error> {
         //    debug(.nightscout, "\(request.httpMethod!)  ***\(request.url!.path)\(request.url!.query.map { "?" + $0 } ?? "")")
-        URLSession.shared
+        session
             .dataTaskPublisher(for: request)
             .tryMap { data, response in
                 let code = (response as! HTTPURLResponse).statusCode
@@ -25,5 +39,54 @@ struct NetworkService {
                 return data
             }
             .eraseToAnyPublisher()
+    }
+}
+
+extension NetworkService {
+    /// Run a request and return raw Data. Throws for non-2xx and transport errors.
+    func runAsync(_ request: URLRequest, retries: Int = 1) async throws -> Data {
+        try await retry(retries) {
+            do {
+                let (data, response) = try await session.data(for: request)
+                guard let http = response as? HTTPURLResponse else {
+                    throw NetworkError.invalidResponse
+                }
+                guard 200 ..< 300 ~= http.statusCode else {
+                    throw NetworkError.badStatus(code: http.statusCode, body: data)
+                }
+                return data
+            } catch is CancellationError {
+                throw NetworkError.cancelled
+            } catch {
+                throw error
+            }
+        }
+    }
+
+    func decode<T: Decodable>(
+        _: T.Type,
+        from request: URLRequest,
+        decoder: JSONDecoder = JSONCoding.decoder,
+        retries: Int = 1
+    ) async throws -> T {
+        try await decoder.decode(T.self, from: runAsync(request, retries: retries))
+    }
+
+    @inline(__always) private func retry<T>(
+        _ times: Int,
+        _ op: () async throws -> T
+    ) async throws -> T {
+        for attempt in 0 ... times {
+            do {
+                return try await op()
+            } catch {
+                if attempt < times {
+                    try? await Task.sleep(for: .milliseconds(200 * (1 << attempt)))
+                } else {
+                    throw error
+                }
+            }
+        }
+        throw NetworkError.zeroRetries
     }
 }

--- a/FreeAPS/Sources/Services/RemoteNotifications/RemoteNotificationsManager.swift
+++ b/FreeAPS/Sources/Services/RemoteNotifications/RemoteNotificationsManager.swift
@@ -1,0 +1,190 @@
+import Foundation
+import Swinject
+
+protocol RemoteNotificationsManager {
+    func setDeviceToken(_ deviceToken: String)
+    func subscribe() async -> String?
+    func unsubscribe() async -> String?
+}
+
+final class BaseRemoteNotificationsManager: NSObject, RemoteNotificationsManager, Injectable, SettingsObserver {
+    private let keychain: Keychain
+    private let settingsManager: SettingsManager
+    private let broadcaster: Broadcaster
+
+    private let service = NetworkService()
+
+    private var deviceToken: String?
+    private var nightscountHeartbeatServiceEnabled: Bool = false
+    private var nightscountHeartbeatServiceURL: String?
+    private var cgm: CGMType?
+
+    private let bundleId = Bundle.main.bundleIdentifier
+
+    init(resolver: Resolver) {
+        keychain = resolver.resolve(Keychain.self)!
+        settingsManager = resolver.resolve(SettingsManager.self)!
+        broadcaster = resolver.resolve(Broadcaster.self)!
+
+        super.init()
+
+        nightscountHeartbeatServiceEnabled = settingsManager.settings.nightscountHeartbeatServiceEnabled
+        nightscountHeartbeatServiceURL = settingsManager.settings.nightscountHeartbeatServiceURL
+        cgm = settingsManager.settings.cgm
+        broadcaster.register(SettingsObserver.self, observer: self)
+        refresh()
+    }
+
+    func setDeviceToken(_ deviceToken: String) {
+        guard self.deviceToken == nil else { return }
+        self.deviceToken = deviceToken
+        refresh()
+    }
+
+    func subscribe() async -> String? {
+        guard !nightscountHeartbeatServiceEnabled else { return nil }
+        return await callSubscribeEnpoint()
+    }
+
+    func unsubscribe() async -> String? {
+        guard nightscountHeartbeatServiceEnabled else { return nil }
+        return await callUnsubscribeEnpoint()
+    }
+
+    func settingsDidChange(_: FreeAPSSettings) {
+        if nightscountHeartbeatServiceEnabled != settingsManager.settings.nightscountHeartbeatServiceEnabled ||
+            nightscountHeartbeatServiceURL != settingsManager.settings.nightscountHeartbeatServiceURL ||
+            cgm != settingsManager.settings.cgm
+        {
+            nightscountHeartbeatServiceEnabled = settingsManager.settings.nightscountHeartbeatServiceEnabled
+            nightscountHeartbeatServiceURL = settingsManager.settings.nightscountHeartbeatServiceURL
+            cgm = settingsManager.settings.cgm
+            refresh()
+        }
+    }
+
+    private func refresh() {
+        // do nothing until we get the device token
+        guard deviceToken != nil else { return }
+        if cgm == .nightscout {
+            if nightscountHeartbeatServiceURL != nil,
+               nightscountHeartbeatServiceEnabled
+            {
+                print("CGM is nightscout, heartbeat enabled, (re)subscribing to Nightscout heartbeat service")
+                Task {
+                    await callSubscribeEnpoint()
+                }
+            }
+        } else {
+            if nightscountHeartbeatServiceEnabled {
+                print(
+                    "CGM changed from nightscout to something else, heartbeat enabled, unsubscribing from Nightscout heartbeat service"
+                )
+                Task {
+                    await callUnsubscribeEnpoint()
+                    // TODO: this change doesn't propagate to the CGM view unless it's closed and reopened
+                    settingsManager.settings.nightscountHeartbeatServiceEnabled = false
+                }
+            }
+        }
+    }
+
+    private func makePayload() -> SubscribeRequest? {
+        guard let bundleId = self.bundleId,
+              let deviceToken = self.deviceToken,
+              let nightscoutURL = keychain.getValue(String.self, forKey: NightscoutConfig.Config.urlKey),
+              let nightscoutSecret = keychain.getValue(String.self, forKey: NightscoutConfig.Config.secretKey),
+              nightscoutURL != "",
+              nightscoutSecret != ""
+        else { return nil }
+
+        #if DEBUG
+            let useSandbox = true
+        #else
+            let useSandbox = false
+        #endif
+
+        return SubscribeRequest(
+            deviceToken: deviceToken,
+            nsBase: nightscoutURL,
+            apiSecretSha1: nightscoutSecret.sha1(),
+            bundleId: bundleId,
+            useSandbox: useSandbox
+        )
+    }
+
+    private func callSubscribeEnpoint() async -> String? {
+        guard let urlString = nightscountHeartbeatServiceURL,
+              let url = URL(string: urlString),
+              let payload = makePayload()
+        else { return "Missing settings" }
+
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = "/api/v1/ns/subscribe"
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+//        request.timeoutInterval = Config.timeout
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        request.httpBody = try! JSONCoding.encoder.encode(payload)
+        request.httpMethod = "POST"
+
+        do {
+            let response = try await service.decode(SubscribeResponse.self, from: request)
+            if response.okay { return nil }
+            return response.error ?? "Failed to subscribe."
+        } catch {
+            warning(.service, "failed to subscribe to nightscout heartbeat service: \(error.localizedDescription)")
+            return error.localizedDescription
+        }
+    }
+
+    private func callUnsubscribeEnpoint() async -> String? {
+        guard let urlString = nightscountHeartbeatServiceURL,
+              let url = URL(string: urlString),
+              let payload = makePayload()
+        else { return "Missing settings" }
+
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = "/api/v1/ns/unsubscribe"
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+//        request.timeoutInterval = Config.timeout
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        request.httpBody = try! JSONCoding.encoder.encode(payload)
+        request.httpMethod = "POST"
+
+        do {
+            let response = try await service.decode(SubscribeResponse.self, from: request)
+            if response.okay { return nil }
+            return response.error ?? "Failed to subscribe."
+        } catch {
+            warning(.service, "failed to unsubscribe from nightscout heartbeat service: \(error.localizedDescription)")
+            return error.localizedDescription
+        }
+    }
+}
+
+private extension BaseRemoteNotificationsManager {
+    struct SubscribeRequest: Codable {
+        let deviceToken: String
+        let nsBase: String
+        let apiSecretSha1: String
+        let bundleId: String
+        let useSandbox: Bool
+    }
+
+    struct SubscribeResponse: Codable {
+        let okay: Bool
+        let error: String?
+    }
+}


### PR DESCRIPTION
Remote notifications for nightscout-as-CGM.

Requires a counterpart backend server (https://github.com/yurique/iaps-ns-apns), which subscribes to updates from Nightscout and sends remote notifications via APNs.