### PR TITLE
set the `unfiltered` field for manual glucose records

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -378,6 +378,8 @@ extension Bolus {
                 sgv: Int(glucose),
                 date: Decimal(now.timeIntervalSince1970) * 1000,
                 dateString: now,
+                unfiltered: glucose,
+                uncalibrated: glucose,
                 glucose: Int(glucose),
                 type: GlucoseType.manual.rawValue
             )

--- a/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
@@ -191,6 +191,8 @@ extension DataTable {
                 sgv: Int(glucose),
                 date: Decimal(now.timeIntervalSince1970) * 1000,
                 dateString: now,
+                unfiltered: glucose,
+                uncalibrated: glucose,
                 glucose: Int(glucose),
                 type: GlucoseType.manual.rawValue
             )


### PR DESCRIPTION
otherwise it's not displayed on the home screen if it's the latest

(also setting `uncalibrated` for consistency)