### PR TITLE
in overrides, read autoISF settings by override ID - not latest by date

### DIFF
--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -386,14 +386,14 @@ final class OpenAPS {
 
     private func aisfEnabled(override: Override?) -> Bool {
         guard let current = override, current.enabled else { return false }
-        guard current.overrideAutoISF, let settings = OverrideStorage().fetchLatestAutoISFsettings().first,
+        guard current.overrideAutoISF, let settings = OverrideStorage().fetchAutoISFsetting(id: current.id ?? ""),
               settings.autoisf else { return false }
         return true
     }
 
     private func notDisabled(override: Override?) -> Bool {
         guard let current = override, current.enabled else { return true }
-        guard current.overrideAutoISF, let settings = OverrideStorage().fetchLatestAutoISFsettings().first,
+        guard current.overrideAutoISF, let settings = OverrideStorage().fetchAutoISFsetting(id: current.id ?? ""),
               !settings.autoisf else { return true }
         return false
     }


### PR DESCRIPTION
to reproduce the issue before this fix:

* enable dyn ISF in settings (although this one is probably irrelevant)
* enable auto ISF in settings
* create an override with auto ISF = ON
* after that, create an override with auto ISF= OFF
* enable the older override (with auto ISF = ON)
* loop - fails

 (the important part is to have an override that disables autoISF created *after* the currently selected override)
