### PR TITLE
Autotune2.0

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -353,6 +353,8 @@
 		9825E5E923F0B8FA80C8C7C7 /* NightscoutConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0A48AE3AC813A49A517846A /* NightscoutConfigStateModel.swift */; };
 		98641AF4F92123DA668AB931 /* CREditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0BDC6993C1087310EDFC428 /* CREditorRootView.swift */; };
 		A05235B9112E677ED03B6E8E /* AutotuneConfigRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CF5ACEE1F0859670E71B2C0 /* AutotuneConfigRootView.swift */; };
+		02DEAF04587E4AFAAAC70303 /* CalculatedBasalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B866287E5E4CCDB1B0AFEC /* CalculatedBasalView.swift */; };
+		2E92985D8C5A45A1A2EE51A7 /* CalculatedISFView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFD3A0EAB97247D1B98250EF /* CalculatedISFView.swift */; };
 		A0B8EC8CC5CD1DD237D1BCD2 /* PumpSettingsEditorRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C7F882606FF83A21BE00D8 /* PumpSettingsEditorRootView.swift */; };
 		A228DF96647338139F152B15 /* PreferencesEditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12204445D7632AF09264A979 /* PreferencesEditorDataFlow.swift */; };
 		A33352ED40476125EBAC6EE0 /* CREditorDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E22146D3DF4853786C78132 /* CREditorDataFlow.swift */; };
@@ -1041,6 +1043,8 @@
 		8A965332F237348B119FB858 /* PreferencesEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PreferencesEditorRootView.swift; sourceTree = "<group>"; };
 		8C3B5FD881CA45DFDEE0EDA9 /* AddTempTargetStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddTempTargetStateModel.swift; sourceTree = "<group>"; };
 		8CF5ACEE1F0859670E71B2C0 /* AutotuneConfigRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutotuneConfigRootView.swift; sourceTree = "<group>"; };
+		D3B866287E5E4CCDB1B0AFEC /* CalculatedBasalView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalculatedBasalView.swift; sourceTree = "<group>"; };
+		BFD3A0EAB97247D1B98250EF /* CalculatedISFView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CalculatedISFView.swift; sourceTree = "<group>"; };
 		8DCCCCE633F5E98E41B0CD3C /* AutotuneConfigDataFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AutotuneConfigDataFlow.swift; sourceTree = "<group>"; };
 		920DDB21E5D0EB813197500D /* ConfigEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConfigEditorRootView.swift; sourceTree = "<group>"; };
 		9455FA2D92E77A6C4AFED8A3 /* DataTableStateModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataTableStateModel.swift; sourceTree = "<group>"; };
@@ -2521,6 +2525,8 @@
 			isa = PBXGroup;
 			children = (
 				8CF5ACEE1F0859670E71B2C0 /* AutotuneConfigRootView.swift */,
+				D3B866287E5E4CCDB1B0AFEC /* CalculatedBasalView.swift */,
+				BFD3A0EAB97247D1B98250EF /* CalculatedISFView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -3793,6 +3799,8 @@
 				891DECF7BC20968D7F566161 /* AutotuneConfigProvider.swift in Sources */,
 				D76333C9256787610B3B4875 /* AutotuneConfigStateModel.swift in Sources */,
 				A05235B9112E677ED03B6E8E /* AutotuneConfigRootView.swift in Sources */,
+				02DEAF04587E4AFAAAC70303 /* CalculatedBasalView.swift in Sources */,
+				2E92985D8C5A45A1A2EE51A7 /* CalculatedISFView.swift in Sources */,
 				19389E552D69393900636E49 /* TemporaryData.swift in Sources */,
 				7F7B756BE8543965D9FDF1A2 /* DataTableDataFlow.swift in Sources */,
 				1D845DF2E3324130E1D95E67 /* DataTableProvider.swift in Sources */,

