### PR TITLE
Watch update

### DIFF
--- a/FreeAPSWatch WatchKit Extension/Views/CarbsView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/CarbsView.swift
@@ -39,7 +39,7 @@ struct CarbsView: View {
             }
             buttonStack
         }
-        .onAppear { carbAmount = Double(state.carbsRequired ?? 0) }
+       // .onAppear { carbAmount = Double(state.carbsRequired ?? 0) }
     }
 
     var nutrient: some View {


### PR DESCRIPTION
Never replace carb amount with carbs required. The carbs required need a different workflow and presentation.

Resolves issue https://github.com/Artificial-Pancreas/iAPS/issues/1795
