### PR TITLE
revert the accidental change to contact image size, display a message when pump setup is incomplete

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -276,8 +276,13 @@ final class BaseDeviceDataManager: Injectable, DeviceDataManager {
     }
 
     private func updatePumpData(completion: @escaping () -> Void) {
-        guard let pumpManager = pumpManager, pumpManager.isOnboarded else {
+        guard let pumpManager = pumpManager else {
             debug(.deviceManager, "Pump is not set, skip updating")
+            completion()
+            return
+        }
+        guard pumpManager.isOnboarded else {
+            debug(.deviceManager, "Pump is not onboarded, skip updating")
             completion()
             return
         }

--- a/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
@@ -30,6 +30,11 @@ extension PumpConfig {
                             }
                         }
                         Section {
+                            if !pumpManager.isOnboarded {
+                                HStack {
+                                    Text("Pump setup incomplete").foregroundColor(.red)
+                                }
+                            }
                             if let status = pumpManager.pumpStatusHighlight?.localizedMessage {
                                 HStack {
                                     Text(status.replacingOccurrences(of: "\n", with: " "))

--- a/FreeAPS/Sources/Services/ContactTrick/ContactPicture.swift
+++ b/FreeAPS/Sources/Services/ContactTrick/ContactPicture.swift
@@ -19,8 +19,8 @@ struct ContactPicture: View {
         contact: ContactTrickEntry,
         state: ContactTrickState
     ) -> UIImage {
-        let width = 256.0
-        let height = 256.0
+        let width = 1024.0
+        let height = 1024.0
         var rect = CGRect(x: 0, y: 0, width: width, height: height)
         let textColor: Color = contact.darkMode ?
             Color(red: 250 / 256, green: 250 / 256, blue: 250 / 256) :


### PR DESCRIPTION
At some point I accidentally committed a change to the contact image size 1024px -> 256px. Reverting that change here.
Also adding a message to the pump settings screen when the pump manager reports `isOnboarded=false`.