### PR TITLE
fix pump manager onboarding

### DIFF
--- a/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
@@ -14,7 +14,7 @@ extension PumpConfig {
         var body: some View {
             NavigationView {
                 Form {
-                    if let pumpManager = state.deviceManager.pumpManager {
+                    if let pumpManager = state.deviceManager.pumpManager, pumpManager.isOnboarded {
                         Section(header: Text("Model")) {
                             Button {
                                 state.setupPump(pumpManager.pluginIdentifier)
@@ -30,11 +30,6 @@ extension PumpConfig {
                             }
                         }
                         Section {
-                            if !pumpManager.isOnboarded {
-                                HStack {
-                                    Text("Pump setup incomplete").foregroundColor(.red)
-                                }
-                            }
                             if let status = pumpManager.pumpStatusHighlight?.localizedMessage {
                                 HStack {
                                     Text(status.replacingOccurrences(of: "\n", with: " "))
@@ -67,7 +62,7 @@ extension PumpConfig {
                 .navigationBarTitleDisplayMode(.inline)
                 .sheet(isPresented: $state.pumpSetupPresented) {
                     if let pumpIdentifier = state.pumpIdentifierToSetUp {
-                        if let pumpManager = state.deviceManager.pumpManager {
+                        if let pumpManager = state.deviceManager.pumpManager, pumpManager.isOnboarded {
                             PumpSettingsView(
                                 pumpManager: pumpManager,
                                 deviceManager: state.deviceManager,


### PR DESCRIPTION
The bug manifested as follows:

* a user starts on-boarding a pump 
* after the initial couple of steps, the pump manager calls the `pumpManagerOnboarding(didCreatePumpManager)` callback
* `DeviceDataManager` stores the newly created `pumpManager`
* the `PumpConfigRootView` immediately switches from the pump setup UI to the pump settings UI:
  * `if let pumpManager = state.deviceManager.pumpManager { showSettings } else { showSetup }`
* this was preventing the pump manager from guiding the user through the remaining steps, and the `pumpManager` never becomes fully onboarded.

This PR fixes the problem.