--- a/FreeAPS/Sources/APS/OpenAPS/Constants.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/Constants.swift
@@ -52,6 +52,7 @@ extension OpenAPS {
         static let model = "settings/model.json"
         static let contactTrick = "settings/contact_trick.json"
         static let autoisf = "settings/autoisf.json"
+        static let reasonsISFSchedule = "settings/reasons_isf_schedule.json"
     }
 
     enum Monitor {

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -273,7 +273,7 @@ final class OpenAPS {
                     }
 
                     // Build the improved ISF schedule if the user has opted in.
-                    let freeapsRaw = self.loadFileFromStorage(name: Settings.settings)
+                    let freeapsRaw = self.loadFileFromStorage(name: FreeAPS.settings)
                     if FreeAPSSettings(from: freeapsRaw)?.calculateISFSuggestions == true {
                         self.buildReasonsISFSchedule()
                     }

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -1420,6 +1420,8 @@ final class OpenAPS {
         // which is the quantity we want regardless of how aggressively AutoISF was working.
         var allEstimates: [(value: Double, hour: Int, date: Date)] = []
 
+        let mmolToMgdl = 1.0 / Double(GlucoseUnits.exchangeRate)
+
         for r in reasons {
             guard
                 let isfDecimal = r.isf?.decimalValue, isfDecimal > 0,
@@ -1427,11 +1429,14 @@ final class OpenAPS {
                 let date = r.date
             else { continue }
 
-            let isfBefore = isfDecimal * ratioDecimal
+            // Reasons.isf is stored in the profile's display units (mmol/L/U or mg/dL/U).
+            // Normalize to mg/dL/U so displayISF(mgdl:) in the view produces correct output.
+            var isfBefore = Double(truncating: (isfDecimal * ratioDecimal) as NSDecimalNumber)
+            if r.mmol { isfBefore *= mmolToMgdl }
             if isfBefore <= 0 { continue }
 
             let hour = Calendar.current.component(.hour, from: date)
-            allEstimates.append((value: Double(truncating: isfBefore as NSDecimalNumber), hour: hour, date: date))
+            allEstimates.append((value: isfBefore, hour: hour, date: date))
         }
 
         guard !allEstimates.isEmpty else {
@@ -1535,11 +1540,13 @@ final class OpenAPS {
             let cob = Double(truncating: cobDecimal as NSDecimalNumber)
             guard cob <= 5 else { continue }
 
-            let isfBefore = Double(truncating: (isfDecimal * ratioDecimal) as NSDecimalNumber)
+            var isfBefore = Double(truncating: (isfDecimal * ratioDecimal) as NSDecimalNumber)
+            if curr.mmol { isfBefore *= mmolToMgdl }
             guard isfBefore > 0 else { continue }
 
-            let delta = Double(truncating: currGlucoseDecimal as NSDecimalNumber)
-                - Double(truncating: prevGlucoseDecimal as NSDecimalNumber)
+            let scale = curr.mmol ? mmolToMgdl : 1.0
+            let delta = (Double(truncating: currGlucoseDecimal as NSDecimalNumber)
+                - Double(truncating: prevGlucoseDecimal as NSDecimalNumber)) * scale
             let expectedBGI = -iob * isfBefore * (elapsedMin / 60.0)
             guard abs(expectedBGI) > 0.5 else { continue }
 

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -271,6 +271,12 @@ final class OpenAPS {
                     } else {
                         promise(.success(nil))
                     }
+
+                    // Build the improved ISF schedule if the user has opted in.
+                    let freeapsRaw = self.loadFileFromStorage(name: Settings.settings)
+                    if FreeAPSSettings(from: freeapsRaw)?.calculateISFSuggestions == true {
+                        self.buildReasonsISFSchedule()
+                    }
                 }
             }
         }
@@ -1389,5 +1395,127 @@ final class OpenAPS {
             return ""
         }
         return (try? String(contentsOf: url)) ?? ""
+    }
+
+    // MARK: - Calculated ISF Schedule
+
+    /// Builds a per-hour median ISF schedule from CoreData Reasons entries using the
+    /// improved algorithm: back-calculates isf_before = isf × ratio for every entry
+    /// (no near-basal filter), applies a global p5/p95 trim, then buckets by hour.
+    ///
+    /// Uses a 21-day window to match the web ISF Profiler. Requires at least 12 hours
+    /// with ≥ 3 direct data points each before the schedule is considered reliable.
+    @discardableResult
+    func buildReasonsISFSchedule() -> ReasonsISFSchedule? {
+        let cutoff = Date().addingTimeInterval(-21 * 24 * 3600) as NSDate
+        let reasons = CoreDataStorage().fetchReasons(interval: cutoff)
+
+        guard !reasons.isEmpty else {
+            debug(.openAPS, "Calculated ISF: no Reasons data available")
+            return nil
+        }
+
+        // Back-calculate isf_before = applied_isf × sensitivity_ratio for every entry.
+        // This recovers the profile (or autosens-adjusted) ISF before any dynamic scaling,
+        // which is the quantity we want regardless of how aggressively AutoISF was working.
+        var allEstimates: [(value: Double, hour: Int, date: Date)] = []
+
+        for r in reasons {
+            guard
+                let isfDecimal = r.isf?.decimalValue, isfDecimal > 0,
+                let ratioDecimal = r.ratio?.decimalValue, ratioDecimal > 0,
+                let date = r.date
+            else { continue }
+
+            let isfBefore = isfDecimal * ratioDecimal
+            if isfBefore <= 0 { continue }
+
+            let hour = Calendar.current.component(.hour, from: date)
+            allEstimates.append((value: Double(truncating: isfBefore as NSDecimalNumber), hour: hour, date: date))
+        }
+
+        guard !allEstimates.isEmpty else {
+            debug(.openAPS, "Calculated ISF: no valid estimates after back-calculation")
+            return nil
+        }
+
+        let totalEntries = allEstimates.count
+        let fromDate = allEstimates.map(\.date).min() ?? cutoff as Date
+        let toDate = allEstimates.map(\.date).max() ?? Date()
+
+        // Count distinct calendar days represented.
+        let calendar = Calendar.current
+        let daysAnalyzed = Set(allEstimates.map { calendar.startOfDay(for: $0.date) }).count
+
+        // Global p5/p95 trim — eliminates extreme outliers without filtering by ratio.
+        let sorted = allEstimates.map(\.value).sorted()
+        let n = sorted.count
+        let p5Index  = Int((Double(n - 1) * 0.05).rounded())
+        let p95Index = Int((Double(n - 1) * 0.95).rounded())
+        let p5  = sorted[p5Index]
+        let p95 = sorted[p95Index]
+
+        var hourBuckets: [Int: [Double]] = [:]
+        for e in allEstimates {
+            guard e.value >= p5, e.value <= p95 else { continue }
+            hourBuckets[e.hour, default: []].append(e.value)
+        }
+
+        let qualifyingEntries = hourBuckets.values.reduce(0) { $0 + $1.count }
+
+        // Per-hour median (minimum 3 points for a direct measurement).
+        var hourMedians: [Int: Double] = [:]
+        var counts: [String: Int] = [:]
+
+        for hour in 0 ..< 24 {
+            let pts = hourBuckets[hour] ?? []
+            counts[String(hour)] = pts.count
+            if pts.count >= 3 {
+                let s = pts.sorted()
+                hourMedians[hour] = s[s.count / 2]
+            }
+        }
+
+        // Require at least 12 hours with direct measurements.
+        guard hourMedians.count >= 12 else {
+            debug(.openAPS, "Calculated ISF: only \(hourMedians.count) hours have ≥ 3 data points (need 12)")
+            return nil
+        }
+
+        // Interpolate hours with insufficient data from the nearest measured neighbour.
+        var schedule: [String: Double] = [:]
+        for (hour, median) in hourMedians {
+            schedule[String(hour)] = median
+        }
+        for hour in 0 ..< 24 {
+            guard schedule[String(hour)] == nil else { continue }
+            for offset in 1 ..< 12 {
+                if let v = schedule[String((hour - offset + 24) % 24)] { schedule[String(hour)] = v; break }
+                if let v = schedule[String((hour + offset) % 24)]      { schedule[String(hour)] = v; break }
+            }
+        }
+
+        // Overall median from directly-measured hours only.
+        let measuredMedians = (0 ..< 24)
+            .filter { (counts[String($0)] ?? 0) >= 3 }
+            .compactMap { schedule[String($0)] }
+            .sorted()
+        let overallMedian = measuredMedians[measuredMedians.count / 2]
+
+        let result = ReasonsISFSchedule(
+            hours: schedule,
+            counts: counts,
+            overallMedian: overallMedian,
+            generatedAt: Date(),
+            daysAnalyzed: daysAnalyzed,
+            totalEntries: totalEntries,
+            qualifyingEntries: qualifyingEntries,
+            fromDate: fromDate,
+            toDate: toDate
+        )
+
+        storage.save(result, as: Settings.reasonsISFSchedule)
+        debug(.openAPS, "Calculated ISF: built schedule from \(totalEntries) entries (\(daysAnalyzed) days); median \(String(format: "%.1f", overallMedian)) mg/dL/U")
+        return result
     }
 }

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -1452,32 +1452,58 @@ final class OpenAPS {
         let calendar = Calendar.current
         let daysAnalyzed = Set(allEstimates.map { calendar.startOfDay(for: $0.date) }).count
 
-        // Global p5/p95 trim — eliminates extreme outliers without filtering by ratio.
-        let sorted = allEstimates.map(\.value).sorted()
-        let n = sorted.count
-        let p5Index  = Int((Double(n - 1) * 0.05).rounded())
-        let p95Index = Int((Double(n - 1) * 0.95).rounded())
-        let p5  = sorted[p5Index]
-        let p95 = sorted[p95Index]
-
-        var hourBuckets: [Int: [Double]] = [:]
-        for e in allEstimates {
-            guard e.value >= p5, e.value <= p95 else { continue }
-            hourBuckets[e.hour, default: []].append(e.value)
+        // Weighted percentile over a pre-sorted (ascending) parallel (values, weights) pair.
+        func weightedPercentile(_ values: [Double], weights: [Double], p: Double) -> Double {
+            guard values.count > 1 else { return values.first ?? 0 }
+            let totalWeight = weights.reduce(0, +)
+            guard totalWeight > 0 else { return values[values.count / 2] }
+            let target = p / 100.0 * totalWeight
+            var cumulative = 0.0
+            for i in 0 ..< values.count {
+                let prevCum = cumulative
+                cumulative += weights[i]
+                if cumulative >= target {
+                    if i == 0 || weights[i] <= 0 { return values[i] }
+                    let frac = (target - prevCum) / weights[i]
+                    return values[i - 1] + frac * (values[i] - values[i - 1])
+                }
+            }
+            return values.last!
         }
 
-        let qualifyingEntries = hourBuckets.values.reduce(0) { $0 + $1.count }
+        // Recency weighting: weight = exp(-ln(2)/7 × daysSince), half-life 7 days.
+        // A settings change a week ago already outweighs data from three weeks ago.
+        let decayLambda = log(2.0) / 7.0
 
-        // Per-hour median (minimum 3 points for a direct measurement).
+        // Per-hour bucket fill — no global trim; each hour trims its own 5% tails.
+        var hourBuckets: [Int: [(value: Double, weight: Double)]] = [:]
+        for e in allEstimates {
+            let daysSince = toDate.timeIntervalSince(e.date) / 86400.0
+            let weight = exp(-decayLambda * daysSince)
+            hourBuckets[e.hour, default: []].append((value: e.value, weight: weight))
+        }
+
+        var qualifyingEntries = 0
         var hourMedians: [Int: Double] = [:]
         var counts: [String: Int] = [:]
 
         for hour in 0 ..< 24 {
-            let pts = hourBuckets[hour] ?? []
+            var pts = (hourBuckets[hour] ?? []).sorted { $0.value < $1.value }
+            let n = pts.count
+
+            // Trim bottom and top 5% by count (only when n is large enough to be meaningful).
+            if n >= 10 {
+                let trimN = Int(floor(Double(n) * 0.05))
+                pts = Array(pts.dropFirst(trimN).dropLast(trimN))
+            }
+
+            qualifyingEntries += pts.count
             counts[String(hour)] = pts.count
+
             if pts.count >= 3 {
-                let s = pts.sorted()
-                hourMedians[hour] = s[s.count / 2]
+                let values  = pts.map(\.value)
+                let weights = pts.map(\.weight)
+                hourMedians[hour] = weightedPercentile(values, weights: weights, p: 50.0)
             }
         }
 
@@ -1513,7 +1539,7 @@ final class OpenAPS {
         // Positive deviation → BG dropped less than expected → profile ISF is too high → suggest lower ISF.
         let sortedReasons = reasons.sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
 
-        var devHourBuckets: [Int: [(isfBefore: Double, deviation: Double, absExpBGI: Double)]] = [:]
+        var devHourBuckets: [Int: [(isfBefore: Double, deviation: Double, absExpBGI: Double, weight: Double)]] = [:]
         var devQualifyingEntries = 0
 
         for i in 1 ..< sortedReasons.count {
@@ -1552,7 +1578,9 @@ final class OpenAPS {
 
             let deviation = delta - expectedBGI
             let hour = Calendar.current.component(.hour, from: currDate)
-            devHourBuckets[hour, default: []].append((isfBefore, deviation, abs(expectedBGI)))
+            let devDaysSince = toDate.timeIntervalSince(currDate) / 86400.0
+            let devWeight = exp(-decayLambda * devDaysSince)
+            devHourBuckets[hour, default: []].append((isfBefore, deviation, abs(expectedBGI), devWeight))
             devQualifyingEntries += 1
         }
 
@@ -1561,13 +1589,13 @@ final class OpenAPS {
         for (hour, entries) in devHourBuckets {
             guard entries.count >= 5 else { continue }
 
-            let deviations  = entries.map(\.deviation).sorted()
-            let expBGIs     = entries.map(\.absExpBGI).sorted()
-            let isfBefores  = entries.map(\.isfBefore).sorted()
+            let sortedDev    = entries.sorted { $0.deviation < $1.deviation }
+            let sortedExpBGI = entries.sorted { $0.absExpBGI < $1.absExpBGI }
+            let sortedISF    = entries.sorted { $0.isfBefore < $1.isfBefore }
 
-            let medDev      = deviations[deviations.count / 2]
-            let medExpBGI   = expBGIs[expBGIs.count / 2]
-            let medISFBefore = isfBefores[isfBefores.count / 2]
+            let medDev       = weightedPercentile(sortedDev.map(\.deviation),    weights: sortedDev.map(\.weight),    p: 50.0)
+            let medExpBGI    = weightedPercentile(sortedExpBGI.map(\.absExpBGI), weights: sortedExpBGI.map(\.weight), p: 50.0)
+            let medISFBefore = weightedPercentile(sortedISF.map(\.isfBefore),    weights: sortedISF.map(\.weight),    p: 50.0)
 
             guard medExpBGI > 0.5 else { continue }
 

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -1502,6 +1502,93 @@ final class OpenAPS {
             .sorted()
         let overallMedian = measuredMedians[measuredMedians.count / 2]
 
+        // MARK: - Deviation analysis
+        // Sort by date ascending and compute per-entry BG delta from consecutive readings.
+        // deviation = actual_delta - expectedBGI, where expectedBGI = -IOB × isf_before × (elapsed/60).
+        // Positive deviation → BG dropped less than expected → profile ISF is too high → suggest lower ISF.
+        let sortedReasons = reasons.sorted { ($0.date ?? .distantPast) < ($1.date ?? .distantPast) }
+
+        var devHourBuckets: [Int: [(isfBefore: Double, deviation: Double, absExpBGI: Double)]] = [:]
+        var devQualifyingEntries = 0
+
+        for i in 1 ..< sortedReasons.count {
+            let prev = sortedReasons[i - 1]
+            let curr = sortedReasons[i]
+
+            guard
+                let prevDate = prev.date,
+                let currDate = curr.date,
+                let currGlucoseDecimal = curr.glucose?.decimalValue,
+                let prevGlucoseDecimal = prev.glucose?.decimalValue,
+                let iobDecimal = curr.iob?.decimalValue,
+                let isfDecimal = curr.isf?.decimalValue, isfDecimal > 0,
+                let ratioDecimal = curr.ratio?.decimalValue, ratioDecimal > 0,
+                let cobDecimal = curr.cob?.decimalValue
+            else { continue }
+
+            let elapsedMin = currDate.timeIntervalSince(prevDate) / 60.0
+            guard elapsedMin >= 3, elapsedMin <= 10 else { continue }
+
+            let iob = Double(truncating: iobDecimal as NSDecimalNumber)
+            guard iob > 0 else { continue }
+
+            let cob = Double(truncating: cobDecimal as NSDecimalNumber)
+            guard cob <= 5 else { continue }
+
+            let isfBefore = Double(truncating: (isfDecimal * ratioDecimal) as NSDecimalNumber)
+            guard isfBefore > 0 else { continue }
+
+            let delta = Double(truncating: currGlucoseDecimal as NSDecimalNumber)
+                - Double(truncating: prevGlucoseDecimal as NSDecimalNumber)
+            let expectedBGI = -iob * isfBefore * (elapsedMin / 60.0)
+            guard abs(expectedBGI) > 0.5 else { continue }
+
+            let deviation = delta - expectedBGI
+            let hour = Calendar.current.component(.hour, from: currDate)
+            devHourBuckets[hour, default: []].append((isfBefore, deviation, abs(expectedBGI)))
+            devQualifyingEntries += 1
+        }
+
+        // Per-hour: median deviation → adjustment fraction → suggested ISF.
+        var suggestedDirect: [String: Double] = [:]
+        for (hour, entries) in devHourBuckets {
+            guard entries.count >= 5 else { continue }
+
+            let deviations  = entries.map(\.deviation).sorted()
+            let expBGIs     = entries.map(\.absExpBGI).sorted()
+            let isfBefores  = entries.map(\.isfBefore).sorted()
+
+            let medDev      = deviations[deviations.count / 2]
+            let medExpBGI   = expBGIs[expBGIs.count / 2]
+            let medISFBefore = isfBefores[isfBefores.count / 2]
+
+            guard medExpBGI > 0.5 else { continue }
+
+            var adjFraction = medDev / medExpBGI
+            adjFraction = max(-0.20, min(0.20, adjFraction))
+
+            suggestedDirect[String(hour)] = medISFBefore * (1.0 - adjFraction)
+        }
+
+        // Interpolate suggested hours from nearest neighbour (require ≥6 directly-computed hours).
+        var suggestedSchedule: [String: Double]? = nil
+        if suggestedDirect.count >= 6 {
+            var interpolated = suggestedDirect
+            for hour in 0 ..< 24 {
+                guard interpolated[String(hour)] == nil else { continue }
+                for offset in 1 ..< 12 {
+                    if let v = interpolated[String((hour - offset + 24) % 24)] { interpolated[String(hour)] = v; break }
+                    if let v = interpolated[String((hour + offset) % 24)]      { interpolated[String(hour)] = v; break }
+                }
+            }
+            suggestedSchedule = interpolated
+        }
+
+        let suggestedMeasured = suggestedDirect.values.sorted()
+        let overallSuggestedMedian: Double? = suggestedMeasured.isEmpty
+            ? nil
+            : suggestedMeasured[suggestedMeasured.count / 2]
+
         let result = ReasonsISFSchedule(
             hours: schedule,
             counts: counts,
@@ -1511,11 +1598,14 @@ final class OpenAPS {
             totalEntries: totalEntries,
             qualifyingEntries: qualifyingEntries,
             fromDate: fromDate,
-            toDate: toDate
+            toDate: toDate,
+            suggestedHours: suggestedSchedule,
+            overallSuggestedMedian: overallSuggestedMedian,
+            devQualifyingEntries: devQualifyingEntries
         )
 
         storage.save(result, as: Settings.reasonsISFSchedule)
-        debug(.openAPS, "Calculated ISF: built schedule from \(totalEntries) entries (\(daysAnalyzed) days); median \(String(format: "%.1f", overallMedian)) mg/dL/U")
+        debug(.openAPS, "Calculated ISF: built schedule from \(totalEntries) entries (\(daysAnalyzed) days); median \(String(format: "%.1f", overallMedian)) mg/dL/U; deviation entries \(devQualifyingEntries), suggested hours \(suggestedDirect.count)")
         return result
     }
 }

--- a/FreeAPS/Sources/Models/Autotune.swift
+++ b/FreeAPS/Sources/Models/Autotune.swift
@@ -21,6 +21,12 @@ struct ReasonsISFSchedule: JSON {
     let fromDate: Date
     /// Latest Reasons entry date included.
     let toDate: Date
+    /// Deviation-adjusted suggested ISF per hour, mg/dL. Nil when insufficient deviation data.
+    let suggestedHours: [String: Double]?
+    /// Overall median of directly-measured deviation-suggested ISF values, mg/dL.
+    let overallSuggestedMedian: Double?
+    /// Number of loop entries that passed the deviation-analysis filter.
+    let devQualifyingEntries: Int?
 }
 
 struct Autotune: JSON, Equatable {

--- a/FreeAPS/Sources/Models/Autotune.swift
+++ b/FreeAPS/Sources/Models/Autotune.swift
@@ -1,5 +1,28 @@
 import Foundation
 
+/// Per-hour ISF schedule derived from CoreData Reasons entries using the improved
+/// back-calculation algorithm (isf_before = isf × ratio, global p5/p95 trim, 21-day window).
+struct ReasonsISFSchedule: JSON {
+    /// Per-hour median ISF in mg/dL. Keys are "0"–"23".
+    let hours: [String: Double]
+    /// Data-point count used for each hour's median. 0 = interpolated from neighbour.
+    let counts: [String: Int]
+    /// Overall median across all directly-measured hours, in mg/dL.
+    let overallMedian: Double
+    /// When this schedule was last computed.
+    let generatedAt: Date
+    /// Number of calendar days of Reasons data that contributed.
+    let daysAnalyzed: Int
+    /// Total Reasons entries before trimming.
+    let totalEntries: Int
+    /// Entries remaining after global p5/p95 trim.
+    let qualifyingEntries: Int
+    /// Earliest Reasons entry date included.
+    let fromDate: Date
+    /// Latest Reasons entry date included.
+    let toDate: Date
+}
+
 struct Autotune: JSON, Equatable {
     var createdAt: Date?
     var basalProfile: [BasalProfileEntry]

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -128,6 +128,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var iobThresholdPercent: Decimal = 100
     var autoisf_max: Decimal = 1.2
     var autoisf_min: Decimal = 0.8
+    var isfScale: Double = 1.0
     // B30
     var use_B30 = false
     var iTime_Start_Bolus: Decimal = 1.5
@@ -684,6 +685,10 @@ extension FreeAPSSettings: Decodable {
 
         if let autoisf_min = try? container.decode(Decimal.self, forKey: .autoisf_min) {
             settings.autoisf_min = autoisf_min
+        }
+
+        if let isfScale = try? container.decode(Double.self, forKey: .isfScale) {
+            settings.isfScale = isfScale
         }
 
         if let glucoseOverrideThreshold = try? container.decode(Decimal.self, forKey: .glucoseOverrideThreshold) {

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -51,6 +51,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var displayFatAndProteinOnWatch: Bool = false
     var confirmBolusFaster: Bool = false
     var onlyAutotuneBasals: Bool = false
+    var calculateISFSuggestions: Bool = false
     var overrideFactor: Decimal = 0.8
     var useCalc: Bool = true
     var fattyMeals: Bool = false
@@ -455,6 +456,10 @@ extension FreeAPSSettings: Decodable {
 
         if let onlyAutotuneBasals = try? container.decode(Bool.self, forKey: .onlyAutotuneBasals) {
             settings.onlyAutotuneBasals = onlyAutotuneBasals
+        }
+
+        if let calculateISFSuggestions = try? container.decode(Bool.self, forKey: .calculateISFSuggestions) {
+            settings.calculateISFSuggestions = calculateISFSuggestions
         }
 
         if let displayPredictions = try? container.decode(Bool.self, forKey: .displayPredictions) {

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -128,7 +128,7 @@ struct FreeAPSSettings: JSON, Equatable {
     var iobThresholdPercent: Decimal = 100
     var autoisf_max: Decimal = 1.2
     var autoisf_min: Decimal = 0.8
-    var isfScale: Double = 1.0
+    var isfScale: Decimal = 1.0
     // B30
     var use_B30 = false
     var iTime_Start_Bolus: Decimal = 1.5
@@ -687,7 +687,7 @@ extension FreeAPSSettings: Decodable {
             settings.autoisf_min = autoisf_min
         }
 
-        if let isfScale = try? container.decode(Double.self, forKey: .isfScale) {
+        if let isfScale = try? container.decode(Decimal.self, forKey: .isfScale) {
             settings.isfScale = isfScale
         }
 

--- a/FreeAPS/Sources/Modules/AutoISF/AutoISFStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutoISF/AutoISFStateModel.swift
@@ -22,7 +22,6 @@ extension AutoISF {
         @Published var bgAccelISFweight: Decimal = 0
         @Published var bgBrakeISFweight: Decimal = 0.10
         @Published var iobThresholdPercent: Decimal = 100
-        @Published var isfScale: Decimal = 1.0
 
         // B30
         @Published var iTime_Start_Bolus: Decimal = 1.5
@@ -62,7 +61,6 @@ extension AutoISF {
             subscribeSetting(\.bgAccelISFweight, on: $bgAccelISFweight) { bgAccelISFweight = $0 }
             subscribeSetting(\.bgBrakeISFweight, on: $bgBrakeISFweight) { bgBrakeISFweight = $0 }
             subscribeSetting(\.iobThresholdPercent, on: $iobThresholdPercent) { iobThresholdPercent = $0 }
-            subscribeSetting(\.isfScale, on: $isfScale) { isfScale = $0 }
 
             subscribeSetting(\.use_B30, on: $use_B30) { use_B30 = $0 }
             subscribeSetting(\.iTime_Start_Bolus, on: $iTime_Start_Bolus) { iTime_Start_Bolus = $0 }

--- a/FreeAPS/Sources/Modules/AutoISF/AutoISFStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutoISF/AutoISFStateModel.swift
@@ -22,7 +22,7 @@ extension AutoISF {
         @Published var bgAccelISFweight: Decimal = 0
         @Published var bgBrakeISFweight: Decimal = 0.10
         @Published var iobThresholdPercent: Decimal = 100
-        @Published var isfScale: Double = 1.0
+        @Published var isfScale: Decimal = 1.0
 
         // B30
         @Published var iTime_Start_Bolus: Decimal = 1.5

--- a/FreeAPS/Sources/Modules/AutoISF/AutoISFStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutoISF/AutoISFStateModel.swift
@@ -22,6 +22,7 @@ extension AutoISF {
         @Published var bgAccelISFweight: Decimal = 0
         @Published var bgBrakeISFweight: Decimal = 0.10
         @Published var iobThresholdPercent: Decimal = 100
+        @Published var isfScale: Double = 1.0
 
         // B30
         @Published var iTime_Start_Bolus: Decimal = 1.5
@@ -61,6 +62,7 @@ extension AutoISF {
             subscribeSetting(\.bgAccelISFweight, on: $bgAccelISFweight) { bgAccelISFweight = $0 }
             subscribeSetting(\.bgBrakeISFweight, on: $bgBrakeISFweight) { bgBrakeISFweight = $0 }
             subscribeSetting(\.iobThresholdPercent, on: $iobThresholdPercent) { iobThresholdPercent = $0 }
+            subscribeSetting(\.isfScale, on: $isfScale) { isfScale = $0 }
 
             subscribeSetting(\.use_B30, on: $use_B30) { use_B30 = $0 }
             subscribeSetting(\.iTime_Start_Bolus, on: $iTime_Start_Bolus) { iTime_Start_Bolus = $0 }

--- a/FreeAPS/Sources/Modules/AutoISF/View/AutoISFRootView.swift
+++ b/FreeAPS/Sources/Modules/AutoISF/View/AutoISFRootView.swift
@@ -339,19 +339,6 @@ extension AutoISF {
                                 .disabled(isPresented)
                         }
 
-                        HStack {
-                            Text("ISF Scale")
-                                .onTapGesture {
-                                    info(
-                                        header: "ISF Scale",
-                                        body: "Multiplier applied to the entire autotune-calculated ISF schedule before it is written to your profile. Default is 1.0 (no adjustment). Reduce below 1.0 (e.g. 0.93) if AutoISF is consistently hitting its autoisf_max ceiling — this lowers the profile ISF anchor, giving the algorithm more headroom on meal responses. Increase above 1.0 to make the profile more conservative. Change in small steps (0.02–0.05) and allow 2–3 days to evaluate.",
-                                        useGraphics: nil
-                                    )
-                                }
-                            Spacer()
-                            DecimalTextField("1", value: $state.isfScale, formatter: formatter)
-                                .disabled(isPresented)
-                        }
                     } header: { Text("Settings") }
 
                     Section {

--- a/FreeAPS/Sources/Modules/AutoISF/View/AutoISFRootView.swift
+++ b/FreeAPS/Sources/Modules/AutoISF/View/AutoISFRootView.swift
@@ -338,6 +338,20 @@ extension AutoISF {
                             DecimalTextField("0", value: $state.iobThresholdPercent, formatter: formatter)
                                 .disabled(isPresented)
                         }
+
+                        HStack {
+                            Text("ISF Scale")
+                                .onTapGesture {
+                                    info(
+                                        header: "ISF Scale",
+                                        body: "Multiplier applied to the entire autotune-calculated ISF schedule before it is written to your profile. Default is 1.0 (no adjustment). Reduce below 1.0 (e.g. 0.93) if AutoISF is consistently hitting its autoisf_max ceiling — this lowers the profile ISF anchor, giving the algorithm more headroom on meal responses. Increase above 1.0 to make the profile more conservative. Change in small steps (0.02–0.05) and allow 2–3 days to evaluate.",
+                                        useGraphics: nil
+                                    )
+                                }
+                            Spacer()
+                            DecimalTextField("1", value: $state.isfScale, formatter: formatter)
+                                .disabled(isPresented)
+                        }
                     } header: { Text("Settings") }
 
                     Section {

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigDataFlow.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigDataFlow.swift
@@ -8,4 +8,7 @@ protocol AutotuneConfigProvider: Provider {
     var autotune: Autotune? { get }
     func runAutotune() -> AnyPublisher<Autotune?, Never>
     func deleteAutotune()
+    var reasonsISFSchedule: ReasonsISFSchedule? { get }
+    var currentISFProfile: InsulinSensitivities? { get }
+    func saveISFProfile(_ profile: InsulinSensitivities)
 }

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigProvider.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigProvider.swift
@@ -21,5 +21,18 @@ extension AutotuneConfig {
                 ?? [BasalProfileEntry](from: OpenAPS.defaults(for: OpenAPS.Settings.basalProfile))
                 ?? []
         }
+
+        var reasonsISFSchedule: ReasonsISFSchedule? {
+            storage.retrieve(OpenAPS.Settings.reasonsISFSchedule, as: ReasonsISFSchedule.self)
+        }
+
+        var currentISFProfile: InsulinSensitivities? {
+            storage.retrieve(OpenAPS.Settings.insulinSensitivities, as: InsulinSensitivities.self)
+                ?? InsulinSensitivities(from: OpenAPS.defaults(for: OpenAPS.Settings.insulinSensitivities))
+        }
+
+        func saveISFProfile(_ profile: InsulinSensitivities) {
+            storage.save(profile, as: OpenAPS.Settings.insulinSensitivities)
+        }
     }
 }

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
@@ -15,6 +15,7 @@ extension AutotuneConfig {
         @Published var publishedDate = Date()
         @Published var increment: Double = 0.1
         @Published var running: Bool = false
+        @Published var isfScale: Decimal = 1.0
 
         @Persisted(key: "lastAutotuneDate") private var lastAutotuneDate = Date() {
             didSet {
@@ -38,6 +39,7 @@ extension AutotuneConfig {
             increment = Double(settingsManager.preferences.bolusIncrement)
             subscribeSetting(\.onlyAutotuneBasals, on: $onlyAutotuneBasals) { onlyAutotuneBasals = $0 }
             subscribeSetting(\.calculateISFSuggestions, on: $calculateISFSuggestions) { calculateISFSuggestions = $0 }
+            subscribeSetting(\.isfScale, on: $isfScale) { isfScale = $0 }
 
             currentProfile = provider.profile
             calcTotal()

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
@@ -175,7 +175,7 @@ extension AutotuneConfig {
                 guard let mgdl = mgdl else { return nil }
                 let offsetMinutes = hour * 60
                 let date = Date(timeIntervalSince1970: TimeInterval(offsetMinutes * 60))
-                let scaledMgdl = mgdl * settingsManager.settings.isfScale
+                let scaledMgdl = mgdl * (settingsManager.settings.isfScale as NSDecimalNumber).doubleValue
                 return InsulinSensitivityEntry(
                     sensitivity: displayISF(mgdl: scaledMgdl),
                     offset: offsetMinutes,

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
@@ -171,7 +171,8 @@ extension AutotuneConfig {
             formatter.dateFormat = "HH:mm:ss"
 
             let entries: [InsulinSensitivityEntry] = (0 ..< 24).compactMap { hour in
-                guard let mgdl = schedule.hours[String(hour)] else { return nil }
+                let mgdl = schedule.suggestedHours?[String(hour)] ?? schedule.hours[String(hour)]
+                guard let mgdl = mgdl else { return nil }
                 let offsetMinutes = hour * 60
                 let date = Date(timeIntervalSince1970: TimeInterval(offsetMinutes * 60))
                 return InsulinSensitivityEntry(

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
@@ -175,8 +175,9 @@ extension AutotuneConfig {
                 guard let mgdl = mgdl else { return nil }
                 let offsetMinutes = hour * 60
                 let date = Date(timeIntervalSince1970: TimeInterval(offsetMinutes * 60))
+                let scaledMgdl = mgdl * settingsManager.settings.isfScale
                 return InsulinSensitivityEntry(
-                    sensitivity: displayISF(mgdl: mgdl),
+                    sensitivity: displayISF(mgdl: scaledMgdl),
                     offset: offsetMinutes,
                     start: formatter.string(from: date)
                 )

--- a/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/AutotuneConfigStateModel.swift
@@ -9,6 +9,7 @@ extension AutotuneConfig {
         @Injected() private var storage: FileStorage!
         @Published var useAutotune = false
         @Published var onlyAutotuneBasals = false
+        @Published var calculateISFSuggestions = false
         @Published var autotune: Autotune?
         private(set) var units: GlucoseUnits = .mmolL
         @Published var publishedDate = Date()
@@ -26,6 +27,9 @@ extension AutotuneConfig {
         @Published var currentProfile: [BasalProfileEntry] = []
         @Published var currentTotal: Decimal = 0.0
 
+        @Published private(set) var isfSchedule: ReasonsISFSchedule?
+        @Published private(set) var currentISFProfile: InsulinSensitivities?
+
         override func subscribe() {
             autotune = provider.autotune
             units = settingsManager.settings.units
@@ -33,9 +37,11 @@ extension AutotuneConfig {
             publishedDate = lastAutotuneDate
             increment = Double(settingsManager.preferences.bolusIncrement)
             subscribeSetting(\.onlyAutotuneBasals, on: $onlyAutotuneBasals) { onlyAutotuneBasals = $0 }
+            subscribeSetting(\.calculateISFSuggestions, on: $calculateISFSuggestions) { calculateISFSuggestions = $0 }
 
             currentProfile = provider.profile
             calcTotal()
+            loadISFSchedule()
 
             $useAutotune
                 .removeDuplicates()
@@ -86,6 +92,7 @@ extension AutotuneConfig {
                     DispatchQueue.main.async {
                         self?.lastAutotuneDate = Date()
                         self?.running.toggle()
+                        self?.loadISFSchedule()
                     }
                 }.store(in: &lifetime)
         }
@@ -126,6 +133,67 @@ extension AutotuneConfig {
                     }
                 }
             }
+        }
+
+        // MARK: - Calculated ISF
+
+        private func loadISFSchedule() {
+            isfSchedule = provider.reasonsISFSchedule
+            currentISFProfile = provider.currentISFProfile
+        }
+
+        /// Returns the profile ISF covering the given hour in the user's display units.
+        func currentISFForHour(_ hour: Int) -> Decimal? {
+            guard let profile = currentISFProfile, !profile.sensitivities.isEmpty else { return nil }
+            let targetMinutes = hour * 60
+            return profile.sensitivities
+                .sorted { $0.offset < $1.offset }
+                .last { $0.offset <= targetMinutes }
+                .map(\.sensitivity)
+        }
+
+        /// Converts a raw mg/dL ISF value to the user's display unit.
+        func displayISF(mgdl: Double) -> Decimal {
+            if units == .mmolL {
+                let mmol = mgdl * Double(GlucoseUnits.exchangeRate)
+                return Decimal((mmol * 10).rounded() / 10)
+            } else {
+                return Decimal(Int(mgdl.rounded()))
+            }
+        }
+
+        /// Writes the calculated ISF schedule to the profile and triggers a profile rebuild.
+        func saveISFToProfile() {
+            guard let schedule = isfSchedule else { return }
+
+            let formatter = DateFormatter()
+            formatter.timeZone = TimeZone(secondsFromGMT: 0)
+            formatter.dateFormat = "HH:mm:ss"
+
+            let entries: [InsulinSensitivityEntry] = (0 ..< 24).compactMap { hour in
+                guard let mgdl = schedule.hours[String(hour)] else { return nil }
+                let offsetMinutes = hour * 60
+                let date = Date(timeIntervalSince1970: TimeInterval(offsetMinutes * 60))
+                return InsulinSensitivityEntry(
+                    sensitivity: displayISF(mgdl: mgdl),
+                    offset: offsetMinutes,
+                    start: formatter.string(from: date)
+                )
+            }
+            guard !entries.isEmpty else { return }
+
+            let profile = InsulinSensitivities(
+                units: units,
+                userPrefferedUnits: units,
+                sensitivities: entries
+            )
+            provider.saveISFProfile(profile)
+            currentISFProfile = profile
+            debug(.service, "Profile ISF replaced with Calculated ISF schedule by user.")
+
+            apsManager.makeProfiles()
+                .cancellable()
+                .store(in: &lifetime)
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -108,6 +108,24 @@ extension AutotuneConfig {
                 Toggle("Use Autotune", isOn: $state.useAutotune)
                 if state.useAutotune {
                     Toggle("Only Autotune Basal Insulin", isOn: $state.onlyAutotuneBasals)
+                    Toggle("Calculate ISF Suggestions", isOn: $state.calculateISFSuggestions)
+                    if state.calculateISFSuggestions {
+                        NavigationLink(destination: CalculatedISFView(state: state)) {
+                            HStack {
+                                Text("Calculated ISF")
+                                Spacer()
+                                if let schedule = state.isfSchedule {
+                                    Text(dateFormatter.string(from: schedule.generatedAt))
+                                        .font(.footnote)
+                                        .foregroundColor(.secondary)
+                                } else {
+                                    Text("No data yet")
+                                        .font(.footnote)
+                                        .foregroundColor(.secondary)
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -13,6 +13,14 @@ extension AutotuneConfig {
             return formatter
         }
 
+        private var scaleFormatter: NumberFormatter {
+            let f = NumberFormatter()
+            f.numberStyle = .decimal
+            f.minimumFractionDigits = 2
+            f.maximumFractionDigits = 2
+            return f
+        }
+
         init(resolver: Resolver) {
             self.resolver = resolver
             _state = StateObject(wrappedValue: StateModel(resolver: resolver))
@@ -38,6 +46,24 @@ extension AutotuneConfig {
                 if state.useAutotune {
                     Toggle("Only Autotune Basal Insulin", isOn: $state.onlyAutotuneBasals)
                     Toggle("Calculate ISF Suggestions", isOn: $state.calculateISFSuggestions)
+
+                    if state.calculateISFSuggestions {
+                        HStack {
+                            Text("ISF Scale")
+                                .onTapGesture {
+                                    info(
+                                        header: "ISF Scale",
+                                        body: "Multiplier applied to the calculated ISF schedule when saving to your profile. Default is 1.0 (no change). Reduce below 1.0 (e.g. 0.93) if the algorithm consistently needs more insulin than the calculated ISF provides — this shifts the entire 24-hour schedule proportionally. Increase above 1.0 to make the profile more conservative. Change in small steps (0.02–0.05) and allow 2–3 days to evaluate.",
+                                        useGraphics: nil
+                                    )
+                                }
+                            Spacer()
+                            DecimalTextField("1.00", value: $state.isfScale, formatter: scaleFormatter)
+                                .multilineTextAlignment(.trailing)
+                                .keyboardType(.decimalPad)
+                                .frame(width: 80)
+                        }
+                    }
 
                     NavigationLink(destination: CalculatedBasalView(state: state)) {
                         subPageRow(

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -5,67 +5,12 @@ extension AutotuneConfig {
     struct RootView: BaseView {
         let resolver: Resolver
         @StateObject var state: StateModel
-        @State var replaceAlert = false
-
-        private var isfFormatter: NumberFormatter {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 2
-            return formatter
-        }
-
-        private var rateFormatter: NumberFormatter {
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .decimal
-            formatter.maximumFractionDigits = 2
-            formatter.minimumFractionDigits = 2
-            return formatter
-        }
-
-        private func roundToNearestBasalStep(_ value: Decimal) -> Decimal {
-            let step = Decimal(0.05)
-            let scaled = (value / step)
-            let roundedDouble = (scaled as NSDecimalNumber).doubleValue.rounded()
-            let rounded = roundedDouble * 0.05
-            return Decimal(rounded)
-        }
 
         private var dateFormatter: DateFormatter {
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
             formatter.timeStyle = .short
             return formatter
-        }
-
-        private let timeFormatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "HH:mm:ss"
-            return formatter
-        }()
-
-        private let outputTimeFormatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.dateFormat = "HH:mm"
-            return formatter
-        }()
-
-        private func matchingProfileEntry(forSuggestedIndex index: Int) -> BasalProfileEntry? {
-            guard let autotune = state.autotune else { return nil }
-
-            let suggested = autotune.basalProfile[index]
-            let suggestedEnds: Int =
-                (index + 1 < autotune.basalProfile.count)
-                    ? autotune.basalProfile[index + 1].minutes
-                    : 24 * 60
-
-            return state.currentProfile.enumerated().first(where: { currentIndex, currentEntry in
-                let nextOffset =
-                    (currentIndex + 1 < state.currentProfile.count)
-                        ? state.currentProfile[currentIndex + 1].minutes
-                        : 24 * 60
-
-                return currentEntry.minutes <= suggested.minutes && suggestedEnds <= nextOffset
-            })?.element
         }
 
         init(resolver: Resolver) {
@@ -75,55 +20,41 @@ extension AutotuneConfig {
 
         var body: some View {
             Form {
-                autotuneToggles
+                togglesSection
                 runSection
                 runningIndicator
-
-                if let autotune = state.autotune, !state.running {
-                    if !state.onlyAutotuneBasals {
-                        carbAndSensitivitySection(autotune)
-                    }
-
-                    basalProfileSection(autotune)
-                    deleteSection
-                    saveSection
-                }
             }
             .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             .navigationTitle("Autotune")
             .navigationBarTitleDisplayMode(.automatic)
-            .alert(Text("Are you sure?"), isPresented: $replaceAlert) {
-                Button("Yes") {
-                    state.replace()
-                    replaceAlert.toggle()
-                }
-                Button("No") {
-                    replaceAlert.toggle()
-                }
-            }
         }
 
-        private var autotuneToggles: some View {
+        // MARK: - Sections
+
+        private var togglesSection: some View {
             Section {
                 Toggle("Use Autotune", isOn: $state.useAutotune)
+
                 if state.useAutotune {
                     Toggle("Only Autotune Basal Insulin", isOn: $state.onlyAutotuneBasals)
                     Toggle("Calculate ISF Suggestions", isOn: $state.calculateISFSuggestions)
+
+                    NavigationLink(destination: CalculatedBasalView(state: state)) {
+                        subPageRow(
+                            label: "Calculated Basal",
+                            subtitle: state.autotune != nil
+                                ? dateFormatter.string(from: state.publishedDate)
+                                : "No data yet"
+                        )
+                    }
+
                     if state.calculateISFSuggestions {
                         NavigationLink(destination: CalculatedISFView(state: state)) {
-                            HStack {
-                                Text("Calculated ISF")
-                                Spacer()
-                                if let schedule = state.isfSchedule {
-                                    Text(dateFormatter.string(from: schedule.generatedAt))
-                                        .font(.footnote)
-                                        .foregroundColor(.secondary)
-                                } else {
-                                    Text("No data yet")
-                                        .font(.footnote)
-                                        .foregroundColor(.secondary)
-                                }
-                            }
+                            subPageRow(
+                                label: "Calculated ISF",
+                                subtitle: state.isfSchedule.map { dateFormatter.string(from: $0.generatedAt) }
+                                    ?? "No data yet"
+                            )
                         }
                     }
                 }
@@ -136,6 +67,7 @@ extension AutotuneConfig {
                     Text("Last run")
                     Spacer()
                     Text(dateFormatter.string(from: state.publishedDate))
+                        .foregroundColor(.secondary)
                 }
                 Button("Run now") {
                     state.run()
@@ -155,118 +87,15 @@ extension AutotuneConfig {
             }
         }
 
-        private func carbAndSensitivitySection(_ autotune: Autotune) -> some View {
-            Section {
-                HStack {
-                    Text("Carb ratio")
-                    Spacer()
-                    Text(isfFormatter.string(from: autotune.carbRatio as NSNumber) ?? "0")
-                    Text("g/U").foregroundColor(.secondary)
-                }
-                HStack {
-                    Text("Sensitivity")
-                    Spacer()
-                    if state.units == .mmolL {
-                        Text(isfFormatter.string(from: autotune.sensitivity.asMmolL as NSNumber) ?? "0")
-                    } else {
-                        Text(isfFormatter.string(from: autotune.sensitivity as NSNumber) ?? "0")
-                    }
-                    Text(state.units.rawValue + "/U").foregroundColor(.secondary)
-                }
-            }
-        }
+        // MARK: - Helpers
 
-        @ViewBuilder private func basalProfileSection(_ autotune: Autotune) -> some View {
-            Section(header: Text("Basal profile")) {
-                Grid {
-                    ForEach(0 ..< autotune.basalProfile.count, id: \.self) { index in
-                        basalProfileRow(for: autotune, index: index)
-                        Divider()
-                    }
-
-                    GridRow {
-                        Text("Total")
-                            .bold()
-                            .foregroundColor(.primary)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-
-                        Text(rateFormatter.string(from: state.currentTotal as NSNumber) ?? "0")
-                            .foregroundColor(.secondary)
-                        Text("⇢").foregroundColor(.secondary)
-
-                        let total = autotune.basalProfile.reduce(Decimal(0)) { $0 + $1.rate }
-                        let roundedTotal = roundToNearestBasalStep(total)
-
-                        Text(rateFormatter.string(from: roundedTotal as NSNumber) ?? "0")
-                            .foregroundColor(.primary)
-
-                        Text("U/day").foregroundColor(.secondary)
-                    }
-                    .padding(.vertical, 4)
-                }
-                .frame(maxWidth: .infinity, alignment: .trailing)
-            }
-        }
-
-        @ViewBuilder private func basalProfileRow(for autotune: Autotune, index: Int) -> some View {
-            GridRow {
-                if let date = timeFormatter.date(from: autotune.basalProfile[index].start) {
-                    Text(outputTimeFormatter.string(from: date))
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                } else {
-                    Text(autotune.basalProfile[index].start)
-                        .foregroundColor(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-
-                if let current = matchingProfileEntry(forSuggestedIndex: index) {
-                    let oldRate = roundToNearestBasalStep(current.rate)
-                    let newRate = roundToNearestBasalStep(autotune.basalProfile[index].rate)
-                    let difference = newRate - oldRate
-                    let tolerance = Decimal(0.0001)
-
-                    if abs(difference) > tolerance {
-                        Text(rateFormatter.string(from: oldRate as NSNumber) ?? "0")
-                            .foregroundColor(.secondary)
-
-                        Text("⇢").foregroundColor(.secondary)
-
-                        Text(rateFormatter.string(from: newRate as NSNumber) ?? "0")
-                            .foregroundColor(.primary)
-                    } else {
-                        Text("")
-                        Text("")
-                        Text(rateFormatter.string(from: newRate as NSNumber) ?? "0")
-                            .foregroundColor(.secondary)
-                    }
-                } else {
-                    Text("")
-                    Text("")
-                    Text(rateFormatter.string(from: autotune.basalProfile[index].rate as NSNumber) ?? "0")
-                        .foregroundColor(.secondary)
-                }
-
-                Text("U/hr").foregroundColor(.secondary)
-            }
-            .padding(.vertical, 4)
-        }
-
-        private var deleteSection: some View {
-            Section {
-                Button(role: .destructive) {
-                    state.delete()
-                } label: {
-                    Text("Delete autotune data")
-                }
-            }
-        }
-
-        private var saveSection: some View {
-            Section(header: Text("Save on Pump")) {
-                Button("Save as your Normal Basal Rates") {
-                    replaceAlert = true
-                }
+        private func subPageRow(label: String, subtitle: String) -> some View {
+            HStack {
+                Text(label)
+                Spacer()
+                Text(subtitle)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
             }
         }
     }

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -6,6 +6,12 @@ extension AutotuneConfig {
         let resolver: Resolver
         @StateObject var state: StateModel
 
+        @State private var isPresented = false
+        @State private var description = Text("")
+        @State private var descriptionHeader = Text("")
+        @State private var graphics: (any View)?
+        @State private var scrollView = false
+
         private var dateFormatter: DateFormatter {
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
@@ -31,6 +37,10 @@ extension AutotuneConfig {
                 togglesSection
                 runSection
                 runningIndicator
+            }
+            .blur(radius: isPresented ? 5 : 0)
+            .description(isPresented: isPresented, alignment: .center) {
+                infoView()
             }
             .dynamicTypeSize(...DynamicTypeSize.xxLarge)
             .navigationTitle("Autotune")
@@ -109,6 +119,26 @@ extension AutotuneConfig {
                         ActivityIndicator(isAnimating: .constant(true), style: .medium)
                     }
                 }
+            }
+        }
+
+        // MARK: - Info popup
+
+        private func info(header: String, body: String, useGraphics: (any View)?) {
+            isPresented.toggle()
+            description = Text(LocalizedStringKey(body))
+            descriptionHeader = Text(NSLocalizedString(header, comment: "Autotune setting title"))
+            graphics = useGraphics
+        }
+
+        private func infoView() -> some View {
+            VStack(spacing: 20) {
+                descriptionHeader.font(.title2).bold()
+                description.font(.body)
+            }
+            .formatDescription()
+            .onTapGesture {
+                isPresented.toggle()
             }
         }
 

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/AutotuneConfigRootView.swift
@@ -39,6 +39,7 @@ extension AutotuneConfig {
 
         // MARK: - Sections
 
+        @ViewBuilder
         private var togglesSection: some View {
             Section {
                 Toggle("Use Autotune", isOn: $state.useAutotune)
@@ -46,6 +47,15 @@ extension AutotuneConfig {
                 if state.useAutotune {
                     Toggle("Only Autotune Basal Insulin", isOn: $state.onlyAutotuneBasals)
                     Toggle("Calculate ISF Suggestions", isOn: $state.calculateISFSuggestions)
+
+                    NavigationLink(destination: CalculatedBasalView(state: state)) {
+                        subPageRow(
+                            label: "Calculated Basal",
+                            subtitle: state.autotune != nil
+                                ? dateFormatter.string(from: state.publishedDate)
+                                : "No data yet"
+                        )
+                    }
 
                     if state.calculateISFSuggestions {
                         HStack {
@@ -63,18 +73,7 @@ extension AutotuneConfig {
                                 .keyboardType(.decimalPad)
                                 .frame(width: 80)
                         }
-                    }
 
-                    NavigationLink(destination: CalculatedBasalView(state: state)) {
-                        subPageRow(
-                            label: "Calculated Basal",
-                            subtitle: state.autotune != nil
-                                ? dateFormatter.string(from: state.publishedDate)
-                                : "No data yet"
-                        )
-                    }
-
-                    if state.calculateISFSuggestions {
                         NavigationLink(destination: CalculatedISFView(state: state)) {
                             subPageRow(
                                 label: "Calculated ISF",

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedBasalView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedBasalView.swift
@@ -33,10 +33,10 @@ extension AutotuneConfig {
         }()
 
         private func roundToNearestBasalStep(_ value: Decimal) -> Decimal {
-            let step = Decimal(0.05)
+            let step = Decimal(state.increment)
             let scaled = value / step
             let roundedDouble = (scaled as NSDecimalNumber).doubleValue.rounded()
-            return Decimal(roundedDouble * 0.05)
+            return Decimal(roundedDouble * state.increment)
         }
 
         private func matchingProfileEntry(forSuggestedIndex index: Int) -> BasalProfileEntry? {

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedBasalView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedBasalView.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+extension AutotuneConfig {
+    struct CalculatedBasalView: View {
+        @ObservedObject var state: StateModel
+        @State private var replaceAlert = false
+
+        private var isfFormatter: NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 2
+            return formatter
+        }
+
+        private var rateFormatter: NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .decimal
+            formatter.maximumFractionDigits = 2
+            formatter.minimumFractionDigits = 2
+            return formatter
+        }
+
+        private let timeFormatter: DateFormatter = {
+            let f = DateFormatter()
+            f.dateFormat = "HH:mm:ss"
+            return f
+        }()
+
+        private let outputTimeFormatter: DateFormatter = {
+            let f = DateFormatter()
+            f.dateFormat = "HH:mm"
+            return f
+        }()
+
+        private func roundToNearestBasalStep(_ value: Decimal) -> Decimal {
+            let step = Decimal(0.05)
+            let scaled = value / step
+            let roundedDouble = (scaled as NSDecimalNumber).doubleValue.rounded()
+            return Decimal(roundedDouble * 0.05)
+        }
+
+        private func matchingProfileEntry(forSuggestedIndex index: Int) -> BasalProfileEntry? {
+            guard let autotune = state.autotune else { return nil }
+            let suggested = autotune.basalProfile[index]
+            let suggestedEnds = (index + 1 < autotune.basalProfile.count)
+                ? autotune.basalProfile[index + 1].minutes
+                : 24 * 60
+            return state.currentProfile.enumerated().first(where: { currentIndex, currentEntry in
+                let nextOffset = (currentIndex + 1 < state.currentProfile.count)
+                    ? state.currentProfile[currentIndex + 1].minutes
+                    : 24 * 60
+                return currentEntry.minutes <= suggested.minutes && suggestedEnds <= nextOffset
+            })?.element
+        }
+
+        var body: some View {
+            Form {
+                if let autotune = state.autotune {
+                    if !state.onlyAutotuneBasals {
+                        carbAndSensitivitySection(autotune)
+                    }
+                    basalProfileSection(autotune)
+                    deleteSection
+                    saveSection
+                } else {
+                    noDataSection
+                }
+            }
+            .navigationTitle("Calculated Basal")
+            .navigationBarTitleDisplayMode(.automatic)
+            .alert(Text("Are you sure?"), isPresented: $replaceAlert) {
+                Button("Yes") {
+                    state.replace()
+                    replaceAlert = false
+                }
+                Button("No") {
+                    replaceAlert = false
+                }
+            }
+        }
+
+        // MARK: - Sections
+
+        private func carbAndSensitivitySection(_ autotune: Autotune) -> some View {
+            Section {
+                HStack {
+                    Text("Carb ratio")
+                    Spacer()
+                    Text(isfFormatter.string(from: autotune.carbRatio as NSNumber) ?? "0")
+                    Text("g/U").foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Sensitivity")
+                    Spacer()
+                    if state.units == .mmolL {
+                        Text(isfFormatter.string(from: autotune.sensitivity.asMmolL as NSNumber) ?? "0")
+                    } else {
+                        Text(isfFormatter.string(from: autotune.sensitivity as NSNumber) ?? "0")
+                    }
+                    Text(state.units.rawValue + "/U").foregroundColor(.secondary)
+                }
+            }
+        }
+
+        @ViewBuilder private func basalProfileSection(_ autotune: Autotune) -> some View {
+            Section(header: Text("Basal profile")) {
+                Grid {
+                    ForEach(0 ..< autotune.basalProfile.count, id: \.self) { index in
+                        basalProfileRow(for: autotune, index: index)
+                        Divider()
+                    }
+
+                    GridRow {
+                        Text("Total")
+                            .bold()
+                            .foregroundColor(.primary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Text(rateFormatter.string(from: state.currentTotal as NSNumber) ?? "0")
+                            .foregroundColor(.secondary)
+                        Text("⇢").foregroundColor(.secondary)
+
+                        let total = autotune.basalProfile.reduce(Decimal(0)) { $0 + $1.rate }
+                        let roundedTotal = roundToNearestBasalStep(total)
+                        Text(rateFormatter.string(from: roundedTotal as NSNumber) ?? "0")
+                            .foregroundColor(.primary)
+
+                        Text("U/day").foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 4)
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+
+        @ViewBuilder private func basalProfileRow(for autotune: Autotune, index: Int) -> some View {
+            GridRow {
+                if let date = timeFormatter.date(from: autotune.basalProfile[index].start) {
+                    Text(outputTimeFormatter.string(from: date))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                } else {
+                    Text(autotune.basalProfile[index].start)
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                if let current = matchingProfileEntry(forSuggestedIndex: index) {
+                    let oldRate = roundToNearestBasalStep(current.rate)
+                    let newRate = roundToNearestBasalStep(autotune.basalProfile[index].rate)
+                    let difference = newRate - oldRate
+                    let tolerance = Decimal(0.0001)
+
+                    if abs(difference) > tolerance {
+                        Text(rateFormatter.string(from: oldRate as NSNumber) ?? "0")
+                            .foregroundColor(.secondary)
+                        Text("⇢").foregroundColor(.secondary)
+                        Text(rateFormatter.string(from: newRate as NSNumber) ?? "0")
+                            .foregroundColor(.primary)
+                    } else {
+                        Text("")
+                        Text("")
+                        Text(rateFormatter.string(from: newRate as NSNumber) ?? "0")
+                            .foregroundColor(.secondary)
+                    }
+                } else {
+                    Text("")
+                    Text("")
+                    Text(rateFormatter.string(from: autotune.basalProfile[index].rate as NSNumber) ?? "0")
+                        .foregroundColor(.secondary)
+                }
+
+                Text("U/hr").foregroundColor(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+
+        private var deleteSection: some View {
+            Section {
+                Button(role: .destructive) {
+                    state.delete()
+                } label: {
+                    Text("Delete autotune data")
+                }
+            }
+        }
+
+        private var saveSection: some View {
+            Section(header: Text("Save on Pump")) {
+                Button("Save as your Normal Basal Rates") {
+                    replaceAlert = true
+                }
+            }
+        }
+
+        private var noDataSection: some View {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("No data yet")
+                        .fontWeight(.semibold)
+                    Text("Run Autotune from the previous screen to generate basal suggestions.")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+    }
+}

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
@@ -125,7 +125,7 @@ extension AutotuneConfig {
                     .fontWeight(.semibold)
                     .foregroundColor(.primary)
                 Text(
-                    "Calculated — Each loop cycle records the applied ISF and the sensitivity ratio. " +
+                    "Historical — Each loop cycle records the applied ISF and the sensitivity ratio. " +
                     "The profile ISF is back-calculated as ISF × ratio across the past 21 days, " +
                     "the top and bottom 5% are trimmed, and per-hour medians are computed. " +
                     "Hours with fewer than 3 data points are interpolated from the nearest measured hour."
@@ -138,7 +138,7 @@ extension AutotuneConfig {
                     "back-calculated ISF predicted. If BG consistently drops more than expected at a given hour, " +
                     "the ISF suggestion is raised; if it drops less, it is lowered. " +
                     "The adjustment is capped at ±20% per run to prevent overcorrection. " +
-                    "A large gap between Calculated and Adjusted means the actual glucose response at that hour " +
+                    "A large gap between Historical and Adjusted means the actual glucose response at that hour " +
                     "differs meaningfully from what the profile predicts — for example, the end of dawn phenomenon " +
                     "around 04–06 h often shows insulin becoming noticeably more effective."
                 )
@@ -164,7 +164,7 @@ extension AutotuneConfig {
                         .frame(maxWidth: .infinity, alignment: .leading)
                     Text("Current")
                         .frame(maxWidth: .infinity, alignment: .trailing)
-                    Text("Calculated")
+                    Text("Historical")
                         .frame(maxWidth: .infinity, alignment: .trailing)
                     Text("Adjusted")
                         .frame(maxWidth: .infinity, alignment: .trailing)

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
@@ -233,8 +233,34 @@ extension AutotuneConfig {
             .opacity(isInterpolated ? 0.6 : 1.0)
         }
 
+        private let scaleFormatter: NumberFormatter = {
+            let f = NumberFormatter()
+            f.numberStyle = .decimal
+            f.minimumFractionDigits = 2
+            f.maximumFractionDigits = 2
+            return f
+        }()
+
         private var saveSection: some View {
             Section {
+                HStack {
+                    Text("ISF Scale")
+                    Spacer()
+                    DecimalTextField("1.00", value: $state.isfScale, formatter: scaleFormatter)
+                        .multilineTextAlignment(.trailing)
+                        .keyboardType(.decimalPad)
+                        .frame(width: 80)
+                }
+
+                Text(
+                    "Scale multiplier applied to the calculated schedule before saving. " +
+                    "Default 1.0 (no change). Reduce (e.g. 0.93) if the algorithm consistently " +
+                    "needs more insulin than the calculated ISF provides. Change in small steps " +
+                    "(0.02–0.05) and allow 2–3 days to evaluate."
+                )
+                .font(.footnote)
+                .foregroundColor(.secondary)
+
                 Button(action: { saveAlert = true }) {
                     HStack {
                         Spacer()

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
@@ -125,13 +125,26 @@ extension AutotuneConfig {
                     .fontWeight(.semibold)
                     .foregroundColor(.primary)
                 Text(
-                    "Each loop cycle records the ISF before AutoISF correction and the sensitivity ratio. " +
-                    "The profile ISF is back-calculated as ISF × ratio across all loops in the past 21 days, " +
-                    "the top and bottom 5% are trimmed as outliers, and the remaining values are grouped by hour " +
-                    "to compute per-hour medians. Hours with fewer than 3 data points are interpolated from the nearest measured hour."
+                    "Calculated — Each loop cycle records the applied ISF and the sensitivity ratio. " +
+                    "The profile ISF is back-calculated as ISF × ratio across the past 21 days, " +
+                    "the top and bottom 5% are trimmed, and per-hour medians are computed. " +
+                    "Hours with fewer than 3 data points are interpolated from the nearest measured hour."
                 )
                 .font(.footnote)
                 .foregroundColor(.secondary)
+                .padding(.top, 2)
+                Text(
+                    "Adjusted — A second pass compares how much BG actually moved against what the " +
+                    "back-calculated ISF predicted. If BG consistently drops more than expected at a given hour, " +
+                    "the ISF suggestion is raised; if it drops less, it is lowered. " +
+                    "The adjustment is capped at ±20% per run to prevent overcorrection. " +
+                    "A large gap between Calculated and Adjusted means the actual glucose response at that hour " +
+                    "differs meaningfully from what the profile predicts — for example, the end of dawn phenomenon " +
+                    "around 04–06 h often shows insulin becoming noticeably more effective."
+                )
+                .font(.footnote)
+                .foregroundColor(.secondary)
+                .padding(.top, 2)
             }
             .padding(.vertical, 4)
         }

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
@@ -97,6 +97,22 @@ extension AutotuneConfig {
                     Text("\(median) \(isfUnit)")
                         .foregroundColor(.secondary)
                 }
+                if let suggestedMedian = schedule.overallSuggestedMedian {
+                    HStack {
+                        Text("Suggested median ISF")
+                        Spacer()
+                        let suggested = state.displayISF(mgdl: suggestedMedian)
+                        Text("\(suggested) \(isfUnit)")
+                            .foregroundColor(.accentColor)
+                            .fontWeight(.semibold)
+                    }
+                }
+                HStack {
+                    Text("Deviation entries")
+                    Spacer()
+                    Text("\(schedule.devQualifyingEntries ?? 0)")
+                        .foregroundColor(.secondary)
+                }
 
                 infoNote
             }
@@ -137,7 +153,7 @@ extension AutotuneConfig {
                         .frame(maxWidth: .infinity, alignment: .trailing)
                     Text("Calculated")
                         .frame(maxWidth: .infinity, alignment: .trailing)
-                    Text("Rounded")
+                    Text("Adjusted")
                         .frame(maxWidth: .infinity, alignment: .trailing)
                     Text("n")
                         .frame(width: 30, alignment: .trailing)
@@ -153,7 +169,9 @@ extension AutotuneConfig {
             let isInterpolated = count < 3
             let calculatedMgdl = schedule.hours[String(hour)]
             let calculated = calculatedMgdl.map { state.displayISF(mgdl: $0) }
-            let rounded = calculatedMgdl.map { roundedISF(mgdl: $0) }
+            let suggestedMgdl = schedule.suggestedHours?[String(hour)]
+            let adjusted = (suggestedMgdl ?? calculatedMgdl).map { roundedISF(mgdl: $0) }
+            let hasDeviation = suggestedMgdl != nil && !isInterpolated
             let current = state.currentISFForHour(hour)
 
             Grid {
@@ -182,10 +200,10 @@ extension AutotuneConfig {
                             .frame(maxWidth: .infinity, alignment: .trailing)
                     }
 
-                    if let r = rounded {
+                    if let r = adjusted {
                         Text("\(r)")
-                            .foregroundColor(isInterpolated ? .secondary : .accentColor)
-                            .fontWeight(isInterpolated ? .regular : .semibold)
+                            .foregroundColor(isInterpolated ? .secondary : hasDeviation ? .accentColor : .primary)
+                            .fontWeight(hasDeviation ? .semibold : isInterpolated ? .regular : .regular)
                             .frame(maxWidth: .infinity, alignment: .trailing)
                     } else {
                         Text("—")

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+
+extension AutotuneConfig {
+    struct CalculatedISFView: View {
+        @ObservedObject var state: StateModel
+        @State private var saveAlert = false
+
+        private var dateFormatter: DateFormatter {
+            let f = DateFormatter()
+            f.dateStyle = .medium
+            f.timeStyle = .short
+            return f
+        }
+
+        private var shortDateFormatter: DateFormatter {
+            let f = DateFormatter()
+            f.dateStyle = .medium
+            f.timeStyle = .none
+            return f
+        }
+
+        private let hourFormatter: DateFormatter = {
+            let f = DateFormatter()
+            f.timeZone = TimeZone(secondsFromGMT: 0)
+            f.dateFormat = "HH:mm"
+            return f
+        }()
+
+        private func hourLabel(_ hour: Int) -> String {
+            let date = Date(timeIntervalSince1970: TimeInterval(hour * 3600))
+            return hourFormatter.string(from: date)
+        }
+
+        private var isfUnit: String {
+            state.units.rawValue + "/U"
+        }
+
+        var body: some View {
+            Form {
+                if let schedule = state.isfSchedule {
+                    metadataSection(schedule)
+                    scheduleSection(schedule)
+                    saveSection
+                } else {
+                    noDataSection
+                }
+            }
+            .navigationTitle("Calculated ISF")
+            .navigationBarTitleDisplayMode(.automatic)
+            .alert(Text("Save to Profile ISF?"), isPresented: $saveAlert) {
+                Button("Save") {
+                    state.saveISFToProfile()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text(
+                    "This will replace your current ISF schedule with 24 hourly values " +
+                    "calculated from your last \(state.isfSchedule?.daysAnalyzed ?? 0) days of loop data. " +
+                    "Your previous schedule will be overwritten."
+                )
+            }
+        }
+
+        // MARK: - Sections
+
+        private func metadataSection(_ schedule: ReasonsISFSchedule) -> some View {
+            Section(header: Text("Data Summary")) {
+                HStack {
+                    Text("Last calculated")
+                    Spacer()
+                    Text(dateFormatter.string(from: schedule.generatedAt))
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Days of data")
+                    Spacer()
+                    Text("\(schedule.daysAnalyzed) days")
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Date range")
+                    Spacer()
+                    Text("\(shortDateFormatter.string(from: schedule.fromDate)) – \(shortDateFormatter.string(from: schedule.toDate))")
+                        .foregroundColor(.secondary)
+                        .font(.footnote)
+                }
+                HStack {
+                    Text("Loop entries used")
+                    Spacer()
+                    Text("\(schedule.qualifyingEntries) of \(schedule.totalEntries)")
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Overall median ISF")
+                    Spacer()
+                    let median = state.displayISF(mgdl: schedule.overallMedian)
+                    Text("\(median) \(isfUnit)")
+                        .foregroundColor(.secondary)
+                }
+
+                infoNote
+            }
+        }
+
+        private var infoNote: some View {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("How this is calculated")
+                    .font(.footnote)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+                Text(
+                    "Each loop cycle records the ISF before AutoISF correction and the sensitivity ratio. " +
+                    "The profile ISF is back-calculated as ISF × ratio across all loops in the past 21 days, " +
+                    "the top and bottom 5% are trimmed as outliers, and the remaining values are grouped by hour " +
+                    "to compute per-hour medians. Hours with fewer than 3 data points are interpolated from the nearest measured hour."
+                )
+                .font(.footnote)
+                .foregroundColor(.secondary)
+            }
+            .padding(.vertical, 4)
+        }
+
+        private func scheduleSection(_ schedule: ReasonsISFSchedule) -> some View {
+            Section(header: scheduleHeader) {
+                ForEach(0 ..< 24, id: \.self) { hour in
+                    scheduleRow(hour: hour, schedule: schedule)
+                }
+            }
+        }
+
+        private var scheduleHeader: some View {
+            Grid {
+                GridRow {
+                    Text("Time")
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Text("Current")
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    Text("Calculated")
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    Text("Rounded")
+                        .frame(maxWidth: .infinity, alignment: .trailing)
+                    Text("n")
+                        .frame(width: 30, alignment: .trailing)
+                }
+                .font(.caption)
+                .foregroundColor(.secondary)
+            }
+        }
+
+        @ViewBuilder
+        private func scheduleRow(hour: Int, schedule: ReasonsISFSchedule) -> some View {
+            let count = schedule.counts[String(hour)] ?? 0
+            let isInterpolated = count < 3
+            let calculatedMgdl = schedule.hours[String(hour)]
+            let calculated = calculatedMgdl.map { state.displayISF(mgdl: $0) }
+            let rounded = calculatedMgdl.map { roundedISF(mgdl: $0) }
+            let current = state.currentISFForHour(hour)
+
+            Grid {
+                GridRow {
+                    Text(hourLabel(hour))
+                        .foregroundColor(.secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    if let c = current {
+                        Text("\(c)")
+                            .foregroundColor(.primary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    } else {
+                        Text("—")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+
+                    if let calc = calculated {
+                        Text("\(calc)")
+                            .foregroundColor(isInterpolated ? .secondary : .primary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    } else {
+                        Text("—")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+
+                    if let r = rounded {
+                        Text("\(r)")
+                            .foregroundColor(isInterpolated ? .secondary : .accentColor)
+                            .fontWeight(isInterpolated ? .regular : .semibold)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    } else {
+                        Text("—")
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                    }
+
+                    Text(isInterpolated ? "~" : "\(count)")
+                        .foregroundColor(isInterpolated ? .secondary : .primary)
+                        .font(.footnote)
+                        .frame(width: 30, alignment: .trailing)
+                }
+            }
+            .opacity(isInterpolated ? 0.6 : 1.0)
+        }
+
+        private var saveSection: some View {
+            Section {
+                Button(action: { saveAlert = true }) {
+                    HStack {
+                        Spacer()
+                        Text("Save to Profile ISF")
+                            .fontWeight(.semibold)
+                        Spacer()
+                    }
+                }
+                .foregroundColor(.accentColor)
+
+                Text("Applying this schedule will overwrite your current ISF profile with 24 hourly entries. Review the values above before saving.")
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+
+        private var noDataSection: some View {
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("No data yet")
+                        .fontWeight(.semibold)
+                    Text(
+                        "Run Autotune to calculate your ISF schedule. " +
+                        "The calculation requires at least 12 hours of your day to have 3 or more loop data points each, " +
+                        "drawn from the past 21 days."
+                    )
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+        }
+
+        // MARK: - Helpers
+
+        /// Rounds an ISF to the nearest display-unit increment (0.1 mmol/L or 1 mg/dL).
+        private func roundedISF(mgdl: Double) -> Decimal {
+            if state.units == .mmolL {
+                let mmol = mgdl * Double(GlucoseUnits.exchangeRate)
+                return Decimal((mmol * 10).rounded() / 10)
+            } else {
+                return Decimal(Int(mgdl.rounded()))
+            }
+        }
+    }
+}

--- a/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
+++ b/FreeAPS/Sources/Modules/AutotuneConfig/View/CalculatedISFView.swift
@@ -233,34 +233,8 @@ extension AutotuneConfig {
             .opacity(isInterpolated ? 0.6 : 1.0)
         }
 
-        private let scaleFormatter: NumberFormatter = {
-            let f = NumberFormatter()
-            f.numberStyle = .decimal
-            f.minimumFractionDigits = 2
-            f.maximumFractionDigits = 2
-            return f
-        }()
-
         private var saveSection: some View {
             Section {
-                HStack {
-                    Text("ISF Scale")
-                    Spacer()
-                    DecimalTextField("1.00", value: $state.isfScale, formatter: scaleFormatter)
-                        .multilineTextAlignment(.trailing)
-                        .keyboardType(.decimalPad)
-                        .frame(width: 80)
-                }
-
-                Text(
-                    "Scale multiplier applied to the calculated schedule before saving. " +
-                    "Default 1.0 (no change). Reduce (e.g. 0.93) if the algorithm consistently " +
-                    "needs more insulin than the calculated ISF provides. Change in small steps " +
-                    "(0.02–0.05) and allow 2–3 days to evaluate."
-                )
-                .font(.footnote)
-                .foregroundColor(.secondary)
-
                 Button(action: { saveAlert = true }) {
                     HStack {
                         Spacer()


### PR DESCRIPTION
This does not replace autotune, but runs *with* it at this time.

Its meant to be a more robust ISF calculator then is currently in autotune, but since its brand new and needs more broad testing and feedback, it operators like the Basal Scheduler in Autotune, where you have to consciously decide to apply this to your profile ISF

Unless this is saved to your profile ISF, the values have no effect anywhere

It builds fine, and I currently have it running on my phone, so far with no problems .. the numbers come out what I think are normal, but feedback always good.