### PR TITLE
Upgrade for Node.js 24

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -123,7 +123,7 @@ jobs:
           echo "NEW_COMMITS=${{ steps.sync.outputs.has_new_commits }}" >> $GITHUB_OUTPUT
 
       - name: Checkout Repo for building
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GH_PAT }}
           submodules: recursive
@@ -172,7 +172,7 @@ jobs:
       # Upload Build artifacts
       - name: Upload build log, IPA and Symbol artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: build-artifacts
           path: |


### PR DESCRIPTION

This has been build tested using github actions:



--
  actions/checkout@v5 — no changes needed:
  - Credentials are now stored in $RUNNER_TEMP instead of .git/config (more secure), but git commands in subsequent steps are unaffected. Your token: ${{ secrets.GH_PAT }} + submodules: recursive usage works identically.

  actions/upload-artifact@v6 — no changes needed for your usage:
  - The only notable breaking change from v4 is that hidden files are excluded by default (opt-in via include-hidden-files: true). Your paths are artifacts and buildlog — .ipa, .dSYM and build logs are not hidden files, so this doesn't affect you.
  - The name: build-artifacts and path: parameters are unchanged.

  So the version bumps are all that's needed — checkout@v5 and upload-artifact@v6 are drop-in replacements for your workflow.

  Sources:
  - https://github.com/actions/checkout/releases/tag/v5.0.0
  - https://github.com/actions/upload-artifact/releases
  - https://www.eliostruyf.com/breaking-github-upload-artifact-action/ --
  
  
  
  
