### PR TITLE
Fix for iOS 26

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -380,7 +380,7 @@ extension Home {
                 }
             }
             .confirmationDialog("Bolus already in Progress", isPresented: $showBolusActiveAlert) {
-                Button("Bolus already in Progress!", role: .cancel) {
+                Button("Bolus already in Progress!", role: .destructive) {
                     showBolusActiveAlert = false
                 }
             }


### PR DESCRIPTION
Resolves the bolus in progress alert confirmation pop-up not displaying properly with iOS 26 