### PR TITLE
remove 1-minute developer toggles until 1-minute readings are available

### DIFF
--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -133,7 +133,6 @@ struct FreeAPSSettings: JSON, Equatable {
     var ketoProtectAbsolut: Bool = false
     var ketoProtectBasalAbsolut: Decimal = 0
     // 1-min loops
-    var allowOneMinuteReadings: Bool = false // allow 1-minute readings from libre sensors
     var allowOneMinuteLoop: Bool = false // allow running loops every minute
     var allowOneMinuteGlucose: Bool = false // allow sending 1-minute readings to oref, even if loops are with 5-minute intervals
 }
@@ -653,9 +652,6 @@ extension FreeAPSSettings: Decodable {
         }
 
         // 1-minute loops
-        if let allowOneMinuteReadings = try? container.decode(Bool.self, forKey: .allowOneMinuteReadings) {
-            settings.allowOneMinuteReadings = allowOneMinuteReadings
-        }
         if let allowOneMinuteLoop = try? container.decode(Bool.self, forKey: .allowOneMinuteLoop) {
             settings.allowOneMinuteLoop = allowOneMinuteLoop
         }

--- a/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
@@ -13,7 +13,6 @@ extension Settings {
         @Published var allowDilution = false
         @Published var extended_overrides = false
         @Published var noCarbs = false
-        @Published var allowOneMinuteReadings = false
         @Published var allowOneMinuteLoop = false
         @Published var allowOneMinuteGlucose = false
 
@@ -30,7 +29,6 @@ extension Settings {
             subscribeSetting(\.allowDilution, on: $allowDilution) { allowDilution = $0 }
             subscribeSetting(\.extended_overrides, on: $extended_overrides) { extended_overrides = $0 }
             subscribeSetting(\.noCarbs, on: $noCarbs) { noCarbs = $0 }
-            subscribeSetting(\.allowOneMinuteReadings, on: $allowOneMinuteReadings) { allowOneMinuteReadings = $0 }
             subscribeSetting(\.allowOneMinuteLoop, on: $allowOneMinuteLoop) { allowOneMinuteLoop = $0 }
             subscribeSetting(\.allowOneMinuteGlucose, on: $allowOneMinuteGlucose) { allowOneMinuteGlucose = $0 }
 

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -136,14 +136,6 @@ extension Settings {
                                 HStack {
                                     Toggle("Max Override 400%", isOn: $state.extended_overrides)
                                 }
-                                if state.allowOneMinuteReadings {
-                                    HStack {
-                                        Toggle("Allow 1-minute loops", isOn: $state.allowOneMinuteLoop)
-                                    }
-                                    HStack {
-                                        Toggle("Allow 1-minute glucose", isOn: $state.allowOneMinuteGlucose)
-                                    }
-                                }
                             }
                             Group {
                                 Text("Preferences")


### PR DESCRIPTION
Removing developer settings related to "1-minute" glucose readings from UI for now.