### PR TITLE
I've added an FDDB-Extender-Importer to IAPS

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -319,6 +319,7 @@
 		45717281F743594AA9D87191 /* ConfigEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 920DDB21E5D0EB813197500D /* ConfigEditorRootView.swift */; };
 		5075C1608E6249A51495C422 /* TargetsEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BDEA2DC60EDE0A3CA54DC73 /* TargetsEditorProvider.swift */; };
 		53F2382465BF74DB1A967C8B /* PumpConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8630D58BDAD6D9C650B9B39 /* PumpConfigProvider.swift */; };
+		55CBBCED2F77208C00B34829 /* FddbExtenderImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55CBBCEC2F77208C00B34829 /* FddbExtenderImporter.swift */; };
 		5BFA1C2208114643B77F8CEB /* AddTempTargetProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE53A13D26F101B332EFFC8 /* AddTempTargetProvider.swift */; };
 		5D16287A969E64D18CE40E44 /* PumpConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F60E97100041040446F44E7 /* PumpConfigStateModel.swift */; };
 		63E890B4D951EAA91C071D5C /* BasalProfileEditorStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFF91130F2FCCC7EBBA11AD /* BasalProfileEditorStateModel.swift */; };
@@ -1010,6 +1011,7 @@
 		4DD795BA46B193644D48138C /* TargetsEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TargetsEditorRootView.swift; sourceTree = "<group>"; };
 		500371C09F54F89A97D65FDB /* CalibrationsRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalibrationsRootView.swift; sourceTree = "<group>"; };
 		505E09DC17A0C3D0AF4B66FE /* ISFEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorStateModel.swift; sourceTree = "<group>"; };
+		55CBBCEC2F77208C00B34829 /* FddbExtenderImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FddbExtenderImporter.swift; sourceTree = "<group>"; };
 		5B8A42073A2D03A278914448 /* AddTempTargetDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddTempTargetDataFlow.swift; sourceTree = "<group>"; };
 		5C018D1680307A31C9ED7120 /* CGMStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CGMStateModel.swift; sourceTree = "<group>"; };
 		5D5B4F8B4194BB7E260EF251 /* ConfigEditorStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorStateModel.swift; sourceTree = "<group>"; };
@@ -2492,6 +2494,7 @@
 				F2FA68932EEC87D200476D7B /* AIProgressView.swift */,
 				F2DCBC512F0B2DEB005D713E /* ManualNutritionOverrideEditor.swift */,
 				F2DCBC552F0B30A2005D713E /* ViewExtensions.swift */,
+				55CBBCEC2F77208C00B34829 /* FddbExtenderImporter.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -3729,6 +3732,7 @@
 				A6F097A14CAAE0CE0D11BE1B /* AddCarbsProvider.swift in Sources */,
 				33E198D3039045D98C3DC5D4 /* AddCarbsStateModel.swift in Sources */,
 				28089E07169488CF6DCC2A31 /* AddCarbsRootView.swift in Sources */,
+				55CBBCED2F77208C00B34829 /* FddbExtenderImporter.swift in Sources */,
 				D2165E9D78EFF692C1DED1C6 /* AddTempTargetDataFlow.swift in Sources */,
 				CE82E02728E869DF00473A9C /* AlertEntry.swift in Sources */,
 				38E4451E274DB04600EC9A94 /* AppDelegate.swift in Sources */,
