### PR TITLE
device manager - do not sync pump when a loop is in progress

### DIFF
--- a/FreeAPS/Sources/APS/AppCoordinator.swift
+++ b/FreeAPS/Sources/APS/AppCoordinator.swift
@@ -7,6 +7,8 @@ final class AppCoordinator {
     @Published private(set) var shouldUploadGlucose: Bool = false
     @Published private(set) var sensorDays: Double? = nil
 
+    let isLooping = CurrentValueSubject<Bool, Never>(false)
+
     var heartbeat: AnyPublisher<Void, Never> {
         _heartbeat.eraseToAnyPublisher()
     }

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -504,6 +504,13 @@ final class BaseDeviceDataManager: Injectable, DeviceDataManager {
         // storeNewBloodGlucose runs in queue.async with callback so that we don't block the CGM manager
         bloodGlucoseManager.storeNewBloodGlucose(bloodGlucose: bloodGlucose) { newGlucoseStored in
             if newGlucoseStored || forceRecommendLoop {
+                guard !self.appCoordinator.isLooping.value else {
+                    debug(
+                        .deviceManager,
+                        "new glucose saved, but the loop is already in progress - skipping pump sync and loop recommendation"
+                    )
+                    return
+                }
                 self.processQueue.safeSync {
                     self.updatePumpData {
                         self._recommendsLoop.send(())

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -263,7 +263,7 @@ extension Home {
                 }
             }
 
-            apsManager.isLooping
+            appCoordinator.isLooping
                 .receive(on: DispatchQueue.main)
                 .weakAssign(to: \.isLooping, on: self)
                 .store(in: &lifetime)


### PR DESCRIPTION
It looks like G7 can provide glucose readings soon after the previous one, but not within 1 second that we reserve for "wait for backfill", causing "stuck loops" with (at least) Dana pumps (because iAPS tries to sync pump data while another command is in progress).

This PR is to prevent pump synchronization and loop recommendation if another loop is already in progress.

(moved `isLooping` from `APSManager` to `AppCoordinator` because `DeviceDataManager` now needs access to it as well)