### PR TITLE
live activity on the watch

### DIFF
--- a/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
+++ b/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
@@ -264,12 +264,12 @@ final class LiveActivityBridge: Injectable, ObservableObject, SettingsObserver {
                         )
                         return ActivityContent(
                             state: state.withoutPredictions(),
-                            staleDate: min(state.date, Date.now).addingTimeInterval(TimeInterval(12 * 60))
+                            staleDate: Date.now.addingTimeInterval(TimeInterval(12 * 60))
                         )
                     } else {
                         return ActivityContent(
                             state: state,
-                            staleDate: min(state.date, Date.now).addingTimeInterval(TimeInterval(12 * 60))
+                            staleDate: Date.now.addingTimeInterval(TimeInterval(12 * 60))
                         )
                     }
                 }()

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -25,7 +25,7 @@ struct LiveActivity: Widget {
     }()
 
     var body: some WidgetConfiguration {
-        ActivityConfiguration(for: LiveActivityAttributes.self) { context in
+        let config = ActivityConfiguration(for: LiveActivityAttributes.self) { context in
             // Lock screen/banner UI goes here
             if !context.state.showChart {
                 bannerWithoutChart(for: context)
@@ -87,6 +87,12 @@ struct LiveActivity: Widget {
             .contentMargins(.horizontal, 0, for: .minimal)
             .contentMargins(.trailing, 0, for: .compactLeading)
             .contentMargins(.leading, 0, for: .compactTrailing)
+        }
+
+        if #available(iOS 18.0, *) {
+            return config.supplementalActivityFamilies([.small])
+        } else {
+            return config
         }
     }
 
@@ -191,7 +197,7 @@ struct LiveActivity: Widget {
     }
 
     private func bannerWithChart(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
-        LiveActivityChart(context: context)
+        LiveActivityChartWrapper(context: context)
     }
 
     @ViewBuilder private func bannerWithoutChart(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
@@ -536,6 +542,27 @@ extension Color {
     LiveActivityAttributes.ContentState.chart3
     LiveActivityAttributes.ContentState.chart4
     LiveActivityAttributes.ContentState.chart5
+}
+
+private struct LiveActivityChartWrapper: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        if #available(iOS 18.0, *) {
+            LiveActivityChartWrapperIOS18(context: context)
+        } else {
+            LiveActivityChart(context: context, isWatch: false)
+        }
+    }
+}
+
+@available(iOS 18.0, *) private struct LiveActivityChartWrapperIOS18: View {
+    @Environment(\.activityFamily) private var activityFamily
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        LiveActivityChart(context: context, isWatch: activityFamily == .small)
+    }
 }
 
 struct LoopActivity: View {

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -32,66 +32,78 @@ struct LiveActivityChart: View {
     }()
 
     var body: some View {
+        if isWatch {
+            watchView
+        } else {
+            defaultView
+        }
+    }
+
+    private var defaultView: some View {
         Group {
-            if isWatch {
-                VStack(spacing: 0) {
-                    HStack(alignment: .center) {
-                        watchIOBCOBView(context.state)
-                        Spacer()
-                        if context.isStale || Date().timeIntervalSince(context.state.loopDate) > 7 * 60 {
-                            updatedLabel(context: context)
-                                .font(.system(size: 12))
-                                .foregroundStyle(Color(.loopRed))
-                                .brightness(0.3)
-                        }
-                        Spacer()
-                        glucoseDisplayWatch(context.state)
-                    }
-                    .padding(.horizontal, 8)
-                    .padding(.top, 4)
+            HStack(alignment: .top) {
+                chartView
+                    .padding(.bottom, 10)
+                    .padding(.top, 30)
+                    .padding(.leading, 15)
+                    .padding(.trailing, 10)
+                    .background(.black.opacity(0.30))
 
-                    chartView(for: context.state)
-                        .padding(.bottom, 4)
-                        .padding(.leading, 5)
-                        .padding(.trailing, 5)
+                ZStack(alignment: .topTrailing) {
+                    chartRightHandView
                 }
-            } else {
-                HStack(alignment: .top) {
-                    chartView(for: context.state)
-                        .padding(.bottom, 10)
-                        .padding(.top, 30)
-                        .padding(.leading, 15)
-                        .padding(.trailing, 10)
-                        .background(.black.opacity(0.30))
-
-                    ZStack(alignment: .topTrailing) {
-                        VStack(alignment: .trailing, spacing: 0) {
-                            chartRightHandView(for: context)
-                        }
-                    }
-                    .fixedSize(horizontal: true, vertical: false)
-                    .frame(maxHeight: .infinity)
-                    .padding(.top, 15)
-                    .padding(.bottom, 15)
-                    .padding(.trailing, 15)
-                }
-                .overlay {
-                    ZStack {
-                        timeAndEventualOverlay(for: context)
-                    }
-                }
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(maxHeight: .infinity)
+                .padding(.vertical, 15)
+                .padding(.trailing, 15)
+            }
+            .overlay {
+                timeAndEventualOverlay
             }
         }
         .foregroundStyle(.white)
         .privacySensitive()
         .padding(0)
-        .background(isWatch ? Color.black : Color.black.opacity(0.6))
+        .background(Color.black.opacity(0.6))
         .activityBackgroundTint(Color.clear)
     }
 
-    private func chartView(for state: LiveActivityAttributes.ContentState) -> some View {
+    private var watchView: some View {
+        Group {
+            VStack(spacing: 0) {
+                watchTopRow
+                chartView
+            }
+            .padding(.vertical, 4)
+            .padding(.horizontal, 8)
+        }
+        .foregroundStyle(.white)
+        .privacySensitive()
+        .padding(0)
+        .background(Color.black)
+        .activityBackgroundTint(Color.black)
+    }
+
+    private var watchTopRow: some View {
+        HStack(alignment: .center) {
+            watchIOBCOBView
+            Spacer()
+            if context.isStale || Date().timeIntervalSince(context.state.loopDate) > 7 * 60 {
+                updatedLabel
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color(.loopRed))
+                    .brightness(0.3)
+            }
+            Spacer()
+            glucoseDisplayWatch
+        }
+    }
+
+    private var chartView: some View {
+        let state = context.state
         let ConversionConstant: Double = (state.mmol ? 0.0555 : 1)
 
+        // on the watch, we display only up to 10 prediction points
         let predictions = isWatch ? limitedPredictions(state.predictions, to: 10) : state.predictions
 
         // Prediction data
@@ -302,8 +314,9 @@ struct LiveActivityChart: View {
         .applyingChartXScale(domain: isWatch ? xStart.map { $0 ... xScaleEnd } : nil)
     }
 
-    @ViewBuilder private func chartRightHandView(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
-        glucoseDrop(context.state).offset(y: -7)
+    @ViewBuilder private var chartRightHandView: some View {
+        glucoseDrop
+            .offset(y: -7)
             .frame(width: dropWidth, height: dropHeight)
 
         Grid(horizontalSpacing: 0) {
@@ -333,7 +346,7 @@ struct LiveActivityChart: View {
         .frame(width: dropWidth)
     }
 
-    @ViewBuilder private func timeAndEventualOverlay(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
+    @ViewBuilder private var timeAndEventualOverlay: some View {
         // Eventual Glucose
         HStack(spacing: 4) {
             Text(EventualSymbol)
@@ -351,17 +364,17 @@ struct LiveActivityChart: View {
         .padding(.trailing, 110)
 
         // Timestamp
-        updatedLabel(context: context)
+        updatedLabel
             .font(.system(size: 11))
             .foregroundStyle(context.isStale ? Color(.loopRed) : .white.opacity(0.7))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .padding(.vertical, 10).padding(.leading, 50)
     }
 
-    @ViewBuilder private func watchIOBCOBView(_ state: LiveActivityAttributes.ContentState) -> some View {
+    @ViewBuilder private var watchIOBCOBView: some View {
         HStack(spacing: 10) {
             HStack(spacing: 0.5) {
-                Text(state.iob)
+                Text(context.state.iob)
                     .font(.system(size: 19))
                     .tracking(-0.5)
                     .foregroundStyle(.white)
@@ -371,9 +384,9 @@ struct LiveActivityChart: View {
             }
             .fontWidth(.compressed)
 
-            if state.cob != "0" {
+            if context.state.cob != "0" {
                 HStack(spacing: 0.5) {
-                    Text(state.cob)
+                    Text(context.state.cob)
                         .font(.system(size: 19))
                         .tracking(-0.5)
                         .foregroundStyle(.white)
@@ -386,46 +399,9 @@ struct LiveActivityChart: View {
         }
     }
 
-    @ViewBuilder private func chartRightHandViewWatch(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
-        VStack(alignment: .trailing, spacing: 0) {
-            glucoseDisplayWatch(context.state)
-
-            updatedLabel(context: context)
-                .font(.system(size: 11))
-                .foregroundStyle(context.isStale ? Color(.loopRed) : .white.opacity(0.7))
-                .padding(.top, -2)
-
-            Spacer(minLength: 0)
-
-            Grid(horizontalSpacing: 1, verticalSpacing: -3) {
-                GridRow {
-                    Text(context.state.iob)
-                        .font(.system(size: 13))
-                        .foregroundStyle(Color(.insulin))
-                        .gridColumnAlignment(.trailing)
-                    Text("U")
-                        .font(.system(size: 13).smallCaps())
-                        .foregroundStyle(Color(.insulin))
-                        .gridColumnAlignment(.leading)
-                }
-                GridRow {
-                    Text(context.state.cob)
-                        .font(.system(size: 13))
-                        .foregroundStyle(Color(.loopYellow))
-                    Text("g")
-                        .font(.system(size: 13))
-                        .foregroundStyle(Color(.loopYellow))
-                }
-            }
-            .fontWidth(.condensed)
-        }
-        .fixedSize(horizontal: true, vertical: false)
-        .frame(maxHeight: .infinity)
-    }
-
-    private func glucoseDrop(_ state: LiveActivityAttributes.ContentState) -> some View {
+    private var glucoseDrop: some View {
         ZStack {
-            let degree = dropAngle(state)
+            let degree = dropAngle
             let shadowDirection = direction(degree: degree)
 
             Image("SmallGlucoseDrops")
@@ -434,7 +410,7 @@ struct LiveActivityChart: View {
                 .animation(.bouncy(duration: 1, extraBounce: 0.2), value: degree)
                 .shadow(radius: 3, x: shadowDirection.x, y: shadowDirection.y)
 
-            let string = state.bg
+            let string = context.state.bg
             let decimalSeparator =
                 string.contains(decimalString) ? decimalString : "."
 
@@ -457,9 +433,9 @@ struct LiveActivityChart: View {
         }
     }
 
-    private func glucoseDisplayWatch(_ state: LiveActivityAttributes.ContentState) -> some View {
+    private var glucoseDisplayWatch: some View {
         HStack(alignment: .center, spacing: 6) {
-            let string = state.bg
+            let string = context.state.bg
             let decimalSeparator =
                 string.contains(decimalString) ? decimalString : "."
 
@@ -477,7 +453,7 @@ struct LiveActivityChart: View {
                     .foregroundColor(colorOfGlucose)
             }
 
-            if let direction = state.direction {
+            if let direction = context.state.direction {
                 Text(direction)
                     .font(.system(size: 16))
                     .foregroundColor(colorOfGlucose)
@@ -522,8 +498,8 @@ struct LiveActivityChart: View {
         values.compactMap { $0 }.min().map { min($0, first) } ?? first
     }
 
-    private func dropAngle(_ state: LiveActivityAttributes.ContentState) -> Double {
-        guard let direction = state.direction else {
+    private var dropAngle: Double {
+        guard let direction = context.state.direction else {
             return 90
         }
 
@@ -564,16 +540,15 @@ struct LiveActivityChart: View {
         }
     }
 
-    private func updatedLabel(context: ActivityViewContext<LiveActivityAttributes>) -> Text {
-        let text = Text("\(dateFormatter.string(from: context.state.loopDate))")
-        return text
+    private var updatedLabel: Text {
+        Text("\(dateFormatter.string(from: context.state.loopDate))")
     }
 
-    func displayValues(_ values: [Int16], conversion: Double) -> [Double] {
+    private func displayValues(_ values: [Int16], conversion: Double) -> [Double] {
         values.map { Double($0) * conversion }
     }
 
-    func makePoints(_ dates: [Date], _ values: [Int16], conversion: Double) -> [(date: Date, value: Double)] {
+    private func makePoints(_ dates: [Date], _ values: [Int16], conversion: Double) -> [(date: Date, value: Double)] {
         zip(dates, displayValues(values, conversion: conversion)).map { ($0, $1) }
     }
 }

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -32,37 +32,57 @@ struct LiveActivityChart: View {
     }()
 
     var body: some View {
-        HStack(alignment: .top) {
-            chartView(for: context.state)
-                .padding(.bottom, isWatch ? 4 : 10)
-                .padding(.top, isWatch ? 4 : 30)
-                .padding(.leading, isWatch ? 8 : 15)
-                .padding(.trailing, isWatch ? 5 : 10)
-                .background(.black.opacity(0.30))
+        Group {
+            if isWatch {
+                VStack(spacing: 0) {
+                    HStack(alignment: .center) {
+                        watchIOBCOBView(context.state)
+                        Spacer()
+                        if context.isStale || Date().timeIntervalSince(context.state.loopDate) > 7 * 60 {
+                            updatedLabel(context: context)
+                                .font(.system(size: 12))
+                                .foregroundStyle(Color(.loopRed))
+                                .brightness(0.3)
+                        }
+                        Spacer()
+                        glucoseDisplayWatch(context.state)
+                    }
+                    .padding(.horizontal, 8)
+                    .padding(.top, 4)
 
-            ZStack(alignment: .topTrailing) {
-                VStack(alignment: .trailing, spacing: 0) {
-                    if isWatch {
-                        chartRightHandViewWatch(for: context)
-                    } else {
-                        chartRightHandView(for: context)
+                    chartView(for: context.state)
+                        .padding(.bottom, 4)
+                        .padding(.leading, 5)
+                        .padding(.trailing, 5)
+                }
+            } else {
+                HStack(alignment: .top) {
+                    chartView(for: context.state)
+                        .padding(.bottom, 10)
+                        .padding(.top, 30)
+                        .padding(.leading, 15)
+                        .padding(.trailing, 10)
+                        .background(.black.opacity(0.30))
+
+                    ZStack(alignment: .topTrailing) {
+                        VStack(alignment: .trailing, spacing: 0) {
+                            chartRightHandView(for: context)
+                        }
+                    }
+                    .fixedSize(horizontal: true, vertical: false)
+                    .frame(maxHeight: .infinity)
+                    .padding(.top, 15)
+                    .padding(.bottom, 15)
+                    .padding(.trailing, 15)
+                }
+                .overlay {
+                    ZStack {
+                        timeAndEventualOverlay(for: context)
                     }
                 }
             }
-            .fixedSize(horizontal: true, vertical: false)
-            .frame(maxHeight: .infinity)
-            .padding(.top, isWatch ? 4 : 15)
-            .padding(.bottom, isWatch ? 8 : 15)
-            .padding(.trailing, isWatch ? 8 : 15)
         }
         .foregroundStyle(.white)
-        .overlay {
-            if !isWatch {
-                ZStack {
-                    timeAndEventualOverlay(for: context)
-                }
-            }
-        }
         .privacySensitive()
         .padding(0)
         .background(Color.black.opacity(0.6))
@@ -72,7 +92,7 @@ struct LiveActivityChart: View {
     private func chartView(for state: LiveActivityAttributes.ContentState) -> some View {
         let ConversionConstant: Double = (state.mmol ? 0.0555 : 1)
 
-        let predictions = isWatch ? nil : state.predictions
+        let predictions = isWatch ? limitedPredictions(state.predictions, to: 10) : state.predictions
 
         // Prediction data
         let iob: [Int16] = predictions?.iob?.values ?? []
@@ -143,6 +163,9 @@ struct LiveActivityChart: View {
         let ztPoints = predictions?.zt.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
         let cobPoints = predictions?.cob.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
         let uamPoints = predictions?.uam.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
+
+        let nowDate = Date()
+        let xScaleEnd: Date = isWatch ? max(xEnd ?? nowDate, nowDate) : (xEnd ?? nowDate)
 
         return Chart {
             if let bg = bgPoints {
@@ -227,10 +250,16 @@ struct LiveActivityChart: View {
                 }
             }
 
+            if isWatch {
+                RuleMark(x: .value("Now", nowDate))
+                    .foregroundStyle(.white.opacity(0.4))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [3, 3]))
+            }
+
             if let xStart = xStart, let xEnd = xEnd {
                 RectangleMark(
                     xStart: .value("Start", xStart),
-                    xEnd: .value("End", xEnd),
+                    xEnd: .value("End", isWatch ? xScaleEnd : xEnd),
                     yStart: .value("Bottom", yStart),
                     yEnd: .value("Top", yEnd)
                 )
@@ -241,15 +270,17 @@ struct LiveActivityChart: View {
         .chartXAxis {
             AxisMarks(position: .bottom, values: .stride(by: .hour, count: 1)) { _ in
                 AxisGridLine().foregroundStyle(.white.opacity(0.2))
-                AxisValueLabel(format: .dateTime.hour(), offsetsMarks: isWatch ? false : nil)
-                    .foregroundStyle(.secondary)
-                    .font(isWatch ? .system(size: 10) : .caption)
+                if !isWatch {
+                    AxisValueLabel(format: .dateTime.hour())
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
+                }
             }
         }
         .chartYAxis {
             if let minValue, let maxValue {
                 AxisMarks(
-                    position: .leading,
+                    position: isWatch ? .trailing : .leading,
                     values:
                     abs(maxValue - minValue) < 0.8 ? [
                         (maxValue + minValue) / 2
@@ -268,6 +299,7 @@ struct LiveActivityChart: View {
                 }
             }
         }
+        .applyingChartXScale(domain: isWatch ? xStart.map { $0 ... xScaleEnd } : nil)
     }
 
     @ViewBuilder private func chartRightHandView(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
@@ -324,6 +356,34 @@ struct LiveActivityChart: View {
             .foregroundStyle(context.isStale ? Color(.loopRed) : .white.opacity(0.7))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .padding(.vertical, 10).padding(.leading, 50)
+    }
+
+    @ViewBuilder private func watchIOBCOBView(_ state: LiveActivityAttributes.ContentState) -> some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 0.5) {
+                Text(state.iob)
+                    .font(.system(size: 19))
+                    .tracking(-0.5)
+                    .foregroundStyle(.white)
+                Text("U")
+                    .font(.system(size: 19).smallCaps())
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            .fontWidth(.compressed)
+
+            if state.cob != "0" {
+                HStack(spacing: 0.5) {
+                    Text(state.cob)
+                        .font(.system(size: 19))
+                        .tracking(-0.5)
+                        .foregroundStyle(.white)
+                    Text("g")
+                        .font(.system(size: 19))
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+                .fontWidth(.compressed)
+            }
+        }
     }
 
     @ViewBuilder private func chartRightHandViewWatch(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
@@ -398,7 +458,7 @@ struct LiveActivityChart: View {
     }
 
     private func glucoseDisplayWatch(_ state: LiveActivityAttributes.ContentState) -> some View {
-        HStack(alignment: .center, spacing: 2) {
+        HStack(alignment: .center, spacing: 6) {
             let string = state.bg
             let decimalSeparator =
                 string.contains(decimalString) ? decimalString : "."
@@ -406,21 +466,20 @@ struct LiveActivityChart: View {
             let decimal = string.components(separatedBy: decimalSeparator)
             if decimal.count > 1 {
                 HStack(alignment: .firstTextBaseline, spacing: 0) {
-                    Text(decimal[0]).font(Font.custom("SuggestionSmallPartsFont", size: 22))
-                    Text(decimalSeparator).font(.system(size: 15).weight(.semibold))
-                    Text(decimal[1]).font(.system(size: 15))
+                    Text(decimal[0]).font(.system(size: 28, weight: .semibold, design: .rounded))
+                    Text(decimalSeparator).font(.system(size: 20, weight: .semibold, design: .rounded))
+                    Text(decimal[1]).font(.system(size: 20, weight: .semibold, design: .rounded))
                 }
-                .tracking(-1)
                 .foregroundColor(colorOfGlucose)
             } else {
                 Text(string)
-                    .font(Font.custom("SuggestionSmallPartsFontMgDl", fixedSize: 20).width(.condensed))
+                    .font(.system(size: 28, weight: .semibold, design: .rounded))
                     .foregroundColor(colorOfGlucose)
             }
 
             if let direction = state.direction {
                 Text(direction)
-                    .font(.system(size: 12))
+                    .font(.system(size: 16))
                     .foregroundColor(colorOfGlucose)
             }
         }
@@ -428,6 +487,23 @@ struct LiveActivityChart: View {
 
     private var colorOfGlucose: Color {
         Color.white
+    }
+
+    private func limitedPredictions(
+        _ predictions: LiveActivityAttributes.ActivityPredictions?,
+        to count: Int
+    ) -> LiveActivityAttributes.ActivityPredictions? {
+        guard let predictions else { return nil }
+        func limit(_ series: LiveActivityAttributes.ValueSeries?) -> LiveActivityAttributes.ValueSeries? {
+            guard let series else { return nil }
+            return .init(dates: Array(series.dates.prefix(count)), values: Array(series.values.prefix(count)))
+        }
+        return .init(
+            iob: limit(predictions.iob),
+            zt: limit(predictions.zt),
+            cob: limit(predictions.cob),
+            uam: limit(predictions.uam)
+        )
     }
 
     private func maxOptional<T: Comparable>(_ values: T?...) -> T? {
@@ -499,5 +575,15 @@ struct LiveActivityChart: View {
 
     func makePoints(_ dates: [Date], _ values: [Int16], conversion: Double) -> [(date: Date, value: Double)] {
         zip(dates, displayValues(values, conversion: conversion)).map { ($0, $1) }
+    }
+}
+
+private extension View {
+    @ViewBuilder func applyingChartXScale(domain: ClosedRange<Date>?) -> some View {
+        if let domain {
+            chartXScale(domain: domain)
+        } else {
+            self
+        }
     }
 }

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -85,7 +85,7 @@ struct LiveActivityChart: View {
         .foregroundStyle(.white)
         .privacySensitive()
         .padding(0)
-        .background(Color.black.opacity(0.6))
+        .background(isWatch ? Color.black : Color.black.opacity(0.6))
         .activityBackgroundTint(Color.clear)
     }
 

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -6,6 +6,7 @@ import WidgetKit
 
 struct LiveActivityChart: View {
     let context: ActivityViewContext<LiveActivityAttributes>
+    var isWatch: Bool = false
 
     private let EventualSymbol = "⇢"
     private let dropWidth = CGFloat(80)
@@ -33,26 +34,33 @@ struct LiveActivityChart: View {
     var body: some View {
         HStack(alignment: .top) {
             chartView(for: context.state)
-                .padding(.bottom, 10)
-                .padding(.top, 30)
-                .padding(.leading, 15)
-                .padding(.trailing, 10)
+                .padding(.bottom, isWatch ? 4 : 10)
+                .padding(.top, isWatch ? 4 : 30)
+                .padding(.leading, isWatch ? 8 : 15)
+                .padding(.trailing, isWatch ? 5 : 10)
                 .background(.black.opacity(0.30))
 
             ZStack(alignment: .topTrailing) {
                 VStack(alignment: .trailing, spacing: 0) {
-                    chartRightHandView(for: context)
+                    if isWatch {
+                        chartRightHandViewWatch(for: context)
+                    } else {
+                        chartRightHandView(for: context)
+                    }
                 }
             }
+            .fixedSize(horizontal: true, vertical: false)
             .frame(maxHeight: .infinity)
-            .padding(.top, 15)
-            .padding(.bottom, 15)
-            .padding(.trailing, 15)
+            .padding(.top, isWatch ? 4 : 15)
+            .padding(.bottom, isWatch ? 8 : 15)
+            .padding(.trailing, isWatch ? 8 : 15)
         }
         .foregroundStyle(.white)
         .overlay {
-            ZStack {
-                timeAndEventualOverlay(for: context)
+            if !isWatch {
+                ZStack {
+                    timeAndEventualOverlay(for: context)
+                }
             }
         }
         .privacySensitive()
@@ -64,11 +72,13 @@ struct LiveActivityChart: View {
     private func chartView(for state: LiveActivityAttributes.ContentState) -> some View {
         let ConversionConstant: Double = (state.mmol ? 0.0555 : 1)
 
+        let predictions = isWatch ? nil : state.predictions
+
         // Prediction data
-        let iob: [Int16] = state.predictions?.iob?.values ?? []
-        let cob: [Int16] = state.predictions?.cob?.values ?? []
-        let zt: [Int16] = state.predictions?.zt?.values ?? []
-        let uam: [Int16] = state.predictions?.uam?.values ?? []
+        let iob: [Int16] = predictions?.iob?.values ?? []
+        let cob: [Int16] = predictions?.cob?.values ?? []
+        let zt: [Int16] = predictions?.zt?.values ?? []
+        let uam: [Int16] = predictions?.uam?.values ?? []
 
         // Prepare for domain range
         let lowThreshold = Double(state.chartLowThreshold) * ConversionConstant
@@ -83,10 +93,10 @@ struct LiveActivityChart: View {
         let yEnd = highThreshold
         let xStart = state.readings?.dates.min()
         let xEnd = maxOptional(
-            state.predictions?.iob?.dates.max(),
-            state.predictions?.cob?.dates.max(),
-            state.predictions?.zt?.dates.max(),
-            state.predictions?.uam?.dates.max(),
+            predictions?.iob?.dates.max(),
+            predictions?.cob?.dates.max(),
+            predictions?.zt?.dates.max(),
+            predictions?.uam?.dates.max(),
             state.readings?.dates.max()
         )
 
@@ -129,10 +139,10 @@ struct LiveActivityChart: View {
         let bgPoints = state.readings.map({
             makePoints($0.dates, $0.values, conversion: ConversionConstant)
         })
-        let iobPoints = state.predictions?.iob.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
-        let ztPoints = state.predictions?.zt.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
-        let cobPoints = state.predictions?.cob.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
-        let uamPoints = state.predictions?.uam.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
+        let iobPoints = predictions?.iob.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
+        let ztPoints = predictions?.zt.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
+        let cobPoints = predictions?.cob.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
+        let uamPoints = predictions?.uam.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
 
         return Chart {
             if let bg = bgPoints {
@@ -231,8 +241,9 @@ struct LiveActivityChart: View {
         .chartXAxis {
             AxisMarks(position: .bottom, values: .stride(by: .hour, count: 1)) { _ in
                 AxisGridLine().foregroundStyle(.white.opacity(0.2))
-                AxisValueLabel(format: .dateTime.hour())
+                AxisValueLabel(format: .dateTime.hour(), offsetsMarks: isWatch ? false : nil)
                     .foregroundStyle(.secondary)
+                    .font(isWatch ? .system(size: 10) : .caption)
             }
         }
         .chartYAxis {
@@ -250,9 +261,10 @@ struct LiveActivityChart: View {
                 ) { _ in
                     AxisValueLabel(
                         format: glucoseFormatter,
-                        horizontalSpacing: 10
+                        horizontalSpacing: isWatch ? 8 : 10
                     )
                     .foregroundStyle(.secondary)
+                    .font(isWatch ? .system(size: 12) : .caption)
                 }
             }
         }
@@ -314,6 +326,43 @@ struct LiveActivityChart: View {
             .padding(.vertical, 10).padding(.leading, 50)
     }
 
+    @ViewBuilder private func chartRightHandViewWatch(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
+        VStack(alignment: .trailing, spacing: 0) {
+            glucoseDisplayWatch(context.state)
+
+            updatedLabel(context: context)
+                .font(.system(size: 11))
+                .foregroundStyle(context.isStale ? Color(.loopRed) : .white.opacity(0.7))
+                .padding(.top, -2)
+
+            Spacer(minLength: 0)
+
+            Grid(horizontalSpacing: 1, verticalSpacing: -3) {
+                GridRow {
+                    Text(context.state.iob)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color(.insulin))
+                        .gridColumnAlignment(.trailing)
+                    Text("U")
+                        .font(.system(size: 13).smallCaps())
+                        .foregroundStyle(Color(.insulin))
+                        .gridColumnAlignment(.leading)
+                }
+                GridRow {
+                    Text(context.state.cob)
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color(.loopYellow))
+                    Text("g")
+                        .font(.system(size: 13))
+                        .foregroundStyle(Color(.loopYellow))
+                }
+            }
+            .fontWidth(.condensed)
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .frame(maxHeight: .infinity)
+    }
+
     private func glucoseDrop(_ state: LiveActivityAttributes.ContentState) -> some View {
         ZStack {
             let degree = dropAngle(state)
@@ -344,6 +393,35 @@ struct LiveActivityChart: View {
                     .font(Font.custom("SuggestionSmallPartsFontMgDl", fixedSize: 23).width(.condensed))
                     .foregroundColor(colorOfGlucose)
                     .offset(x: -2)
+            }
+        }
+    }
+
+    private func glucoseDisplayWatch(_ state: LiveActivityAttributes.ContentState) -> some View {
+        HStack(alignment: .center, spacing: 2) {
+            let string = state.bg
+            let decimalSeparator =
+                string.contains(decimalString) ? decimalString : "."
+
+            let decimal = string.components(separatedBy: decimalSeparator)
+            if decimal.count > 1 {
+                HStack(alignment: .firstTextBaseline, spacing: 0) {
+                    Text(decimal[0]).font(Font.custom("SuggestionSmallPartsFont", size: 22))
+                    Text(decimalSeparator).font(.system(size: 15).weight(.semibold))
+                    Text(decimal[1]).font(.system(size: 15))
+                }
+                .tracking(-1)
+                .foregroundColor(colorOfGlucose)
+            } else {
+                Text(string)
+                    .font(Font.custom("SuggestionSmallPartsFontMgDl", fixedSize: 20).width(.condensed))
+                    .foregroundColor(colorOfGlucose)
+            }
+
+            if let direction = state.direction {
+                Text(direction)
+                    .font(.system(size: 12))
+                    .foregroundColor(colorOfGlucose)
             }
         }
     }

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -50,7 +50,9 @@ struct LiveActivityChart: View {
                     .background(.black.opacity(0.30))
 
                 ZStack(alignment: .topTrailing) {
-                    chartRightHandView
+                    VStack(alignment: .trailing, spacing: 0) {
+                        chartRightHandView
+                    }
                 }
                 .fixedSize(horizontal: true, vertical: false)
                 .frame(maxHeight: .infinity)


### PR DESCRIPTION
This enables the iAPS live activity widged on the watch (smart stack).

The layout on the watch is tweaked a little bit, since we have less space, currently it looks like this:

* v2

<img width="200" alt="incoming-9194E855-971B-4D08-A9F1-D7396509203A" src="https://github.com/user-attachments/assets/dfa394cf-2c75-4a9c-afac-215024667f29" />
<img width="200" alt="incoming-9194E855-971B-4D08-A9F1-D7396509203A" src="https://github.com/user-attachments/assets/bfdbc698-8a84-4f16-9082-03d949a9a87c" />

<details>
  <summary>
  previous versions
  </summary>

* v1
<img width="200" alt="incoming-9194E855-971B-4D08-A9F1-D7396509203A" src="https://github.com/user-attachments/assets/6434c8f1-373f-4bcd-b1a2-46276a68bc5e" />

</details>

This change should also make live activity on CarPlay display the full widget (with chart, etc), but I don't have a CarPlay-enabled car to test.