### PR TITLE
more cleanup and refactoring

### DIFF
--- a/FreeAPS/Sources/APS/KnownPlugins.swift
+++ b/FreeAPS/Sources/APS/KnownPlugins.swift
@@ -85,4 +85,50 @@ enum KnownPlugins {
         default: return cgmManager.pluginIdentifier
         }
     }
+
+    static func isManualTempBasalActive(_ pumpManager: PumpManager) -> Bool? {
+        switch pumpManager.pluginIdentifier {
+        case OmnipodPumpManager.pluginIdentifier:
+            if let omnipod = pumpManager as? OmnipodPumpManager,
+               let tempBasal = omnipod.state.podState?.unfinalizedTempBasal,
+               !tempBasal.isFinished(),
+               !tempBasal.automatic
+            {
+                return true
+            } else {
+                return false
+            }
+        case OmniBLEPumpManager.pluginIdentifier:
+            if let omnipodBLE = pumpManager as? OmniBLEPumpManager,
+               let tempBasal = omnipodBLE.state.podState?.unfinalizedTempBasal,
+               !tempBasal.isFinished(),
+               !tempBasal.automatic
+            {
+                return true
+            } else {
+                return false
+            }
+        default: return nil
+        }
+    }
+
+    static func pumpActivationDate(_ pumpManager: PumpManager) -> Date? {
+        switch pumpManager.pluginIdentifier {
+        case OmnipodPumpManager.pluginIdentifier:
+            return (pumpManager as? OmnipodPumpManager)?.state.podState?.activatedAt
+        case OmniBLEPumpManager.pluginIdentifier:
+            return (pumpManager as? OmniBLEPumpManager)?.state.podState?.activatedAt
+        default: return nil
+        }
+    }
+
+    static func pumpExpirationDate(_ pumpManager: PumpManager) -> Date? {
+        switch pumpManager.pluginIdentifier {
+        case OmnipodPumpManager.pluginIdentifier:
+            return (pumpManager as? OmnipodPumpManager)?.state.podState?.expiresAt
+        case OmniBLEPumpManager.pluginIdentifier:
+            return (pumpManager as? OmniBLEPumpManager)?.state.podState?.expiresAt
+        default: return nil
+        }
+    }
 }

--- a/FreeAPS/Sources/Models/AlertEntry.swift
+++ b/FreeAPS/Sources/Models/AlertEntry.swift
@@ -25,6 +25,17 @@ struct AlertEntry: JSON, Codable, Hashable {
         hasher.combine(issuedDate)
     }
 