@@ -4026,6 +4030,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_IDENTIFIER = "ru.artpancreas.$(DEVELOPMENT_TEAM).FreeAPS.diapi";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -4092,6 +4097,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				BUNDLE_IDENTIFIER = "ru.artpancreas.$(DEVELOPMENT_TEAM).FreeAPS.diapi";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -4161,7 +4167,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = $APP_BUILD_NUMBER;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4215,7 +4221,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = $APP_BUILD_NUMBER;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -4270,7 +4276,7 @@
 				CODE_SIGN_ENTITLEMENTS = "FreeAPSWatch WatchKit Extension/FreeAPSWatch WatchKit Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = $APP_BUILD_NUMBER;
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FreeAPSWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = iAPS;
@@ -4314,7 +4320,7 @@
 				CODE_SIGN_ENTITLEMENTS = "FreeAPSWatch WatchKit Extension/FreeAPSWatch WatchKit Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = $APP_BUILD_NUMBER;
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = FreeAPSWatch/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = iAPS;
@@ -4347,7 +4353,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				INFOPLIST_FILE = FreeAPSTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.3;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4368,7 +4374,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				INFOPLIST_FILE = FreeAPSTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.3;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4393,7 +4399,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -4427,7 +4433,7 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "$(DEVELOPER_TEAM)";
+				DEVELOPMENT_TEAM = C9RB6K683T;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -26,6 +26,15 @@ extension AddCarbs {
         // Food Search States
         @State private var showCancelConfirmation = false
 
+        @State private var showFddbImportSheet = false
+        @State private var fddbURLString: String = ""
+        @State private var fddbIsImporting = false
+        @State private var fddbErrorMessage: String? = nil
+        @State private var fddbImportInfo: String? = nil
+
+        // NOTE: We keep the import UI simple and manual on purpose (no deep-link handler).
+        // The importer normalizes values to per serving (1 portion) where possible.
+
         @FetchRequest(
             entity: Presets.entity(),
             sortDescriptors: [NSSortDescriptor(key: "dish", ascending: true)], predicate:
@@ -90,6 +99,7 @@ extension AddCarbs {
                 .onChange(of: foodSearchState.showSavedFoods) { syncDismissState() }
                 .onChange(of: carbPresets.count) { updateSavedFoods() }
                 .sheet(isPresented: $foodSearchState.showNewSavedFoodEntry) { foodItemEditorSheet }
+                .sheet(isPresented: $showFddbImportSheet) { fddbImportSheet }
         }
 
         @ViewBuilder private var content: some View {
@@ -137,6 +147,112 @@ extension AddCarbs {
             .presentationDragIndicator(.visible)
         }
 
+        @ViewBuilder private var fddbImportSheet: some View {
+            NavigationStack {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Import from FDDB")
+                        .font(.headline)
+                        .padding(.top, 8)
+
+                    Text(
+                        "Füge den FDDB-Share-Link ein (z. B. https://share.fddbextender.de/3975627). Wir lesen Name und Nährwerte und normalisieren auf eine Portion."
+                    )
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Share URL")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        HStack(spacing: 8) {
+                            TextField("https://share.fddbextender.de/...", text: $fddbURLString)
+                                .keyboardType(.URL)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled(true)
+                                .disabled(fddbIsImporting)
+                                .textFieldStyle(.roundedBorder)
+
+                            if !fddbURLString.isEmpty {
+                                Button(action: { fddbURLString = "" }) {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .foregroundColor(.secondary)
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(fddbIsImporting)
+                            }
+                        }
+                    }
+
+                    if let error = fddbErrorMessage {
+                        HStack(spacing: 8) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundColor(.orange)
+                            Text(error)
+                                .font(.footnote)
+                        }
+                        .padding(8)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(8)
+                    }
+                    if let info = fddbImportInfo {
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark.circle.fill")
+                                .foregroundColor(.green)
+                            Text(info)
+                                .font(.footnote)
+                        }
+                        .padding(8)
+                        .background(Color(.secondarySystemBackground))
+                        .cornerRadius(8)
+                    }
+
+                    Spacer(minLength: 0)
+
+                    HStack(spacing: 12) {
+                        Button("Cancel") {
+                            showFddbImportSheet = false
+                            fddbErrorMessage = nil
+                            fddbImportInfo = nil
+                            fddbURLString = ""
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.gray.opacity(0.2))
+                        .foregroundColor(.primary)
+                        .cornerRadius(10)
+
+                        Button(action: { performFddbImport() }) {
+                            HStack(spacing: 8) {
+                                if fddbIsImporting {
+                                    ProgressView()
+                                }
+                                Text("Import")
+                                    .fontWeight(.semibold)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(
+                            (!fddbURLString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !fddbIsImporting) ?
+                                Color.accentColor : Color.gray.opacity(0.2)
+                        )
+                        .foregroundColor((
+                            !fddbURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+                                .isEmpty && !fddbIsImporting
+                        ) ? .white : .secondary)
+                        .cornerRadius(10)
+                        .disabled(fddbURLString.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || fddbIsImporting)
+                    }
+                }
+                .padding()
+                .navigationTitle("FDDB Import")
+                .navigationBarTitleDisplayMode(.inline)
+            }
+            .presentationDetents([.height(260), .medium])
+            .presentationDragIndicator(.visible)
+        }
+
         private var hypoHandler: ((FoodItemDetailed, UIImage?, Date?) -> Void)? {
             guard state.id != nil,
                   state.id != "None",
@@ -157,12 +273,23 @@ extension AddCarbs {
 
         @ViewBuilder private var leadingNavItem: some View {
             if foodSearchState.showSavedFoods {
-                Button(action: {
-                    foodSearchState.showNewSavedFoodEntry = true
-                }) {
-                    Label("New", systemImage: "plus.circle.fill")
-                        .font(.body.weight(.semibold))
-                        .foregroundColor(.blue)
+                HStack(spacing: 12) {
+                    Button(action: {
+                        foodSearchState.showNewSavedFoodEntry = true
+                    }) {
+                        Label("New", systemImage: "plus.circle.fill")
+                            .font(.body.weight(.semibold))
+                            .foregroundColor(.blue)
+                    }
+
+                    Button(action: {
+                        // Open the FDDB import sheet where the user can paste a share link
+                        showFddbImportSheet = true
+                    }) {
+                        Label("Import", systemImage: "link.badge.plus")
+                            .font(.body.weight(.semibold))
+                            .foregroundColor(.blue)
+                    }
                 }
             }
         }
@@ -734,6 +861,102 @@ extension AddCarbs {
                         .disabled(disabled)
                 }
             }.environment(\.colorScheme, colorScheme)
+        }
+
+        /// Triggers the FDDB import flow: downloads the share page, parses it, and opens the Saved Food editor prefilled.
+        private func performFddbImport() {
+            let trimmed = fddbURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                fddbErrorMessage = NSLocalizedString("Bitte eine gültige FDDB-Share-URL eingeben.", comment: "")
+                return
+            }
+
+            fddbIsImporting = true
+            fddbErrorMessage = nil
+
+            Task {
+                do {
+                    // 1) Load + parse the FDDB share page
+                    let result = try await FddbExtenderImporter.importFrom(urlString: trimmed)
+
+                    // 2) Map to the app's FoodItemDetailed structure
+                    var values: [NutrientType: Decimal] = [:]
+                    if let c = result.carbs { values[.carbs] = max(0, c) }
+                    if let p = result.protein { values[.protein] = max(0, p) }
+                    if let f = result.fat { values[.fat] = max(0, f) }
+                    if let fi = result.fiber { values[.fiber] = max(0, fi) }
+                    if let su = result.sugars { values[.sugars] = max(0, su) }
+
+                    // Standard serving (if detected)
+                    let standardSize = result.standardServingSize
+                    let units: MealUnits? = {
+                        switch result.standardServingUnit {
+                        case .grams?: return .grams
+                        case .milliliters?: return .milliliters
+                        case nil: return nil
+                        }
+                    }()
+
+                    let importedItem: FoodItemDetailed
+                    switch result.mode {
+                    case .perServing:
+                        importedItem = FoodItemDetailed(
+                            name: result.name,
+                            nutrition: .perServing(values: values, servingsMultiplier: 1),
+                            standardServingSize: standardSize,
+                            units: units ?? .grams,
+                            source: .manual
+                        )
+
+                    case let .per100(unit):
+                        // If only per-100 is available, prefill the editor in per-100 mode.
+                        // Portion size defaults to 100 of the detected unit unless we have a clear standard serving size.
+                        let portionSize = standardSize ?? 100
+                        let portionUnits: MealUnits = (unit == .milliliters) ? .milliliters : .grams
+                        importedItem = FoodItemDetailed(
+                            name: result.name,
+                            nutrition: .per100(values: values, portionSize: portionSize),
+                            standardServingSize: standardSize,
+                            units: portionUnits,
+                            source: .manual
+                        )
+                    }
+
+                    // Show a short info banner about the detected mode before opening the editor
+                    let modeInfo: String = {
+                        switch result.mode {
+                        case .perServing:
+                            return NSLocalizedString("Erkannt: pro Portion", comment: "")
+                        case let .per100(unit):
+                            return unit == .milliliters ? NSLocalizedString("Erkannt: pro 100 ml", comment: "") :
+                                NSLocalizedString("Erkannt: pro 100 g", comment: "")
+                        }
+                    }()
+
+                    await MainActor.run { fddbImportInfo = modeInfo }
+                    try? await Task.sleep(nanoseconds: 700_000_000)
+
+                    await MainActor.run {
+                        // Close the import sheet first
+                        showFddbImportSheet = false
+                        fddbIsImporting = false
+
+                        // Open the Saved Food editor with prefilled values
+                        foodSearchState.newFoodEntryToEdit = importedItem
+                        foodSearchState.showNewSavedFoodEntry = true
+
+                        // Reset the form
+                        fddbURLString = ""
+                        fddbErrorMessage = nil
+                        fddbImportInfo = nil
+                    }
+                } catch {
+                    await MainActor.run {
+                        fddbIsImporting = false
+                        fddbErrorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                    }
+                }
+            }
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/FddbExtenderImporter.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/FddbExtenderImporter.swift
@@ -1,0 +1,661 @@
+import Foundation
+
+// MARK: - Public types
+
+/// Mode in which nutrition is expressed in the import result
+enum FddbResultMode: Equatable {
+    case perServing
+    case per100(unit: FddbUnit) // 100 g or 100 ml
+}
+
+/// Supported mass/volume units for serving sizes and per-100
+enum FddbUnit: String, Equatable {
+    case grams
+    case milliliters
+}
+
+/// Minimal nutrition payload for the editor
+/// - All macros can be nil if not available
+/// - `mode` determines whether values are per-serving or per-100
+/// - `standardServingSize` and `standardServingUnit` are set when reliably detected (e.g., "1 Portion = 250 ml")
+struct FddbImportResult: Equatable {
+    let name: String
+    let carbs: Decimal?
+    let protein: Decimal?
+    let fat: Decimal?
+    let calories: Decimal?
+    let fiber: Decimal?
+    let sugars: Decimal?
+
+    let mode: FddbResultMode
+    let standardServingSize: Decimal?
+    let standardServingUnit: FddbUnit?
+}
+
+// MARK: - Errors
+
+enum FddbImportError: Error, LocalizedError {
+    case unsupportedContent
+    case noParseableContent
+    case invalidURL
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedContent: return "Inhalt konnte nicht verarbeitet werden."
+        case .noParseableContent: return "Keine verwertbaren Nährwerte gefunden."
+        case .invalidURL: return "Ungültige FDDB-Share-URL."
+        }
+    }
+}
+
+// MARK: - Importer
+
+enum FddbExtenderImporter {
+    /// Public entry point. Accepts full share URL (e.g. https://share.fddbextender.de/3975627)
+    static func importFrom(urlString: String) async throws -> FddbImportResult {
+        guard let url = URL(string: urlString) else { throw FddbImportError.invalidURL }
+
+        // Download (headers improve compatibility with some CDNs)
+        let data = try await fetchData(url: url)
+
+        // 0) Some share endpoints may return JSON directly – try that first
+        if let parsed = parseDirectJSON(data: data) { return parsed }
+
+        // 1) Try parsing as text (UTF-8 first; fallback to ISO Latin-1)
+        let html = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .isoLatin1) ?? ""
+        guard !html.isEmpty else { throw FddbImportError.unsupportedContent }
+
+        // 2) Try multiple parse strategies in order
+        if let parsed = parseOgDescription(html: html) { return parsed }
+        if let parsed = parseJSONLD(html: html) { return parsed }
+        if let parsed = parseEmbeddedJSON(html: html) { return parsed }
+        if let parsed = parseHTMLLabels(html: html) { return parsed }
+
+        throw FddbImportError.noParseableContent
+    }
+
+    // MARK: - Networking
+
+    private static func fetchData(url: URL) async throws -> Data {
+        var req = URLRequest(url: url)
+        req.setValue("text/html,application/json", forHTTPHeaderField: "Accept")
+        req.setValue(
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+            forHTTPHeaderField: "User-Agent"
+        )
+        let (data, _) = try await URLSession.shared.data(for: req)
+        return data
+    }
+
+    // MARK: - Direct JSON
+
+    /// Parse a response that is already JSON (object or array) and extract nutrition if present.
+    private static func parseDirectJSON(data: Data) -> FddbImportResult? {
+        guard let any = try? JSONSerialization.jsonObject(with: data) else { return nil }
+        let roots: [[String: Any]]
+        if let dict = any as? [String: Any] {
+            roots = [dict]
+        } else if let arr = any as? [[String: Any]] {
+            roots = arr
+        } else {
+            return nil
+        }
+
+        for root in roots {
+            let name = (root["title"] as? String) ?? (root["name"] as? String) ?? "Food"
+            let nutrition = (root["nutrition"] as? [String: Any]) ?? root
+
+            let carbs = decimal(from: nutrition["carbs"]) ?? decimal(from: nutrition["carbohydrates"]) ??
+                decimal(from: nutrition["carbohydrateContent"]) // g
+            let protein = decimal(from: nutrition["protein"]) ?? decimal(from: nutrition["proteinContent"]) // g
+            let fat = decimal(from: nutrition["fat"]) ?? decimal(from: nutrition["fatContent"]) // g
+
+            let calories = decimal(from: nutrition["calories"]) ?? decimal(from: nutrition["energy"]) // kcal
+            let fiber = decimal(from: nutrition["fiber"]) ?? decimal(from: nutrition["fiberContent"]) // g
+            let sugars = decimal(from: nutrition["sugars"]) ?? decimal(from: nutrition["sugarContent"]) // g
+
+            // Portions: divide totals to per-serving if present
+            let portions = parsePortions(from: root["portions"] ?? root["servings"] ?? root["recipeYield"] ?? root["yield"])
+
+            if carbs != nil || protein != nil || fat != nil || calories != nil {
+                let normalized = normalizePerPortion(
+                    name: name,
+                    carbs: carbs,
+                    protein: protein,
+                    fat: fat,
+                    calories: calories,
+                    fiber: fiber,
+                    sugars: sugars,
+                    portions: portions
+                )
+                return normalized
+            }
+        }
+        return nil
+    }
+
+    // MARK: - og:description Parsing (FDDB Extender specific)
+
+    /// Fast-path for FDDB Extender share pages.
+    /// The og:description always contains per-portion macros in the format:
+    /// "N Portionen - Xkcal / Ykj pro Portion (A.Bg KH, C.Dg Fett, E.Fg Protein) - Zutaten: …"
+    private static func parseOgDescription(html: String) -> FddbImportResult? {
+        guard let desc = extractOgDescription(from: html) else { return nil }
+        let name = extractName(from: html) ?? "Food"
+
+        let calories = firstRegexGroup(
+            in: desc,
+            pattern: "([0-9]+(?:[.,][0-9]+)?)\\s*kcal",
+            options: [.caseInsensitive]
+        ).flatMap { decimal(from: $0) }
+
+        let carbs = firstRegexGroup(
+            in: desc,
+            pattern: "([0-9]+(?:[.,][0-9]+)?)\\s*g\\s*KH",
+            options: [.caseInsensitive]
+        ).flatMap { decimal(from: $0) }
+
+        let fat = firstRegexGroup(
+            in: desc,
+            pattern: "([0-9]+(?:[.,][0-9]+)?)\\s*g\\s*Fett",
+            options: [.caseInsensitive]
+        ).flatMap { decimal(from: $0) }
+
+        let protein = firstRegexGroup(
+            in: desc,
+            pattern: "([0-9]+(?:[.,][0-9]+)?)\\s*g\\s*Protein",
+            options: [.caseInsensitive]
+        ).flatMap { decimal(from: $0) }
+
+        guard carbs != nil || fat != nil || protein != nil else { return nil }
+
+        return FddbImportResult(
+            name: name,
+            carbs: carbs,
+            protein: protein,
+            fat: fat,
+            calories: calories,
+            fiber: nil,
+            sugars: nil,
+            mode: .perServing,
+            standardServingSize: nil,
+            standardServingUnit: nil
+        )
+    }
+
+    private static func extractOgDescription(from html: String) -> String? {
+        // property before content (standard order)
+        if let desc = firstRegexGroup(
+            in: html,
+            pattern: "<meta[^>]*property=\"og:description\"[^>]*content=\"([^\"]*)\"",
+            options: [.caseInsensitive]
+        ) { return desc }
+        // content before property (reversed order)
+        return firstRegexGroup(
+            in: html,
+            pattern: "<meta[^>]*content=\"([^\"]*)\"[^>]*property=\"og:description\"",
+            options: [.caseInsensitive]
+        )
+    }
+
+    // MARK: - JSON-LD Parsing
+
+    private static func parseJSONLD(html: String) -> FddbImportResult? {
+        guard let jsonLD = extractJSONLD(html: html) else { return nil }
+
+        for root in jsonLD {
+            let name = (root["name"] as? String) ?? (root["headline"] as? String) ?? extractName(from: html) ?? "Food"
+            let nutrition = root["nutrition"] as? [String: Any] ?? root
+
+            let carbs = decimal(from: nutrition["carbohydrateContent"]) ?? decimal(from: nutrition["carbohydrates"]) ??
+                decimal(from: nutrition["carbs"]) // g
+            let protein = decimal(from: nutrition["proteinContent"]) ?? decimal(from: nutrition["protein"]) // g
+            let fat = decimal(from: nutrition["fatContent"]) ?? decimal(from: nutrition["fat"]) // g
+
+            let calories = decimal(from: nutrition["calories"]) ?? decimal(from: nutrition["energy"]) // kcal
+            let fiber = decimal(from: nutrition["fiberContent"]) ?? decimal(from: nutrition["fiber"]) // g
+            let sugars = decimal(from: nutrition["sugarContent"]) ?? decimal(from: nutrition["sugars"]) // g
+
+            let portions = parsePortions(from: root["servings"] ?? root["recipeYield"] ?? root["yield"])
+
+            if carbs != nil || protein != nil || fat != nil || calories != nil {
+                let normalized = normalizePerPortion(
+                    name: name,
+                    carbs: carbs,
+                    protein: protein,
+                    fat: fat,
+                    calories: calories,
+                    fiber: fiber,
+                    sugars: sugars,
+                    portions: portions
+                )
+                return normalized
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Embedded JSON Parsing
+
+    private static func parseEmbeddedJSON(html: String) -> FddbImportResult? {
+        guard let embeddedJSON = extractEmbeddedJSON(html: html) else { return nil }
+
+        for root in embeddedJSON {
+            let name = root["title"] as? String ?? root["name"] as? String ?? extractName(from: html) ?? "Food"
+            let nutrition = root["nutrition"] as? [String: Any] ?? root
+
+            let carbs = decimal(from: nutrition["carbs"]) ?? decimal(from: nutrition["carbohydrates"]) ??
+                decimal(from: nutrition["carbohydrateContent"]) // g
+            let protein = decimal(from: nutrition["protein"]) ?? decimal(from: nutrition["proteinContent"]) // g
+            let fat = decimal(from: nutrition["fat"]) ?? decimal(from: nutrition["fatContent"]) // g
+
+            let calories = decimal(from: nutrition["calories"]) ?? decimal(from: nutrition["energy"]) // kcal
+            let fiber = decimal(from: nutrition["fiber"]) ?? decimal(from: nutrition["fiberContent"]) // g
+            let sugars = decimal(from: nutrition["sugars"]) ?? decimal(from: nutrition["sugarContent"]) // g
+
+            let portions = parsePortions(from: root["portions"] ?? root["servings"] ?? root["recipeYield"] ?? root["yield"])
+
+            if carbs != nil || protein != nil || fat != nil || calories != nil {
+                let normalized = normalizePerPortion(
+                    name: name,
+                    carbs: carbs,
+                    protein: protein,
+                    fat: fat,
+                    calories: calories,
+                    fiber: fiber,
+                    sugars: sugars,
+                    portions: portions
+                )
+                return normalized
+            }
+        }
+        return nil
+    }
+
+    // MARK: - HTML Parsing (labels)
+
+    /// Fallback: parse plain HTML with German labels and detect either per-serving totals (with portions) or explicit per-100 blocks.
+    private static func parseHTMLLabels(html: String) -> FddbImportResult? {
+        let name = extractName(from: html) ?? "Food"
+
+        // 1) Prefer a dedicated "per portion" section if present
+        if let range = firstRegexRange(in: html, pattern: "(pro\\s*Portion|je\\s*Portion)", options: [.caseInsensitive]) {
+            let section = slice(html, around: range, before: 300, after: 1200)
+            let m = parseMacros(in: section)
+            if m.carbs != nil || m.protein != nil || m.fat != nil || m.calories != nil {
+                let serving = detectStandardServing(in: html)
+                return FddbImportResult(
+                    name: name,
+                    carbs: m.carbs,
+                    protein: m.protein,
+                    fat: m.fat,
+                    calories: m.calories,
+                    fiber: m.fiber,
+                    sugars: m.sugars,
+                    mode: .perServing,
+                    standardServingSize: serving?.size,
+                    standardServingUnit: serving?.unit
+                )
+            }
+        }
+
+        // 2) Otherwise, look for an explicit per-100 section
+        if let range = firstRegexRange(
+            in: html,
+            pattern: "((?:pro|je)\\s*100\\s*(?:g|ml)|100\\s*(?:g|ml)|100(?:g|ml))",
+            options: [.caseInsensitive]
+        ) {
+            let section = slice(html, around: range, before: 300, after: 1200)
+            let m = parseMacros(in: section)
+            if m.carbs != nil || m.protein != nil || m.fat != nil || m.calories != nil {
+                let unit: FddbUnit = section.range(of: "ml", options: .caseInsensitive) != nil ? .milliliters : .grams
+                let serving = detectStandardServing(in: html)
+                return FddbImportResult(
+                    name: name,
+                    carbs: m.carbs,
+                    protein: m.protein,
+                    fat: m.fat,
+                    calories: m.calories,
+                    fiber: m.fiber,
+                    sugars: m.sugars,
+                    mode: .per100(unit: unit),
+                    standardServingSize: serving?.size,
+                    standardServingUnit: serving?.unit
+                )
+            }
+        }
+
+        // 3) Fallback: parse globally, then try to normalize by portions if a total is implied
+        let m = parseMacros(in: html)
+        if m.carbs != nil || m.protein != nil || m.fat != nil || m.calories != nil {
+            let portions = firstRegexGroup(
+                in: html,
+                pattern: "(?:für\\s*)?([0-9]+)\\s*Portion(?:en)?",
+                options: [.caseInsensitive]
+            ).flatMap { decimal(from: $0) }
+
+            if let portions = portions, portions > 1 {
+                let normalized = normalizePerPortion(
+                    name: name,
+                    carbs: m.carbs,
+                    protein: m.protein,
+                    fat: m.fat,
+                    calories: m.calories,
+                    fiber: m.fiber,
+                    sugars: m.sugars,
+                    portions: portions
+                )
+                let serving = detectStandardServing(in: html)
+                return FddbImportResult(
+                    name: normalized.name,
+                    carbs: normalized.carbs,
+                    protein: normalized.protein,
+                    fat: normalized.fat,
+                    calories: normalized.calories,
+                    fiber: normalized.fiber,
+                    sugars: normalized.sugars,
+                    mode: .perServing,
+                    standardServingSize: serving?.size,
+                    standardServingUnit: serving?.unit
+                )
+            } else {
+                let serving = detectStandardServing(in: html)
+                return FddbImportResult(
+                    name: name,
+                    carbs: m.carbs,
+                    protein: m.protein,
+                    fat: m.fat,
+                    calories: m.calories,
+                    fiber: m.fiber,
+                    sugars: m.sugars,
+                    mode: .perServing,
+                    standardServingSize: serving?.size,
+                    standardServingUnit: serving?.unit
+                )
+            }
+        }
+
+        return nil
+    }
+
+    // MARK: - Helpers
+
+    /// Normalize totals to per single portion; if `portions` is nil or <= 0, values are returned unchanged.
+    private static func normalizePerPortion(
+        name: String,
+        carbs: Decimal?,
+        protein: Decimal?,
+        fat: Decimal?,
+        calories: Decimal?,
+        fiber: Decimal?,
+        sugars: Decimal?,
+        portions: Decimal?
+    ) -> FddbImportResult {
+        let divisor: Decimal = (portions ?? 1) > 0 ? (portions ?? 1) : 1
+        func perPortion(_ value: Decimal?) -> Decimal? {
+            guard let v = value else { return nil }
+            return v / divisor
+        }
+        return FddbImportResult(
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            carbs: perPortion(carbs) ?? carbs,
+            protein: perPortion(protein) ?? protein,
+            fat: perPortion(fat) ?? fat,
+            calories: perPortion(calories),
+            fiber: perPortion(fiber),
+            sugars: perPortion(sugars),
+            mode: .perServing,
+            standardServingSize: nil,
+            standardServingUnit: nil
+        )
+    }
+
+    /// Try to parse a number/decimal from heterogeneous JSON values or numeric strings (comma or dot decimal)
+    private static func decimal(from any: Any?) -> Decimal? {
+        switch any {
+        case let d as Decimal:
+            return d
+        case let n as NSNumber:
+            return n.decimalValue
+        case let s as String:
+            let lower = s
+                .replacingOccurrences(of: ",", with: ".")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            let removedUnits = lower
+                .replacingOccurrences(of: " kcal", with: "")
+                .replacingOccurrences(of: "kcal", with: "")
+                .replacingOccurrences(of: " kj", with: "")
+                .replacingOccurrences(of: "kj", with: "")
+                .replacingOccurrences(of: " g", with: "")
+                .replacingOccurrences(of: "g", with: "")
+                .replacingOccurrences(of: " ml", with: "")
+                .replacingOccurrences(of: "ml", with: "")
+            return Decimal(string: removedUnits)
+        default:
+            return nil
+        }
+    }
+
+    /// Extract number of portions from various shapes (e.g., "10" or "für 10 Portionen")
+    private static func parsePortions(from any: Any?) -> Decimal? {
+        if let n = any as? NSNumber { return n.decimalValue }
+        if let s = any as? String {
+            if let direct = Decimal(string: s.replacingOccurrences(of: ",", with: ".")) { return direct }
+            if let g = firstRegexGroup(in: s, pattern: "([0-9]+)", options: []) { return Decimal(string: g) }
+        }
+        return nil
+    }
+
+    /// Returns the first regex capture group for the given pattern.
+    private static func firstRegexGroup(in text: String, pattern: String, options: NSRegularExpression.Options) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else { return nil }
+        let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range), match.numberOfRanges >= 2 else { return nil }
+        let groupRange = match.range(at: 1)
+        guard let swiftRange = Range(groupRange, in: text) else { return nil }
+        return String(text[swiftRange])
+    }
+
+    /// Returns the overall match range for the first regex occurrence (not a capture group)
+    private static func firstRegexRange(
+        in text: String,
+        pattern: String,
+        options: NSRegularExpression.Options
+    ) -> Range<String.Index>? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: options) else { return nil }
+        let range = NSRange(text.startIndex ..< text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: range) else { return nil }
+        guard let swiftRange = Range(match.range, in: text) else { return nil }
+        return swiftRange
+    }
+
+    /// Safely slice a window around a given range
+    private static func slice(_ text: String, around range: Range<String.Index>, before: Int, after: Int) -> String {
+        let start = text.index(range.lowerBound, offsetBy: -before, limitedBy: text.startIndex) ?? text.startIndex
+        let end = text.index(range.upperBound, offsetBy: after, limitedBy: text.endIndex) ?? text.endIndex
+        return String(text[start ..< end])
+    }
+
+    /// Parse macros in a constrained HTML snippet using strict unit-bound patterns
+    private static func parseMacros(in section: String)
+        -> (carbs: Decimal?, protein: Decimal?, fat: Decimal?, calories: Decimal?, fiber: Decimal?, sugars: Decimal?)
+    {
+        // Units patterns (strict) with word boundaries
+        let gramsUnits = "(?:g|gramm|gr)\\b"
+        let mlUnits = "(?:ml|milliliter)\\b" // reserved if we ever need volume-based macros
+
+        func captureStrict(labelPattern: String, unitsPattern: String) -> Decimal? {
+            let pattern = "(?:\(labelPattern)\\)[^0-9]{0,80}([0-9]+(?:[\\.,][0-9]+)?)\\s*\(unitsPattern)"
+            return firstRegexGroup(in: section, pattern: pattern, options: [.caseInsensitive]).flatMap { decimal(from: $0) }
+        }
+
+        func captureLoose(labelPattern: String) -> Decimal? {
+            // No units, still constrained near the label
+            let pattern = "(?:\(labelPattern)\\)[^0-9]{0,80}([0-9]+(?:[\\.,][0-9]+)?)"
+            return firstRegexGroup(in: section, pattern: pattern, options: [.caseInsensitive]).flatMap { decimal(from: $0) }
+        }
+
+        // Macros in grams
+        let carbs = captureStrict(labelPattern: "Kohlenhydrate|carbohydrate(?:s)?", unitsPattern: gramsUnits)
+            ?? captureLoose(labelPattern: "Kohlenhydrate|carbohydrate(?:s)?")
+        let protein = captureStrict(labelPattern: "Eiweiß|Eiweiss|protein", unitsPattern: gramsUnits)
+            ?? captureLoose(labelPattern: "Eiweiß|Eiweiss|protein")
+        let fat = captureStrict(labelPattern: "Fett|fat", unitsPattern: gramsUnits)
+            ?? captureLoose(labelPattern: "Fett|fat")
+        let fiber = captureStrict(labelPattern: "Ballaststoffe|fiber", unitsPattern: gramsUnits)
+            ?? captureLoose(labelPattern: "Ballaststoffe|fiber")
+        let sugars = captureStrict(labelPattern: "Zucker|sugars?", unitsPattern: gramsUnits)
+            ?? captureLoose(labelPattern: "Zucker|sugars?")
+
+        // Calories: prefer explicit kcal, then labeled kcal
+        let calories = firstRegexGroup(
+            in: section,
+            pattern: "([0-9]+(?:[\\.,][0-9]+)?)\\s*(?:kcal|kilokalorien)",
+            options: [.caseInsensitive]
+        ).flatMap { decimal(from: $0) }
+            ?? firstRegexGroup(
+                in: section,
+                pattern: "(?:Kalorien|Brennwert|Energie)[^0-9]{0,60}([0-9]+(?:[\\.,][0-9]+)?)\\s*(?:kcal|kilokalorien)",
+                options: [.caseInsensitive]
+            ).flatMap { decimal(from: $0) }
+
+        return (carbs, protein, fat, calories, fiber, sugars)
+    }
+
+    /// Extract a likely name from <h1>, og:title, or <title>
+    private static func extractName(from html: String) -> String? {
+        if let h1 = firstRegexGroup(
+            in: html,
+            pattern: "<h1[^>]*>(.*?)</h1>",
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) {
+            return h1.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let og = firstRegexGroup(
+            in: html,
+            pattern: "<meta[^>]*property=\\\"og:title\\\"[^>]*content=\\\"(.*?)\\\"",
+            options: [.caseInsensitive]
+        ) {
+            return og.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        if let title = firstRegexGroup(
+            in: html,
+            pattern: "<title[^>]*>(.*?)</title>",
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) {
+            return title.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return nil
+    }
+
+    /// Detect if the page contains an explicit per-100 block and return its unit (grams/ml)
+    private static func detectPer100Unit(in html: String) -> FddbUnit? {
+        if firstRegexGroup(in: html, pattern: "((?:pro|je)\\s*100\\s*g|100\\s*g|100g)", options: [.caseInsensitive]) != nil {
+            return .grams
+        }
+        if firstRegexGroup(in: html, pattern: "((?:pro|je)\\s*100\\s*ml|100\\s*ml|100ml)", options: [.caseInsensitive]) != nil {
+            return .milliliters
+        }
+        return nil
+    }
+
+    /// Try to detect a clear standard serving size like "1 Portion = 250 ml" or "pro Portion 250 g" (incl. "à/á")
+    private static func detectStandardServing(in html: String) -> (size: Decimal, unit: FddbUnit)? {
+        // Pattern 1: "1 Portion = 250 ml" or "1 Portion = 250 g"
+        if let sizeStr = firstRegexGroup(
+            in: html,
+            pattern: "1\\s*Portion\\s*=\\s*([0-9]+(?:[\\.,][0-9]+)?)\\s*(g|ml)",
+            options: [.caseInsensitive]
+        ),
+            let size = decimal(from: sizeStr)
+        {
+            if let unitStr = firstRegexGroup(
+                in: html,
+                pattern: "1\\s*Portion\\s*=\\s*[0-9]+(?:[\\.,][0-9]+)?\\s*(g|ml)",
+                options: [.caseInsensitive]
+            ) {
+                let unit = unitStr.lowercased().contains("ml") ? FddbUnit.milliliters : FddbUnit.grams
+                return (size, unit)
+            }
+        }
+        // Pattern 2: "pro Portion 250 ml/g"
+        if let sizeStr = firstRegexGroup(
+            in: html,
+            pattern: "pro\\s*Portion\\s*([0-9]+(?:[\\.,][0-9]+)?)\\s*(g|ml)",
+            options: [.caseInsensitive]
+        ),
+            let size = decimal(from: sizeStr)
+        {
+            if let unitStr = firstRegexGroup(
+                in: html,
+                pattern: "pro\\s*Portion\\s*[0-9]+(?:[\\.,][0-9]+)?\\s*(g|ml)",
+                options: [.caseInsensitive]
+            ) {
+                let unit = unitStr.lowercased().contains("ml") ? FddbUnit.milliliters : FddbUnit.grams
+                return (size, unit)
+            }
+        }
+        // Pattern 3: "pro Portion à/á 250 g/ml"
+        if let sizeStr = firstRegexGroup(
+            in: html,
+            pattern: "pro\\s*Portion\\s*(?:à|á)\\s*([0-9]+(?:[\\.,][0-9]+)?)\\s*(g|ml)",
+            options: [.caseInsensitive]
+        ),
+            let size = decimal(from: sizeStr)
+        {
+            if let unitStr = firstRegexGroup(
+                in: html,
+                pattern: "pro\\s*Portion\\s*(?:à|á)\\s*[0-9]+(?:[\\.,][0-9]+)?\\s*(g|ml)",
+                options: [.caseInsensitive]
+            ) {
+                let unit = unitStr.lowercased().contains("ml") ? FddbUnit.milliliters : FddbUnit.grams
+                return (size, unit)
+            }
+        }
+        return nil
+    }
+
+    /// Extract JSON-LD blocks (<script type="application/ld+json">...</script>)
+    private static func extractJSONLD(html: String) -> [[String: Any]]? {
+        let pattern = "<script[^>]*type=\\\"application/ld\\+json\\\"[^>]*>([\\s\\S]*?)</script>"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
+        let range = NSRange(html.startIndex ..< html.endIndex, in: html)
+        let matches = regex.matches(in: html, options: [], range: range)
+        var results: [[String: Any]] = []
+        for match in matches {
+            guard match.numberOfRanges >= 2, let r = Range(match.range(at: 1), in: html) else { continue }
+            let jsonString = String(html[r])
+            guard let data = jsonString.data(using: .utf8) else { continue }
+            if let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] {
+                results.append(contentsOf: arr)
+            } else if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                results.append(obj)
+            }
+        }
+        return results.isEmpty ? nil : results
+    }
+
+    /// Extract embedded JSON objects from common variables like __INITIAL_STATE__ = {...};
+    private static func extractEmbeddedJSON(html: String) -> [[String: Any]]? {
+        let patterns = [
+            "__INITIAL_STATE__\\s*=\\s*({[\\s\\S]*?})\\s*;",
+            "window\\.\\w+\\s*=\\s*({[\\s\\S]*?})\\s*;",
+            "var\\s+\\w+\\s*=\\s*({[\\s\\S]*?})\\s*;"
+        ]
+        var results: [[String: Any]] = []
+        for pattern in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { continue }
+            let range = NSRange(html.startIndex ..< html.endIndex, in: html)
+            let matches = regex.matches(in: html, options: [], range: range)
+            for m in matches {
+                guard m.numberOfRanges >= 2, let r = Range(m.range(at: 1), in: html) else { continue }
+                let json = String(html[r])
+                guard let data = json.data(using: .utf8),
+                      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
+                results.append(obj)
+            }
+        }
+        return results.isEmpty ? nil : results
+    }
+}

