### PR TITLE
fix for users with non-zero-minute local timezones (UTC+10:30, etc)

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -1899,7 +1899,7 @@ extension MainChartView {
 
     private func firstHourDate() -> Date {
         let firstDate = Date().addingTimeInterval(-1.days.timeInterval)
-        return firstDate.dateTruncated(from: .minute)!
+        return DateInRegion(firstDate, region: .current).dateTruncated(from: .minute)!.date
     }
 
     private func firstHourPosition(viewWidth: CGFloat) -> CGFloat {


### PR DESCRIPTION
the main chart was offsetting all dates (visually) by the minutes from the timezone offset

this is because the convenience function .dateTruncated(from: .minute) trunacates the date using the GMT timezone, thus firstHourDate becomes offset, which leads to everything else to become offset

changed it to explicitly use DateInRegion with .current timezone instead