### PR TITLE
fix: restore dedup guard for CGM sensor start treatments to prevent Nightscout flooding

### DIFF
--- a/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
@@ -99,6 +99,21 @@ final class BaseGlucoseStorage: GlucoseStorage, Injectable {
                         notes = "\(notes) activated on \(a)"
                     }
 
+                    let sessionStartDate = sensorSessionStart.sessionStartDate
+                    // When a new Dexcom sensor is started, it produces multiple consecutive
+                    // startDates with sub-second jitter due to activationDate being recomputed
+                    // from the BLE clock on every session. Only append if no existing entry
+                    // is within 60 seconds of this one, to avoid flooding Nightscout with
+                    // thousands of duplicate "Sensor Start" treatments.
+                    // See: https://github.com/Artificial-Pancreas/iAPS/issues/XXXX
+                    if let lastTreatment = treatments.last,
+                       let lastCreatedAt = lastTreatment.createdAt,
+                       let sessionStart = sessionStartDate,
+                       abs(lastCreatedAt.timeIntervalSince(sessionStart)) < 60
+                    {
+                        return
+                    }
+
                     let treatment = NigtscoutTreatment(
                         duration: nil,
                         rawDuration: nil,
@@ -106,7 +121,7 @@ final class BaseGlucoseStorage: GlucoseStorage, Injectable {
                         absolute: nil,
                         rate: nil,
                         eventType: .nsSensorChange,
-                        createdAt: sensorSessionStart.sessionStartDate,
+                        createdAt: sessionStartDate,
                         enteredBy: NigtscoutTreatment.local,
                         bolus: nil,
                         insulin: nil,


### PR DESCRIPTION
Fixes #1806

## Problem

Since v8.0.0 (`e5db2c9`), users with Nightscout upload enabled experience periodic floods of thousands of duplicate **"Sensor Start"** treatments posted to Nightscout within seconds — observable via `GET /api/v1/treatments.json?find[eventType]=Sensor%20Start`.

See issue #1806 for full details, timeline, and real Nightscout data demonstrating the regression.

## Root cause

`GlucoseStorage.storeNewBloodGlucose` appends a new `NigtscoutTreatment` to `cgm-state.json` on **every** glucose reading that carries a `sessionStartDate`:

```swift
treatments.append(treatment)  // no existence check
```

The `sessionStartDate` is derived from `activationDate`, which CGMBLEKit recomputes from the BLE clock on each 5-minute session:

```swift
// CGMBLEKit/Transmitter.swift
activationDate = Date(timeIntervalSinceNow: -TimeInterval(time.currentTime))
```

Because `currentTime` is a whole-second integer and `Date()` has sub-second precision, successive readings produce dates with millisecond-level jitter. The `Set`-based deduplication in `nightscoutCGMStateNotUploaded()` relies on `NigtscoutTreatment.==` (which compares `createdAt` exactly), so it never recognises these near-identical entries as duplicates.

Over a 10-day G6 sensor lifetime this accumulates ~2880 entries. At each sensor change, all of them are treated as not-yet-uploaded and bulk-POSTed to Nightscout in a single burst.

## History

This exact guard existed in v5–v7 with an explanatory comment:

```swift
// When a new Dexcom sensor is started, it produces multiple consecutive
// startDates. Disambiguate them by only allowing a session start per minute.
if let lastTreatment = treatments.last,
   let createdAt = lastTreatment.createdAt,
   abs(createdAt.timeIntervalSince(sessionStartDate)) < TimeInterval(60)
{
    continue
}
```

It was accidentally dropped during the v8.0.0 refactor of `GlucoseStorage`.

## Fix

Restore the guard before appending to `cgm-state.json`: skip the append if the most recent stored treatment already has a `createdAt` within 60 seconds of the incoming `sessionStartDate`.

## Testing

Verify via Nightscout API that only one "Sensor Start" treatment is created per sensor session, spaced ~10 days apart, rather than thousands per session.