+    init(from alert: LoopKit.Alert) {
+        alertIdentifier = alert.identifier.alertIdentifier
+        primitiveInterruptionLevel = alert.interruptionLevel.storedValue as? Decimal
+        issuedDate = Date()
+        managerIdentifier = alert.identifier.managerIdentifier
+        triggerType = alert.trigger.storedType
+        triggerInterval = alert.trigger.storedInterval as? Decimal
+        contentTitle = alert.foregroundContent?.title
+        contentBody = alert.foregroundContent?.body
+    }
+
     private enum CodingKeys: String, CodingKey {
         case alertIdentifier
         case acknowledgedDate

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -1025,9 +1025,7 @@ extension MainChartView {
         calculateManualGlucoseDots(fullSize: fullSize)
         calculateManualGlucoseDotsCenter(fullSize: fullSize)
         calculateAnnouncementDots(fullSize: fullSize)
-        if data.smooth {
-            calculateUnSmoothedGlucoseDots(fullSize: fullSize)
-        }
+        calculateUnSmoothedGlucoseDots(fullSize: fullSize)
         calculateBolusDots(fullSize: fullSize)
         calculateCarbsDots(fullSize: fullSize)
         calculateFPUsDots(fullSize: fullSize)

--- a/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
@@ -14,8 +14,8 @@ extension PumpConfig {
         var body: some View {
             NavigationView {
                 Form {
-                    Section(header: Text("Model")) {
-                        if let pumpManager = state.deviceManager.pumpManager {
+                    if let pumpManager = state.deviceManager.pumpManager {
+                        Section(header: Text("Model")) {
                             Button {
                                 state.setupPump(pumpManager.pluginIdentifier)
                             } label: {
@@ -23,18 +23,26 @@ extension PumpConfig {
                                     Image(uiImage: pumpManager.smallImage ?? UIImage()).padding()
                                     Text(pumpManager.localizedTitle)
                                 }
-                                if let status = pumpManager.pumpStatusHighlight?.localizedMessage {
-                                    HStack {
-                                        Text(status.replacingOccurrences(of: "\n", with: " ")).font(.caption)
-                                    }
+                            }
+                        }
+                        Section {
+                            if let status = pumpManager.pumpStatusHighlight?.localizedMessage {
+                                HStack {
+                                    Text(status.replacingOccurrences(of: "\n", with: " "))
                                 }
                             }
-                            //                            TODO: [loopkit] fix this
+                            if state.pumpManagerStatus?.deliveryIsUncertain ?? false {
+                                HStack {
+                                    Text("Pump delivery uncertain").foregroundColor(.red)
+                                }
+                            }
                             if state.alertNotAck {
                                 Spacer()
                                 Button("Acknowledge all alerts") { state.ack() }
                             }
-                        } else {
+                        }
+                    } else {
+                        Section {
                             ForEach(state.deviceManager.availablePumpManagers, id: \.identifier) { pump in
                                 VStack(alignment: .leading) {
                                     Button("Add " + pump.localizedTitle) {

--- a/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
+++ b/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
@@ -24,7 +24,7 @@ protocol BolusFailureObserver {
     func bolusDidFail()
 }
 
-protocol pumpNotificationObserver {
+protocol PumpNotificationObserver {
     func pumpNotification(alert: AlertEntry)
     func pumpRemoveNotification()
 }
@@ -59,7 +59,7 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
         broadcaster.register(GlucoseObserver.self, observer: self)
         broadcaster.register(SuggestionObserver.self, observer: self)
         broadcaster.register(BolusFailureObserver.self, observer: self)
-        broadcaster.register(pumpNotificationObserver.self, observer: self)
+        broadcaster.register(PumpNotificationObserver.self, observer: self)
 
         requestNotificationPermissionsIfNeeded()
         sendGlucoseNotification()
@@ -444,7 +444,7 @@ extension BaseUserNotificationsManager: GlucoseObserver {
     }
 }
 
-extension BaseUserNotificationsManager: pumpNotificationObserver {
+extension BaseUserNotificationsManager: PumpNotificationObserver {
     func pumpNotification(alert: AlertEntry) {
         ensureCanSendNotification {
             let content = UNMutableNotificationContent()


### PR DESCRIPTION
* AlertHistoryStorage minor refactoring
* DeviceDataManager - cleanup
* moved more pump-specific code into KnownPlugins
* simplified alert acknowledgement (don't rely on completion callback)
* delivery uncertainty message in pump config view

---
* the whole `PersistedAlertStore` protocol - it's supposed to be used by plugins to query the "storage" about existing alerts, but none of the methods are used in any of the pumps, so we just don't do anything there (same as before the `plugins` branch)
* detectedSystemTimeOffset - we're supposed to report the offset to the pump manager, and loop does have an implementation - but none of the pump managers is using it, we are returning `0` (same as before `plugins`)
* removed the whole `reportPluginInitializationComplete` thing (which I initially "copied" from Loop) - Loop notifies plugins when other plugins activate, but this has no effect on pumps/cgms
* Loop watches the `pumpManager.status.deliveryIsUncertain` and when true - it presents the view returned from `pumpManager.deliveryUncertaintyRecoveryViewController` in an alert; all pump managers just show the standard "pump settings" view; in our case - I added a message to the pump config root view when uncertain delivery is detected; and I'm not sure how to test/trigger it

the rest of the changes are just removing comments and minor tweaks/refactorings 