### PR TITLE
pump-related improvements

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -994,7 +994,7 @@ private extension BaseDeviceDataManager {
             pumpDisplayState.value = PumpDisplayState(name: pumpManager.localizedTitle, image: pumpManager.smallImage)
             pumpManagerStatus.value = pumpManager.status
             pumpName.send(pumpManager.localizedTitle)
-            pumpExpiresAtDate.send(KnownPlugins.pumpExpiration(pumpManager: pumpManager))
+            pumpExpiresAtDate.send(KnownPlugins.pumpExpirationDate(pumpManager))
         } else {
             pumpDisplayState.value = nil
             pumpManagerStatus.value = nil

--- a/FreeAPS/Sources/APS/KnownPlugins.swift
+++ b/FreeAPS/Sources/APS/KnownPlugins.swift
@@ -36,17 +36,6 @@ enum KnownPlugins {
         }
     }
 
-    static func pumpExpiration(pumpManager: PumpManager) -> Date? {
-        switch pumpManager.pluginIdentifier {
-        case OmnipodPumpManager.pluginIdentifier:
-            return (pumpManager as? OmnipodPumpManager)?.state.podState?.expiresAt
-        case OmniBLEPumpManager.pluginIdentifier:
-            return (pumpManager as? OmniBLEPumpManager)?.state.podState?.expiresAt
-        default:
-            return nil
-        }
-    }
-
     static func sessionStart(cgmManager: CGMManager) -> Date? {
         switch cgmManager.pluginIdentifier {
         case G5CGMManager.pluginIdentifier:
@@ -158,6 +147,9 @@ enum KnownPlugins {
                 .reservoirLevel ?? 0xDEAD_BEEF
             // TODO: find the value Pod.maximumReservoirReading
             let reservoir = Decimal(reservoirVal) > 50.0 ? 0xDEAD_BEEF : reservoirVal
+            return Decimal(reservoir)
+        case MedtrumPumpManager.pluginIdentifier:
+            guard let reservoir = (pumpManager as? MedtrumPumpManager)?.state.reservoir else { return nil }
             return Decimal(reservoir)
         default: return nil
         }

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -3295,3 +3295,6 @@ Enact a temp Basal or a temp target */
 
 /* message displayed in pump settings screen when the pump manager reports uncertain delivery */
 "Pump delivery uncertain" = "Pump delivery uncertain";
+
+/* message displayed on home screen when the pump is added but not fully onboarded */
+"Re-connect pump!" = "Re-connect pump!";

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import CoreData
 import LibreTransmitter
+import LoopKit
 import LoopKitUI
 import SwiftDate
 import SwiftUI
@@ -9,6 +10,7 @@ extension Home {
     final class StateModel: BaseStateModel<Provider> {
         @Injected() var broadcaster: Broadcaster!
         @Injected() var appCoordinator: AppCoordinator!
+        @Injected() var deviceDataManager: DeviceDataManager!
         @Injected() var apsManager: APSManager!
         @Injected() var nightscoutManager: NightscoutManager!
         @Injected() var storage: TempTargetsStorage!
@@ -305,12 +307,17 @@ extension Home {
                     guard let self = self else { return }
                     if show, let pumpManager = self.provider.deviceManager.pumpManager
                     {
-                        let view = PumpConfig.PumpSettingsView(
-                            pumpManager: pumpManager,
-                            deviceManager: self.provider.deviceManager,
-                            completionDelegate: self,
-                        ).asAny()
-                        self.router.mainSecondaryModalView.send(view)
+                        if pumpManager.isOnboarded {
+                            let view = PumpConfig.PumpSettingsView(
+                                pumpManager: pumpManager,
+                                deviceManager: self.provider.deviceManager,
+                                completionDelegate: self,
+                            ).asAny()
+                            self.router.mainSecondaryModalView.send(view)
+                        } else {
+                            self.router.mainSecondaryModalView.send(nil)
+                            showModal(for: .pumpConfig)
+                        }
                     } else {
                         self.router.mainSecondaryModalView.send(nil)
                     }

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -47,150 +47,157 @@ struct PumpView: View {
         // let sim = state.pumpName.contains("Simulator") // Just For Testing
         HStack(spacing: 5) {
             // OmniPods and Medtrum nanos
-            if let date = expiresAtDate {
-                // Insulin amount (U)
-                if let insulin = reservoir {
-                    // 120 % due to being non rectangular. +10 because of bottom inserter
-                    let amountFraction = 1.0 - (Double(insulin + 10) * 1.2 / 200)
-                    if insulin == 0xDEAD_BEEF {
-                        if nano {
-                            medtrumInsulinAmount(portion: amountFraction)
-                                .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
-                                .overlay {
-                                    if let timeZone = timeZone,
-                                       timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
-                                    {
-                                        ClockOffset(mdtPump: false)
+            if let pumpManager = state.deviceDataManager.pumpManager,
+               !pumpManager.isOnboarded
+            {
+                Text("Re-connect pump!").font(.statusFont).foregroundStyle(.red)
+                    .offset(y: -4)
+            } else {
+                if let date = expiresAtDate {
+                    // Insulin amount (U)
+                    if let insulin = reservoir {
+                        // 120 % due to being non rectangular. +10 because of bottom inserter
+                        let amountFraction = 1.0 - (Double(insulin + 10) * 1.2 / 200)
+                        if insulin == 0xDEAD_BEEF {
+                            if nano {
+                                medtrumInsulinAmount(portion: amountFraction)
+                                    .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
+                                    .overlay {
+                                        if let timeZone = timeZone,
+                                           timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
+                                        {
+                                            ClockOffset(mdtPump: false)
+                                        }
+                                        if (concentration.last?.concentration ?? 1) != 1,
+                                           !state.settingsManager.settings
+                                           .hideInsulinBadge
+                                        {
+                                            NonStandardInsulin(
+                                                concentration: concentration.last?.concentration ?? 1,
+                                                pump: .medtrum
+                                            )
+                                        }
                                     }
-                                    if (concentration.last?.concentration ?? 1) != 1,
-                                       !state.settingsManager.settings
-                                       .hideInsulinBadge
-                                    {
-                                        NonStandardInsulin(
-                                            concentration: concentration.last?.concentration ?? 1,
-                                            pump: .medtrum
-                                        )
+                            } else {
+                                podInsulinAmount(portion: amountFraction)
+                                    .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
+                                    .overlay {
+                                        if let timeZone = timeZone,
+                                           timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
+                                        {
+                                            ClockOffset(mdtPump: false)
+                                        }
+                                        if (concentration.last?.concentration ?? 1) != 1,
+                                           !state.settingsManager.settings
+                                           .hideInsulinBadge
+                                        {
+                                            NonStandardInsulin(concentration: concentration.last?.concentration ?? 1, pump: .pod)
+                                        }
                                     }
-                                }
+                            }
                         } else {
-                            podInsulinAmount(portion: amountFraction)
-                                .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
-                                .overlay {
-                                    if let timeZone = timeZone,
-                                       timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
-                                    {
-                                        ClockOffset(mdtPump: false)
-                                    }
-                                    if (concentration.last?.concentration ?? 1) != 1,
-                                       !state.settingsManager.settings
-                                       .hideInsulinBadge
-                                    {
-                                        NonStandardInsulin(concentration: concentration.last?.concentration ?? 1, pump: .pod)
-                                    }
+                            HStack(spacing: 0) {
+                                let amount: Decimal = (insulin * Decimal(concentration.last?.concentration ?? 1))
+                                if !(nano && amount > 100) {
+                                    Text(reservoirFormatter.string(from: amount as NSNumber) ?? "")
+                                    Text("U").foregroundStyle(.secondary)
                                 }
+                            }.offset(x: 6)
+                            if nano {
+                                medtrumInsulinAmount(portion: amountFraction)
+                                    .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
+                                    .overlay {
+                                        if let timeZone = timeZone,
+                                           timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
+                                        {
+                                            ClockOffset(mdtPump: false)
+                                        }
+                                        if (concentration.last?.concentration ?? 1) != 1,
+                                           !state.settingsManager.settings.hideInsulinBadge
+                                        {
+                                            NonStandardInsulin(
+                                                concentration: concentration.last?.concentration ?? 1,
+                                                pump: .medtrum
+                                            )
+                                        }
+                                    }
+                            } else {
+                                podInsulinAmount(portion: amountFraction)
+                                    .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
+                                    .overlay {
+                                        if let timeZone = timeZone,
+                                           timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
+                                        {
+                                            ClockOffset(mdtPump: false)
+                                        }
+                                        if (concentration.last?.concentration ?? 1) != 1,
+                                           !state.settingsManager.settings.hideInsulinBadge
+                                        {
+                                            NonStandardInsulin(concentration: concentration.last?.concentration ?? 1, pump: .pod)
+                                        }
+                                    }
+                            }
                         }
+                    }
+                    remainingTime(time: date.timeIntervalSince(timerDate))
+                        .font(.pumpFont)
+                        .offset(x: nano ? -7 : -5)
+                } else if state.pumpName.contains("Omni") {
+                    Text("No Pod").font(.statusFont).foregroundStyle(.secondary)
+                        .offset(y: -4)
+                } else if nano {
+                    Text("No Patch").font(.statusFont).foregroundStyle(.secondary)
+                        .offset(y: -4)
+                }
+                // Other pumps
+                else if let reservoir = reservoir {
+                    if (concentration.last?.concentration ?? 1) != 1, !state.settingsManager.settings.hideInsulinBadge {
+                        NonStandardInsulin(concentration: concentration.last?.concentration ?? 1, pump: .other)
+                    }
+                    let amountFraction = 1.0 - (Double(reservoir + 10) * 1.2 / 200)
+
+                    if reservoir == 0xDEAD_BEEF {
+                        pumpInsulinAmount(portion: amountFraction)
+                            .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
+                            .overlay {
+                                if let timeZone = timeZone, timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT() {
+                                    ClockOffset(mdtPump: true)
+                                }
+                            }.offset(y: expiresAtDate == nil ? -4 : 0)
                     } else {
                         HStack(spacing: 0) {
-                            let amount: Decimal = (insulin * Decimal(concentration.last?.concentration ?? 1))
-                            if !(nano && amount > 100) {
-                                Text(reservoirFormatter.string(from: amount as NSNumber) ?? "")
-                                Text("U").foregroundStyle(.secondary)
-                            }
-                        }.offset(x: 6)
-                        if nano {
-                            medtrumInsulinAmount(portion: amountFraction)
-                                .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
-                                .overlay {
-                                    if let timeZone = timeZone,
-                                       timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
-                                    {
-                                        ClockOffset(mdtPump: false)
-                                    }
-                                    if (concentration.last?.concentration ?? 1) != 1,
-                                       !state.settingsManager.settings.hideInsulinBadge
-                                    {
-                                        NonStandardInsulin(
-                                            concentration: concentration.last?.concentration ?? 1,
-                                            pump: .medtrum
-                                        )
-                                    }
-                                }
-                        } else {
-                            podInsulinAmount(portion: amountFraction)
-                                .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
-                                .overlay {
-                                    if let timeZone = timeZone,
-                                       timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT()
-                                    {
-                                        ClockOffset(mdtPump: false)
-                                    }
-                                    if (concentration.last?.concentration ?? 1) != 1,
-                                       !state.settingsManager.settings.hideInsulinBadge
-                                    {
-                                        NonStandardInsulin(concentration: concentration.last?.concentration ?? 1, pump: .pod)
-                                    }
-                                }
+                            Text(
+                                reservoirFormatter
+                                    .string(from: (reservoir * Decimal(concentration.last?.concentration ?? 1)) as NSNumber) ?? ""
+                            ).font(.statusFont)
+                            Text("U").font(.statusFont).foregroundStyle(.secondary)
                         }
-                    }
-                }
-                remainingTime(time: date.timeIntervalSince(timerDate))
-                    .font(.pumpFont)
-                    .offset(x: nano ? -7 : -5)
-            } else if state.pumpName.contains("Omni") {
-                Text("No Pod").font(.statusFont).foregroundStyle(.secondary)
-                    .offset(y: -4)
-            } else if nano {
-                Text("No Patch").font(.statusFont).foregroundStyle(.secondary)
-                    .offset(y: -4)
-            }
-            // Other pumps
-            else if let reservoir = reservoir {
-                if (concentration.last?.concentration ?? 1) != 1, !state.settingsManager.settings.hideInsulinBadge {
-                    NonStandardInsulin(concentration: concentration.last?.concentration ?? 1, pump: .other)
-                }
-                let amountFraction = 1.0 - (Double(reservoir + 10) * 1.2 / 200)
-
-                if reservoir == 0xDEAD_BEEF {
-                    pumpInsulinAmount(portion: amountFraction)
-                        .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
-                        .overlay {
-                            if let timeZone = timeZone, timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT() {
-                                ClockOffset(mdtPump: true)
+                        .offset(y: 7)
+                        pumpInsulinAmount(portion: amountFraction)
+                            .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
+                            .overlay {
+                                if let timeZone = timeZone, timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT() {
+                                    ClockOffset(mdtPump: false)
+                                }
                             }
-                        }.offset(y: expiresAtDate == nil ? -4 : 0)
+                    }
                 } else {
-                    HStack(spacing: 0) {
-                        Text(
-                            reservoirFormatter
-                                .string(from: (reservoir * Decimal(concentration.last?.concentration ?? 1)) as NSNumber) ?? ""
-                        ).font(.statusFont)
-                        Text("U").font(.statusFont).foregroundStyle(.secondary)
-                    }
-                    .offset(y: 7)
-                    pumpInsulinAmount(portion: amountFraction)
-                        .padding(.leading, (concentration.last?.concentration ?? 1) != 1 ? 7 : 0)
-                        .overlay {
-                            if let timeZone = timeZone, timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT() {
-                                ClockOffset(mdtPump: false)
-                            }
-                        }
+                    Text("No Pump").font(.statusFont).foregroundStyle(.secondary)
+                        .offset(y: -4)
                 }
-            } else {
-                Text("No Pump").font(.statusFont).foregroundStyle(.secondary)
-                    .offset(y: -4)
-            }
 
-            // MDT and Dana
-            if let battery = battery, !state.pumpName.contains("Omni"), !nano {
-                let percent = (battery.percent ?? 100) > 80 ? 100 : (battery.percent ?? 100) < 81 &&
-                    (battery.percent ?? 100) >
-                    60 ? 75 : (battery.percent ?? 100) < 61 && (battery.percent ?? 100) > 40 ? 50 : 25
-                Image(systemName: "battery.\(percent)")
-                    .resizable()
-                    .rotationEffect(.degrees(-90))
-                    .frame(maxWidth: 32, maxHeight: 12)
-                    .foregroundColor(batteryColor)
-                    .offset(x: -5, y: -0.7)
+                // MDT and Dana
+                if let battery = battery, !state.pumpName.contains("Omni"), !nano {
+                    let percent = (battery.percent ?? 100) > 80 ? 100 : (battery.percent ?? 100) < 81 &&
+                        (battery.percent ?? 100) >
+                        60 ? 75 : (battery.percent ?? 100) < 61 && (battery.percent ?? 100) > 40 ? 50 : 25
+                    Image(systemName: "battery.\(percent)")
+                        .resizable()
+                        .rotationEffect(.degrees(-90))
+                        .frame(maxWidth: 32, maxHeight: 12)
+                        .foregroundColor(batteryColor)
+                        .offset(x: -5, y: -0.7)
+                }
             }
         }
         .offset(x: (nano && expiresAtDate != nil) ? 5 : 0, y: (nano && expiresAtDate != nil) ? 10 : 5)


### PR DESCRIPTION
* when a pump is not fully unboarded - show a "Re-connect pump!" message on the home screen

This seems to be a frequent issue with Medtronic pumps. After update to 8.0.0, the pump connection will be preserved, but it looks like the old Medtronic pump manager was not setting the "isOnboarded" flag in its state.

We didn't have a check for this condition on the home screen, so it would appear to the user like the pump is connected. But not everything would work - iAPS wouldn't try to refresh the state of the pump (reservoir, etc).

Now we will show the `Re-connect pump!` red message, tapping on it will open the pump selection screen.

<details>
  <summary>Testing</summary>

  * start adding a Minimed pump (in simulator),
  * finish the step where you enter the region and pump ID, tap `Connect` and then `Continue`,
  * but don't complete the `Pump clock` screen - swipe down the whole modal (not the `Cancel` button),
  * return to home screen,
  * the `Re-connect pump!` message should be displayed, 
  * tapping it should open the pump selection screen.
</details>

---

Additionally:
* remove the duplicate `KnownPlugins.pumpExpiration` function
* add Medtrum to known plugins - when reading reservoir