--- a/FreeAPS/Sources/Modules/AddCarbs/View/FoodItemsSelectorView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/FoodItemsSelectorView.swift
@@ -141,8 +141,8 @@ struct FoodItemsSelectorView: View {
                         if foodItem.name.isNotEmpty {
                             FoodItemsSelectorItemRow(
                                 foodItem: foodItem,
-                                onAdd: {
-                                    onFoodItemSelected(foodItem)
+                                onAdd: { multiplier in
+                                    onFoodItemSelected(foodItem.withPortionSizeOrMultiplier(multiplier))
                                 },
                                 onRemove: {
                                     onFoodItemRemoved(foodItem)
@@ -179,7 +179,7 @@ struct FoodItemsSelectorView: View {
 
 private struct FoodItemsSelectorItemRow: View {
     let foodItem: FoodItemDetailed
-    let onAdd: () -> Void
+    let onAdd: (Decimal) -> Void
     let onRemove: () -> Void
     let isAdded: Bool
     let isFirst: Bool
@@ -195,6 +195,7 @@ private struct FoodItemsSelectorItemRow: View {
     @State private var showDeleteConfirmation = false
     @State private var showImageSelector = false
     @State private var isSavingImage = false
+    @State private var showPortionPicker = false
 
     private let displayNutrients: [NutrientType] = [.carbs, .protein, .fat]
 
@@ -262,7 +263,13 @@ private struct FoodItemsSelectorItemRow: View {
                             .truncationMode(.tail)
                             .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Button(action: isAdded ? onRemove : onAdd) {
+                        Button(action: {
+                            if isAdded {
+                                onRemove()
+                            } else {
+                                showPortionPicker = true
+                            }
+                        }) {
                             Image(systemName: isAdded ? "checkmark.circle.fill" : "plus.circle.fill")
                                 .font(.system(size: 28))
                                 .foregroundColor(isAdded ? .green : .accentColor)
@@ -355,6 +362,20 @@ private struct FoodItemsSelectorItemRow: View {
             Text(
                 "Are you sure you want to permanently delete \"\(foodItem.name)\" from your saved foods? This action cannot be undone."
             )
+        }
+        .sheet(isPresented: $showPortionPicker) {
+            PortionAdjusterView(
+                foodItem: foodItem,
+                onSave: { multiplier in
+                    onAdd(multiplier)
+                    showPortionPicker = false
+                },
+                onCancel: {
+                    showPortionPicker = false
+                }
+            )
+            .presentationDetents([.height(foodItem.hasNutritionValues ? 420 : 340)])
+            .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showItemInfo) {
             FoodItemInfoPopup(foodItem: foodItem)


### PR DESCRIPTION
Inspired by my t1d-son:

- **FDDB Importer:** Parse `og:description` meta tag as primary strategy for
  FDDB Extender share pages. The tag reliably contains pre-calculated per-portion
  macros (`kcal`, `KH`, `Fett`, `Protein`) directly – no division by portion
  count needed, no fragile HTML label matching. Falls back to the existing
  JSON-LD / embedded JSON / HTML-label strategies for other sources.

- **Saved Foods – portion picker on add:** Tapping `+` on a saved food now opens
  `PortionAdjusterView` before the item is added to the meal. This allows
  selecting e.g. 0.25 / 0.5 / 1.0 / 2.0 / 2.5 × servings (or any gram amount
  for per-100g items) with a live macro preview. Previously the item was always
  added with the default multiplier of 1×.

## Test plan

- [ ] Import `https://share.fddbextender.de/3975627` via the FDDB import sheet
      → name, kcal, KH, Fett, Protein should be pre-filled correctly (4 Portionen,
      636 kcal, 17.2g KH, 31.3g Fett, 73.2g Protein per serving)
- [ ] Open Saved Foods, tap `+` on any entry → `PortionAdjusterView` appears
- [ ] Select 2 × → macros in the meal are doubled
- [ ] Select 0.25 × → macros are quartered
- [ ] Tapping the checkmark (already added) still removes immediately without dialog

Generated with help from Claude Code, OpenAI Codex and Moonshot Kimi K2.5