### PR TITLE
don't scroll the main chart when the app activates

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -126,12 +126,13 @@ struct MainChartView: View {
             .onChange(of: scenePhase) {
                 switch scenePhase {
                 case .active:
-                    shouldScrollAfterUpdate = true
                     subscribeToUpdates()
                     updateRequests.send(())
                 case .background,
                      .inactive:
                     unsubscribeFromUpdates()
+                @unknown default:
+                    print("unknown scene phase: \(scenePhase)")
                 }
             }
         }
@@ -146,7 +147,6 @@ struct MainChartView: View {
 
         let geom = CalculatedGeometries.make(fullSize: fullSize, data: data)
 
-        // TODO: remove this
         let ended = Date.now
         debug(
             .service,


### PR DESCRIPTION
Removing the "scroll to end" when the app comes back from background. The scroll stays where the user left it.

https://github.com/user-attachments/assets/2ea1057b-25f1-4e7b-94f9-6a2f0d977f73

