### PR TITLE
add the cgm manager to glucose unit observers

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -976,6 +976,10 @@ private extension BaseDeviceDataManager {
 
         appCoordinator.setShouldUploadGlucose(cgmManager?.shouldSyncToRemoteService ?? false)
         appCoordinator.setSensorDays(KnownPlugins.cgmExpirationByPluginIdentifier(cgmManager))
+
+        if let cgmManagerUI = cgmManager as? CGMManagerUI {
+            addDisplayGlucoseUnitObserver(cgmManagerUI)
+        }
     }
 
     func setupPump() {


### PR DESCRIPTION
All the supporting code is there, and CGM manager is removed from the observers when deactivated. But I forgot to add it to the list of observers to begin with.