### PR TITLE
live activity - update no-chart banner for smart stack WIP

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -74,7 +74,6 @@
 		198F67B82CFCBD5D00E538CB /* AutoISFStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198F67B32CFCBD5D00E538CB /* AutoISFStateModel.swift */; };
 		198FA7BA2D380790006858FD /* ChartModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198FA7B92D380790006858FD /* ChartModel.swift */; };
 		198FEED52D3F8C5900A67FAE /* LiveActivityChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198FEED32D3E93CC00A67FAE /* LiveActivityChart.swift */; };
-		198FEED62D3F8C7900A67FAE /* LiveActivityChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198FEED32D3E93CC00A67FAE /* LiveActivityChart.swift */; };
 		1990DC532D6C1DDE00C4D967 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 19DA487F29CD2B8400EEA1E7 /* Assets.xcassets */; };
 		19914CDC2EDDC09400DC2051 /* MealData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19914CDB2EDDC08F00DC2051 /* MealData.swift */; };
 		1994DBE02C696A410076FCF1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 19DA487F29CD2B8400EEA1E7 /* Assets.xcassets */; };
@@ -501,6 +500,7 @@
 		F2C73D642EB6603900B700AB /* MainChartConfigProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C73D632EB6603900B700AB /* MainChartConfigProvider.swift */; };
 		F2C73D662EB6604500B700AB /* MainChartConfigStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C73D652EB6604500B700AB /* MainChartConfigStateModel.swift */; };
 		F2C73D682EB8022C00B700AB /* CalculatedGeometries.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C73D672EB8022C00B700AB /* CalculatedGeometries.swift */; };
+		F2CBFF252F96E64A004CB668 /* LiveActivityBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2CBFF242F96E64A004CB668 /* LiveActivityBanner.swift */; };
 		F2DCBC522F0B2DEB005D713E /* ManualNutritionOverrideEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DCBC512F0B2DEB005D713E /* ManualNutritionOverrideEditor.swift */; };
 		F2DCBC562F0B30A2005D713E /* ViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2DCBC552F0B30A2005D713E /* ViewExtensions.swift */; };
 		F2E8D1492F0960820097F482 /* FoodItemBadges.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2E8D1482F0960820097F482 /* FoodItemBadges.swift */; };
@@ -1203,6 +1203,7 @@
 		F2C73D632EB6603900B700AB /* MainChartConfigProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainChartConfigProvider.swift; sourceTree = "<group>"; };
 		F2C73D652EB6604500B700AB /* MainChartConfigStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainChartConfigStateModel.swift; sourceTree = "<group>"; };
 		F2C73D672EB8022C00B700AB /* CalculatedGeometries.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalculatedGeometries.swift; sourceTree = "<group>"; };
+		F2CBFF242F96E64A004CB668 /* LiveActivityBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveActivityBanner.swift; sourceTree = "<group>"; };
 		F2DCBC512F0B2DEB005D713E /* ManualNutritionOverrideEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualNutritionOverrideEditor.swift; sourceTree = "<group>"; };
 		F2DCBC552F0B30A2005D713E /* ViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewExtensions.swift; sourceTree = "<group>"; };
 		F2E8D1482F0960820097F482 /* FoodItemBadges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoodItemBadges.swift; sourceTree = "<group>"; };
@@ -1638,6 +1639,7 @@
 			isa = PBXGroup;
 			children = (
 				198FEED32D3E93CC00A67FAE /* LiveActivityChart.swift */,
+				F2CBFF242F96E64A004CB668 /* LiveActivityBanner.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3736,7 +3738,6 @@
 				D2165E9D78EFF692C1DED1C6 /* AddTempTargetDataFlow.swift in Sources */,
 				CE82E02728E869DF00473A9C /* AlertEntry.swift in Sources */,
 				38E4451E274DB04600EC9A94 /* AppDelegate.swift in Sources */,
-				198FEED62D3F8C7900A67FAE /* LiveActivityChart.swift in Sources */,
 				5BFA1C2208114643B77F8CEB /* AddTempTargetProvider.swift in Sources */,
 				BD2FF1A02AE29D43005D1C5D /* CheckboxToggleStyle.swift in Sources */,
 				E0D4F80527513ECF00BDF1FE /* HealthKitSample.swift in Sources */,
@@ -3871,6 +3872,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F2CBFF252F96E64A004CB668 /* LiveActivityBanner.swift in Sources */,
 				056EB4812B4C8B3D00CDE36E /* SystemSoundsManager.swift in Sources */,
 				6BCF84DE2B16843A003AD46E /* LiveActitiyShared.swift in Sources */,
 				198FEED52D3F8C5900A67FAE /* LiveActivityChart.swift in Sources */,

--- a/FreeAPS/Resources/Info.plist
+++ b/FreeAPS/Resources/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSSupportsLiveActivitiesFrequentUpdates</key>
+	<true/>
 	<key>AUTHENTICATE</key>
 	<string>$(AUTHENTICATE)</string>
 	<key>AppGroupID</key>
@@ -121,12 +123,6 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
-	<key>NSCalendarsFullAccessUsageDescription</key>
-	<string>To create events with BG reading values, so that they can be viewed on Apple Watch and CarPlay</string>
-    <key>NSContactsUsageDescription</key>
-    <string>To enable the Contact Image feature: to get live updates from iAPS to your Apple Watch Contact complication</string>
-	<key>LSApplicationCategoryType</key>
-	<string></string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
@@ -134,7 +130,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-  <key>NSPhotoLibraryUsageDescription</key>
-  <string>iAPS will save food photos to your photo library.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>iAPS will save food photos to your photo library.</string>
 </dict>
 </plist>

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -259,7 +259,7 @@ struct BannerTimestampLabel: View {
 
     var body: some View {
         TimestampLabel(context: context)
-            .font(.system(size: 13))
+            .font(.system(size: 14))
             .foregroundStyle(.white.opacity(0.7))
     }
 }

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -3,7 +3,7 @@ import Charts
 import SwiftUI
 import WidgetKit
 
-private enum Size {
+enum LiveActivitySize {
     case minimal
     case compact
     case expanded
@@ -113,7 +113,7 @@ struct LiveActivity: Widget {
         return text
     }
 
-    private func bgAndTrend(context: ActivityViewContext<LiveActivityAttributes>, size: Size) -> (some View, Int) {
+    private func bgAndTrend(context: ActivityViewContext<LiveActivityAttributes>, size: LiveActivitySize) -> (some View, Int) {
         var characters = 0
 
         let bgText = context.state.bg
@@ -170,7 +170,7 @@ struct LiveActivity: Widget {
         return (stack, characters)
     }
 
-    private func iob(context: ActivityViewContext<LiveActivityAttributes>, size _: Size) -> some View {
+    private func iob(context: ActivityViewContext<LiveActivityAttributes>, size _: LiveActivitySize) -> some View {
         HStack(spacing: 0) {
             Text(context.state.iob)
             Text(" U")
@@ -178,7 +178,7 @@ struct LiveActivity: Widget {
         .foregroundStyle(.insulin)
     }
 
-    private func cob(context: ActivityViewContext<LiveActivityAttributes>, size _: Size) -> some View {
+    private func cob(context: ActivityViewContext<LiveActivityAttributes>, size _: LiveActivitySize) -> some View {
         HStack(spacing: 0) {
             Text(context.state.cob)
             Text(" g")
@@ -192,63 +192,69 @@ struct LiveActivity: Widget {
         return LoopActivity(stroke: color, compact: size == 12).frame(width: size)
     }
 
-    private var emptyText: some View {
-        Text(" ").font(.caption).offset(x: 0, y: -5)
-    }
-
     private func bannerWithChart(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
         LiveActivityChartWrapper(context: context)
     }
 
-    @ViewBuilder private func bannerWithoutChart(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
-        VStack(spacing: 2) {
-            ZStack {
-                updatedLabel(context: context).font(.caption).foregroundStyle(.primary.opacity(0.7))
-                    .frame(maxWidth: .infinity, alignment: .trailing)
-            }
-            HStack {
-                VStack {
-                    loop(context: context, size: 22)
-                    emptyText
-                }.offset(x: 0, y: 2)
-                Spacer()
-                VStack {
-                    bgAndTrend(context: context, size: .expanded).0.font(.title)
-                    changeLabel(context: context).font(.caption).foregroundStyle(.primary.opacity(0.7)).offset(x: -12, y: -5)
-                }
-                Spacer()
-                VStack {
-                    iob(context: context, size: .expanded).font(.title)
-                    emptyText
-                }
-                Spacer()
-                VStack {
-                    cob(context: context, size: .expanded).font(.title)
-                    emptyText
-                }
-            }
-            HStack {
-                Spacer()
-                Text(NSLocalizedString("Eventual Glucose", comment: ""))
-                Spacer()
-                Text(context.state.eventual)
-                Text(context.state.mmol ? NSLocalizedString(
-                    "mmol/L",
-                    comment: "The short unit display string for millimoles of glucose per liter"
-                ) : NSLocalizedString(
-                    "mg/dL",
-                    comment: "The short unit display string for milligrams of glucose per decilter"
-                )).foregroundStyle(.secondary)
-            }.padding(.top, 10)
+    private func bannerWithoutChart(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
+        LiveActivityBannerWrapper(context: context)
+    }
+}
+
+extension Color {
+    static let uam = Color("UAM")
+    static let zt = Color("ZT")
+}
+
+private struct LiveActivityChartWrapper: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        if #available(iOS 18.0, *) {
+            LiveActivityChartWrapperIOS18(context: context)
+        } else {
+            LiveActivityChart(context: context, isWatch: false)
         }
-        .privacySensitive()
-        .padding(.vertical, 10).padding(.horizontal, 15)
-        // Semantic BackgroundStyle and Color values work here. They adapt to the given interface style (light mode, dark mode)
-        // Semantic UIColors do NOT (as of iOS 17.1.1). Like UIColor.systemBackgroundColor (it does not adapt to changes of the interface style)
-        // The colorScheme environment varaible that is usually used to detect dark mode does NOT work here (it reports false values)
-        .foregroundStyle(Color.primary)
-        .background(BackgroundStyle.background.opacity(0.4))
-        .activityBackgroundTint(Color.clear)
+    }
+}
+
+@available(iOS 18.0, *) private struct LiveActivityChartWrapperIOS18: View {
+    @Environment(\.activityFamily) private var activityFamily
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        LiveActivityChart(context: context, isWatch: activityFamily == .small)
+    }
+}
+
+private struct LiveActivityBannerWrapper: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        if #available(iOS 18.0, *) {
+            LiveActivityBannerWrapperIOS18(context: context)
+        } else {
+            LiveActivityBanner(context: context, isWatch: false)
+        }
+    }
+}
+
+@available(iOS 18.0, *) private struct LiveActivityBannerWrapperIOS18: View {
+    @Environment(\.activityFamily) private var activityFamily
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        LiveActivityBanner(context: context, isWatch: activityFamily == .small)
+    }
+}
+
+struct LoopActivity: View {
+    @Environment(\.colorScheme) var colorScheme
+    let stroke: Color
+    let compact: Bool
+    var body: some View {
+        Circle()
+            .stroke(stroke, lineWidth: compact ? 1.5 : 3)
     }
 }
 
@@ -524,11 +530,6 @@ struct SampleData {
     }
 }
 
-extension Color {
-    static let uam = Color("UAM")
-    static let zt = Color("ZT")
-}
-
 #Preview("Notification", as: .content, using: LiveActivityAttributes.preview) {
     LiveActivity()
 } contentStates: {
@@ -542,35 +543,4 @@ extension Color {
     LiveActivityAttributes.ContentState.chart3
     LiveActivityAttributes.ContentState.chart4
     LiveActivityAttributes.ContentState.chart5
-}
-
-private struct LiveActivityChartWrapper: View {
-    let context: ActivityViewContext<LiveActivityAttributes>
-
-    var body: some View {
-        if #available(iOS 18.0, *) {
-            LiveActivityChartWrapperIOS18(context: context)
-        } else {
-            LiveActivityChart(context: context, isWatch: false)
-        }
-    }
-}
-
-@available(iOS 18.0, *) private struct LiveActivityChartWrapperIOS18: View {
-    @Environment(\.activityFamily) private var activityFamily
-    let context: ActivityViewContext<LiveActivityAttributes>
-
-    var body: some View {
-        LiveActivityChart(context: context, isWatch: activityFamily == .small)
-    }
-}
-
-struct LoopActivity: View {
-    @Environment(\.colorScheme) var colorScheme
-    let stroke: Color
-    let compact: Bool
-    var body: some View {
-        Circle()
-            .stroke(stroke, lineWidth: compact ? 1.5 : 3)
-    }
 }

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -10,20 +10,6 @@ enum LiveActivitySize {
 }
 
 struct LiveActivity: Widget {
-    private let dateFormatter: DateFormatter = {
-        var formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
-
-    private let minuteFormatter: NumberFormatter = {
-        var formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 0
-        return formatter
-    }()
-
     var body: some WidgetConfiguration {
         let config = ActivityConfiguration(for: LiveActivityAttributes.self) { context in
             // Lock screen/banner UI goes here
@@ -216,7 +202,6 @@ private struct LiveActivityBannerWrapper: View {
 struct LoopCircle: View {
     let context: ActivityViewContext<LiveActivityAttributes>
 
-    @Environment(\.colorScheme) var colorScheme
     let compact: Bool
     let size: CGFloat
 
@@ -250,7 +235,7 @@ struct TimestampLabel: View {
     }()
 
     var body: some View {
-        Text("\(Self.dateFormatter.string(from: context.state.loopDate))")
+        Text(Self.dateFormatter.string(from: context.state.loopDate))
     }
 }
 
@@ -273,6 +258,67 @@ struct WatchLoopCircleAndTimestamp: View {
                 .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
                 .padding(.trailing, 2)
             BannerTimestampLabel(context: context)
+        }
+    }
+}
+
+struct WatchGlucoseDisplay: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+    private let decimalString: String = Locale.current.decimalSeparator ?? "."
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            let string = context.state.bg
+            let decimalSeparator = string.contains(decimalString) ? decimalString : "."
+            let decimal = string.components(separatedBy: decimalSeparator)
+            if decimal.count > 1 {
+                HStack(alignment: .firstTextBaseline, spacing: 0) {
+                    Text(decimal[0]).font(.system(size: 28, weight: .semibold, design: .rounded))
+                    Text(decimalSeparator).font(.system(size: 20, weight: .semibold, design: .rounded))
+                    Text(decimal[1]).font(.system(size: 20, weight: .semibold, design: .rounded))
+                }
+            } else {
+                Text(string)
+                    .font(.system(size: 28, weight: .semibold, design: .rounded))
+            }
+
+            if let direction = context.state.direction {
+                Text(direction)
+                    .font(.system(size: 16))
+            }
+        }
+        .foregroundStyle(Color.white)
+    }
+}
+
+struct WatchIOBCOBDisplay: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    @ViewBuilder var body: some View {
+        HStack(spacing: 10) {
+            HStack(spacing: 0.5) {
+                Text(context.state.iob)
+                    .font(.system(size: 19))
+                    .tracking(-0.5)
+                    .foregroundStyle(.white)
+                Text("U")
+                    .font(.system(size: 19).smallCaps())
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+            .fontWidth(.compressed)
+
+            if context.state.cob != "0" {
+                HStack(spacing: 0.5) {
+                    Text(context.state.cob)
+                        .font(.system(size: 19))
+                        .tracking(-0.5)
+                        .foregroundStyle(.white)
+                    Text("g")
+                        .font(.system(size: 19))
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+                .fontWidth(.compressed)
+            }
         }
     }
 }

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -27,18 +27,14 @@ struct LiveActivity: Widget {
     var body: some WidgetConfiguration {
         let config = ActivityConfiguration(for: LiveActivityAttributes.self) { context in
             // Lock screen/banner UI goes here
-            if !context.state.showChart {
-                bannerWithoutChart(for: context)
-            } else {
-                bannerWithChart(for: context)
-            }
+            LiveActivityBannerWrapper(context: context)
         } dynamicIsland: { context in
             DynamicIsland {
                 // Expanded UI goes here.  Compose the expanded UI through
                 // various regions, like leading/trailing/center/bottom
                 DynamicIslandExpandedRegion(.leading) {
                     HStack {
-                        loop(context: context, size: 23)
+                        LoopCircle(context: context, compact: false, size: 23)
                     }.padding(10)
                 }
 
@@ -58,13 +54,14 @@ struct LiveActivity: Widget {
                 }
 
                 DynamicIslandExpandedRegion(.trailing) {
-                    updatedLabel(context: context).font(.caption)
+                    TimestampLabel(context: context)
+                        .font(.caption)
                         .padding(.trailing, 10)
                 }
                 DynamicIslandExpandedRegion(.bottom) {}
             } compactLeading: {
                 HStack {
-                    loop(context: context, size: 12)
+                    LoopCircle(context: context, compact: true, size: 12)
                     bgAndTrend(context: context, size: .compact).0.padding(.leading, 4)
                 }
             } compactTrailing: {
@@ -106,11 +103,6 @@ struct LiveActivity: Widget {
         } else {
             Text("--")
         }
-    }
-
-    private func updatedLabel(context: ActivityViewContext<LiveActivityAttributes>) -> Text {
-        let text = Text("\(dateFormatter.string(from: context.state.loopDate))")
-        return text
     }
 
     private func bgAndTrend(context: ActivityViewContext<LiveActivityAttributes>, size: LiveActivitySize) -> (some View, Int) {
@@ -185,46 +177,11 @@ struct LiveActivity: Widget {
         }
         .foregroundStyle(.loopYellow)
     }
-
-    private func loop(context: ActivityViewContext<LiveActivityAttributes>, size: CGFloat) -> some View {
-        let timeAgo = abs(context.state.loopDate.timeIntervalSinceNow) / 60
-        let color: Color = timeAgo > 8 ? .loopYellow : timeAgo > 12 ? .loopRed : .loopGreen
-        return LoopActivity(stroke: color, compact: size == 12).frame(width: size)
-    }
-
-    private func bannerWithChart(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
-        LiveActivityChartWrapper(context: context)
-    }
-
-    private func bannerWithoutChart(for context: ActivityViewContext<LiveActivityAttributes>) -> some View {
-        LiveActivityBannerWrapper(context: context)
-    }
 }
 
 extension Color {
     static let uam = Color("UAM")
     static let zt = Color("ZT")
-}
-
-private struct LiveActivityChartWrapper: View {
-    let context: ActivityViewContext<LiveActivityAttributes>
-
-    var body: some View {
-        if #available(iOS 18.0, *) {
-            LiveActivityChartWrapperIOS18(context: context)
-        } else {
-            LiveActivityChart(context: context, isWatch: false)
-        }
-    }
-}
-
-@available(iOS 18.0, *) private struct LiveActivityChartWrapperIOS18: View {
-    @Environment(\.activityFamily) private var activityFamily
-    let context: ActivityViewContext<LiveActivityAttributes>
-
-    var body: some View {
-        LiveActivityChart(context: context, isWatch: activityFamily == .small)
-    }
 }
 
 private struct LiveActivityBannerWrapper: View {
@@ -234,7 +191,11 @@ private struct LiveActivityBannerWrapper: View {
         if #available(iOS 18.0, *) {
             LiveActivityBannerWrapperIOS18(context: context)
         } else {
-            LiveActivityBanner(context: context, isWatch: false)
+            if context.state.showChart {
+                LiveActivityChart(context: context, isWatch: false)
+            } else {
+                LiveActivityBanner(context: context, isWatch: false)
+            }
         }
     }
 }
@@ -244,17 +205,91 @@ private struct LiveActivityBannerWrapper: View {
     let context: ActivityViewContext<LiveActivityAttributes>
 
     var body: some View {
-        LiveActivityBanner(context: context, isWatch: activityFamily == .small)
+        if context.state.showChart {
+            LiveActivityChart(context: context, isWatch: activityFamily == .small)
+        } else {
+            LiveActivityBanner(context: context, isWatch: activityFamily == .small)
+        }
     }
 }
 
-struct LoopActivity: View {
+struct LoopCircle: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
     @Environment(\.colorScheme) var colorScheme
-    let stroke: Color
     let compact: Bool
+    let size: CGFloat
+
     var body: some View {
+        let timeAgo = abs(context.state.loopDate.timeIntervalSinceNow) / 60
+        let color: Color = timeAgo > 8 ? .loopYellow : timeAgo > 12 ? .loopRed : .loopGreen
+
         Circle()
-            .stroke(stroke, lineWidth: compact ? 1.5 : 3)
+            .stroke(color, lineWidth: compact ? 1.5 : 3)
+            .frame(width: size)
+    }
+}
+
+struct BannerLoopCircle: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+    let size: CGFloat
+
+    var body: some View {
+        LoopCircle(context: context, compact: false, size: size)
+    }
+}
+
+struct TimestampLabel: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    private static let dateFormatter: DateFormatter = {
+        var formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        Text("\(Self.dateFormatter.string(from: context.state.loopDate))")
+    }
+}
+
+struct BannerTimestampLabel: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        TimestampLabel(context: context)
+            .font(.system(size: 13))
+            .foregroundStyle(.white.opacity(0.7))
+    }
+}
+
+struct WatchLoopCircleAndTimestamp: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    var body: some View {
+        HStack(spacing: 3) {
+            BannerLoopCircle(context: context, size: 9)
+                .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
+                .padding(.trailing, 2)
+            BannerTimestampLabel(context: context)
+        }
+    }
+}
+
+struct BannerEventualGlucose: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+
+    private let eventualSymbol = "⇢"
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Text(eventualSymbol)
+                .opacity(0.7)
+            Text(context.state.eventual)
+                .opacity(0.8)
+                .fontWidth(.condensed)
+        }
     }
 }
 

--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -222,7 +222,7 @@ struct LoopCircle: View {
 
     var body: some View {
         let timeAgo = abs(context.state.loopDate.timeIntervalSinceNow) / 60
-        let color: Color = timeAgo > 8 ? .loopYellow : timeAgo > 12 ? .loopRed : .loopGreen
+        let color: Color = timeAgo > 12 ? .loopRed : timeAgo > 8 ? .loopYellow : .loopGreen
 
         Circle()
             .stroke(color, lineWidth: compact ? 1.5 : 3)

--- a/LiveActivity/Views/LiveActivityBanner.swift
+++ b/LiveActivity/Views/LiveActivityBanner.swift
@@ -8,15 +8,6 @@ struct LiveActivityBanner: View {
     let context: ActivityViewContext<LiveActivityAttributes>
     var isWatch: Bool = false
 
-    private let decimalString: String = NumberFormatter().decimalSeparator
-
-    private let dateFormatter: DateFormatter = {
-        var formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
-
     var body: some View {
         if isWatch {
             watchBody
@@ -27,12 +18,9 @@ struct LiveActivityBanner: View {
 
     private var standardBody: some View {
         VStack(spacing: 2) {
-            ZStack {
-                BannerTimestampLabel(context: context)
-                    .font(.caption)
-                    .foregroundStyle(.primary.opacity(0.7))
-                    .frame(maxWidth: .infinity, alignment: .trailing)
-            }
+            BannerTimestampLabel(context: context)
+                .font(.caption)
+                .frame(maxWidth: .infinity, alignment: .trailing)
             HStack {
                 VStack {
                     BannerLoopCircle(context: context, size: 22)
@@ -81,33 +69,11 @@ struct LiveActivityBanner: View {
     private var watchBody: some View {
         VStack(spacing: 0) {
             HStack(alignment: .center) {
-                HStack(spacing: 10) {
-                    HStack(spacing: 0.5) {
-                        Text(context.state.iob)
-                            .font(.system(size: 19))
-                            .tracking(-0.5)
-                        Text("U")
-                            .font(.system(size: 19).smallCaps())
-                            .foregroundStyle(.white.opacity(0.7))
-                    }
-                    .fontWidth(.compressed)
-
-                    if context.state.cob != "0" {
-                        HStack(spacing: 0.5) {
-                            Text(context.state.cob)
-                                .font(.system(size: 19))
-                                .tracking(-0.5)
-                            Text("g")
-                                .font(.system(size: 19))
-                                .foregroundStyle(.white.opacity(0.7))
-                        }
-                        .fontWidth(.compressed)
-                    }
-                }
+                WatchIOBCOBDisplay(context: context)
 
                 Spacer()
 
-                glucoseDisplayWatch
+                WatchGlucoseDisplay(context: context)
             }
             .padding(.horizontal, 8)
             .padding(.top, 4)
@@ -124,7 +90,7 @@ struct LiveActivityBanner: View {
             }
             .padding(.leading, 10)
             .padding(.trailing, 8)
-            .padding(.bottom, 7)
+            .padding(.bottom, 6)
         }
         .privacySensitive()
         .foregroundStyle(.white)
@@ -132,33 +98,8 @@ struct LiveActivityBanner: View {
         .activityBackgroundTint(Color.clear)
     }
 
-    private var glucoseDisplayWatch: some View {
-        HStack(alignment: .center, spacing: 6) {
-            let string = context.state.bg
-            let decimalSeparator = string.contains(decimalString) ? decimalString : "."
-            let decimal = string.components(separatedBy: decimalSeparator)
-            if decimal.count > 1 {
-                HStack(alignment: .firstTextBaseline, spacing: 0) {
-                    Text(decimal[0]).font(.system(size: 28, weight: .semibold, design: .rounded))
-                    Text(decimalSeparator).font(.system(size: 20, weight: .semibold, design: .rounded))
-                    Text(decimal[1]).font(.system(size: 20, weight: .semibold, design: .rounded))
-                }
-            } else {
-                Text(string)
-                    .font(.system(size: 28, weight: .semibold, design: .rounded))
-            }
-
-            if let direction = context.state.direction {
-                Text(direction)
-                    .font(.system(size: 16))
-            }
-        }
-    }
-
     private var bgAndTrend: some View {
-        let spacing: CGFloat = 3
-
-        let stack = HStack(spacing: spacing) {
+        HStack(spacing: 3) {
             Text(context.state.bg)
 
             if let direction = context.state.direction {
@@ -166,7 +107,6 @@ struct LiveActivityBanner: View {
                     .scaleEffect(x: 0.7, y: 0.7, anchor: .center).padding(.trailing, -5)
             }
         }
-        return stack
     }
 
     private var iob: some View {

--- a/LiveActivity/Views/LiveActivityBanner.swift
+++ b/LiveActivity/Views/LiveActivityBanner.swift
@@ -8,8 +8,6 @@ struct LiveActivityBanner: View {
     let context: ActivityViewContext<LiveActivityAttributes>
     var isWatch: Bool = false
 
-    private let eventualSymbol = "⇢"
-
     private let decimalString: String = NumberFormatter().decimalSeparator
 
     private let dateFormatter: DateFormatter = {
@@ -30,14 +28,14 @@ struct LiveActivityBanner: View {
     private var standardBody: some View {
         VStack(spacing: 2) {
             ZStack {
-                updatedLabel
+                BannerTimestampLabel(context: context)
                     .font(.caption)
                     .foregroundStyle(.primary.opacity(0.7))
                     .frame(maxWidth: .infinity, alignment: .trailing)
             }
             HStack {
                 VStack {
-                    loop(size: 22)
+                    BannerLoopCircle(context: context, size: 22)
                     Spacer()
                 }.offset(x: 0, y: 2)
                 Spacer()
@@ -50,13 +48,13 @@ struct LiveActivityBanner: View {
                 }
                 Spacer()
                 VStack {
-                    iob(context: context, size: .expanded).font(.title)
-                    Spacer() // emptyText
+                    iob.font(.title)
+                    Spacer()
                 }
                 Spacer()
                 VStack {
-                    cob(context: context, size: .expanded).font(.title)
-                    Spacer() // emptyText
+                    cob.font(.title)
+                    Spacer()
                 }
             }
             HStack {
@@ -75,9 +73,6 @@ struct LiveActivityBanner: View {
         }
         .privacySensitive()
         .padding(.vertical, 10).padding(.horizontal, 15)
-        // Semantic BackgroundStyle and Color values work here. They adapt to the given interface style (light mode, dark mode)
-        // Semantic UIColors do NOT (as of iOS 17.1.1). Like UIColor.systemBackgroundColor (it does not adapt to changes of the interface style)
-        // The colorScheme environment varaible that is usually used to detect dark mode does NOT work here (it reports false values)
         .foregroundStyle(Color.primary)
         .background(BackgroundStyle.background.opacity(0.4))
         .activityBackgroundTint(Color.clear)
@@ -119,22 +114,13 @@ struct LiveActivityBanner: View {
 
             Spacer(minLength: 0)
 
-            HStack(spacing: 3) {
-                loop(size: 9)
-                    .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
-                    .padding(.trailing, 2)
-                updatedLabel
-                    .font(.system(size: 13))
-                    .foregroundStyle(.white.opacity(0.7))
+            HStack {
+                WatchLoopCircleAndTimestamp(context: context)
+
                 Spacer()
-                HStack(spacing: 3) {
-                    Text(eventualSymbol)
-                        .font(.system(size: 13))
-                        .opacity(0.7)
-                    Text(context.state.eventual)
-                        .font(.system(size: 13))
-                        .fontWidth(.condensed)
-                }
+
+                BannerEventualGlucose(context: context)
+                    .font(.system(size: 13))
             }
             .padding(.leading, 10)
             .padding(.trailing, 8)
@@ -183,7 +169,7 @@ struct LiveActivityBanner: View {
         return stack
     }
 
-    private func iob(context: ActivityViewContext<LiveActivityAttributes>, size _: LiveActivitySize) -> some View {
+    private var iob: some View {
         HStack(spacing: 0) {
             Text(context.state.iob)
             Text(" U")
@@ -191,22 +177,12 @@ struct LiveActivityBanner: View {
         .foregroundStyle(.insulin)
     }
 
-    private func cob(context: ActivityViewContext<LiveActivityAttributes>, size _: LiveActivitySize) -> some View {
+    private var cob: some View {
         HStack(spacing: 0) {
             Text(context.state.cob)
             Text(" g")
         }
         .foregroundStyle(.loopYellow)
-    }
-
-    private func loop(size: CGFloat) -> some View {
-        let timeAgo = abs(context.state.loopDate.timeIntervalSinceNow) / 60
-        let color: Color = timeAgo > 8 ? .loopYellow : timeAgo > 12 ? .loopRed : .loopGreen
-        return LoopActivity(stroke: color, compact: false).frame(width: size)
-    }
-
-    private var updatedLabel: Text {
-        Text("\(dateFormatter.string(from: context.state.loopDate))")
     }
 
     @ViewBuilder private var changeLabel: some View {

--- a/LiveActivity/Views/LiveActivityBanner.swift
+++ b/LiveActivity/Views/LiveActivityBanner.swift
@@ -124,8 +124,8 @@ struct LiveActivityBanner: View {
                     .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
                     .padding(.trailing, 2)
                 updatedLabel
-                    .font(.system(size: 11))
-                    .foregroundStyle(.white.opacity(0.6))
+                    .font(.system(size: 13))
+                    .foregroundStyle(.white.opacity(0.7))
                 Spacer()
                 HStack(spacing: 3) {
                     Text(eventualSymbol)

--- a/LiveActivity/Views/LiveActivityBanner.swift
+++ b/LiveActivity/Views/LiveActivityBanner.swift
@@ -120,7 +120,7 @@ struct LiveActivityBanner: View {
                 Spacer()
 
                 BannerEventualGlucose(context: context)
-                    .font(.system(size: 13))
+                    .font(.system(size: 16))
             }
             .padding(.leading, 10)
             .padding(.trailing, 8)

--- a/LiveActivity/Views/LiveActivityBanner.swift
+++ b/LiveActivity/Views/LiveActivityBanner.swift
@@ -1,0 +1,223 @@
+import ActivityKit
+import Charts
+import Foundation
+import SwiftUI
+import WidgetKit
+
+struct LiveActivityBanner: View {
+    let context: ActivityViewContext<LiveActivityAttributes>
+    var isWatch: Bool = false
+
+    private let eventualSymbol = "⇢"
+
+    private let decimalString: String = NumberFormatter().decimalSeparator
+
+    private let dateFormatter: DateFormatter = {
+        var formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    var body: some View {
+        if isWatch {
+            watchBody
+        } else {
+            standardBody
+        }
+    }
+
+    private var standardBody: some View {
+        VStack(spacing: 2) {
+            ZStack {
+                updatedLabel
+                    .font(.caption)
+                    .foregroundStyle(.primary.opacity(0.7))
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+            HStack {
+                VStack {
+                    loop(size: 22)
+                    Spacer()
+                }.offset(x: 0, y: 2)
+                Spacer()
+                VStack {
+                    bgAndTrend.font(.title)
+                    changeLabel
+                        .font(.caption)
+                        .foregroundStyle(.primary.opacity(0.7))
+                        .offset(x: -12, y: -5)
+                }
+                Spacer()
+                VStack {
+                    iob(context: context, size: .expanded).font(.title)
+                    Spacer() // emptyText
+                }
+                Spacer()
+                VStack {
+                    cob(context: context, size: .expanded).font(.title)
+                    Spacer() // emptyText
+                }
+            }
+            HStack {
+                Spacer()
+                Text(NSLocalizedString("Eventual Glucose", comment: ""))
+                Spacer()
+                Text(context.state.eventual)
+                Text(context.state.mmol ? NSLocalizedString(
+                    "mmol/L",
+                    comment: "The short unit display string for millimoles of glucose per liter"
+                ) : NSLocalizedString(
+                    "mg/dL",
+                    comment: "The short unit display string for milligrams of glucose per decilter"
+                )).foregroundStyle(.secondary)
+            }.padding(.top, 10)
+        }
+        .privacySensitive()
+        .padding(.vertical, 10).padding(.horizontal, 15)
+        // Semantic BackgroundStyle and Color values work here. They adapt to the given interface style (light mode, dark mode)
+        // Semantic UIColors do NOT (as of iOS 17.1.1). Like UIColor.systemBackgroundColor (it does not adapt to changes of the interface style)
+        // The colorScheme environment varaible that is usually used to detect dark mode does NOT work here (it reports false values)
+        .foregroundStyle(Color.primary)
+        .background(BackgroundStyle.background.opacity(0.4))
+        .activityBackgroundTint(Color.clear)
+    }
+
+    private var watchBody: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .center) {
+                HStack(spacing: 10) {
+                    HStack(spacing: 0.5) {
+                        Text(context.state.iob)
+                            .font(.system(size: 19))
+                            .tracking(-0.5)
+                        Text("U")
+                            .font(.system(size: 19).smallCaps())
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                    .fontWidth(.compressed)
+
+                    if context.state.cob != "0" {
+                        HStack(spacing: 0.5) {
+                            Text(context.state.cob)
+                                .font(.system(size: 19))
+                                .tracking(-0.5)
+                            Text("g")
+                                .font(.system(size: 19))
+                                .foregroundStyle(.white.opacity(0.7))
+                        }
+                        .fontWidth(.compressed)
+                    }
+                }
+
+                Spacer()
+
+                glucoseDisplayWatch
+            }
+            .padding(.horizontal, 8)
+            .padding(.top, 4)
+
+            Spacer(minLength: 0)
+
+            HStack(spacing: 3) {
+                loop(size: 9)
+                    .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
+                    .padding(.trailing, 2)
+                updatedLabel
+                    .font(.system(size: 11))
+                    .foregroundStyle(.white.opacity(0.6))
+                Spacer()
+                HStack(spacing: 3) {
+                    Text(eventualSymbol)
+                        .font(.system(size: 13))
+                        .opacity(0.7)
+                    Text(context.state.eventual)
+                        .font(.system(size: 13))
+                        .fontWidth(.condensed)
+                }
+            }
+            .padding(.leading, 10)
+            .padding(.trailing, 8)
+            .padding(.bottom, 7)
+        }
+        .privacySensitive()
+        .foregroundStyle(.white)
+        .background(Color.black)
+        .activityBackgroundTint(Color.clear)
+    }
+
+    private var glucoseDisplayWatch: some View {
+        HStack(alignment: .center, spacing: 6) {
+            let string = context.state.bg
+            let decimalSeparator = string.contains(decimalString) ? decimalString : "."
+            let decimal = string.components(separatedBy: decimalSeparator)
+            if decimal.count > 1 {
+                HStack(alignment: .firstTextBaseline, spacing: 0) {
+                    Text(decimal[0]).font(.system(size: 28, weight: .semibold, design: .rounded))
+                    Text(decimalSeparator).font(.system(size: 20, weight: .semibold, design: .rounded))
+                    Text(decimal[1]).font(.system(size: 20, weight: .semibold, design: .rounded))
+                }
+            } else {
+                Text(string)
+                    .font(.system(size: 28, weight: .semibold, design: .rounded))
+            }
+
+            if let direction = context.state.direction {
+                Text(direction)
+                    .font(.system(size: 16))
+            }
+        }
+    }
+
+    private var bgAndTrend: some View {
+        let spacing: CGFloat = 3
+
+        let stack = HStack(spacing: spacing) {
+            Text(context.state.bg)
+
+            if let direction = context.state.direction {
+                Text(direction)
+                    .scaleEffect(x: 0.7, y: 0.7, anchor: .center).padding(.trailing, -5)
+            }
+        }
+        return stack
+    }
+
+    private func iob(context: ActivityViewContext<LiveActivityAttributes>, size _: LiveActivitySize) -> some View {
+        HStack(spacing: 0) {
+            Text(context.state.iob)
+            Text(" U")
+        }
+        .foregroundStyle(.insulin)
+    }
+
+    private func cob(context: ActivityViewContext<LiveActivityAttributes>, size _: LiveActivitySize) -> some View {
+        HStack(spacing: 0) {
+            Text(context.state.cob)
+            Text(" g")
+        }
+        .foregroundStyle(.loopYellow)
+    }
+
+    private func loop(size: CGFloat) -> some View {
+        let timeAgo = abs(context.state.loopDate.timeIntervalSinceNow) / 60
+        let color: Color = timeAgo > 8 ? .loopYellow : timeAgo > 12 ? .loopRed : .loopGreen
+        return LoopActivity(stroke: color, compact: false).frame(width: size)
+    }
+
+    private var updatedLabel: Text {
+        Text("\(dateFormatter.string(from: context.state.loopDate))")
+    }
+
+    @ViewBuilder private var changeLabel: some View {
+        if !context.state.change.isEmpty {
+            if !context.isStale {
+                Text(context.state.change)
+            } else {
+                Text("old").foregroundStyle(.secondary)
+            }
+        } else {
+            Text("--")
+        }
+    }
+}

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -8,7 +8,6 @@ struct LiveActivityChart: View {
     let context: ActivityViewContext<LiveActivityAttributes>
     var isWatch: Bool = false
 
-    private let EventualSymbol = "⇢"
     private let dropWidth = CGFloat(80)
     private let dropHeight = CGFloat(80)
 
@@ -28,37 +27,37 @@ struct LiveActivityChart: View {
         return formatter
     }()
 
+    private let glucoseColor = Color.white
+
     var body: some View {
         if isWatch {
-            watchView
+            watchBody
         } else {
-            defaultView
+            standardBody
         }
     }
 
-    private var defaultView: some View {
-        Group {
-            HStack(alignment: .top) {
-                chartView
-                    .padding(.bottom, 10)
-                    .padding(.top, 30)
-                    .padding(.leading, 15)
-                    .padding(.trailing, 10)
-                    .background(.black.opacity(0.30))
+    private var standardBody: some View {
+        HStack(alignment: .top) {
+            chartView
+                .padding(.bottom, 10)
+                .padding(.top, 30)
+                .padding(.leading, 15)
+                .padding(.trailing, 10)
+                .background(.black.opacity(0.30))
 
-                ZStack(alignment: .topTrailing) {
-                    VStack(alignment: .trailing, spacing: 0) {
-                        chartRightHandView
-                    }
+            ZStack(alignment: .topTrailing) {
+                VStack(alignment: .trailing, spacing: 0) {
+                    chartRightHandView
                 }
-                .fixedSize(horizontal: true, vertical: false)
-                .frame(maxHeight: .infinity)
-                .padding(.vertical, 15)
-                .padding(.trailing, 15)
             }
-            .overlay {
-                timeAndEventualOverlay
-            }
+            .fixedSize(horizontal: true, vertical: false)
+            .frame(maxHeight: .infinity)
+            .padding(.vertical, 15)
+            .padding(.trailing, 15)
+        }
+        .overlay {
+            timeAndEventualOverlay
         }
         .foregroundStyle(.white)
         .privacySensitive()
@@ -67,29 +66,20 @@ struct LiveActivityChart: View {
         .activityBackgroundTint(Color.clear)
     }
 
-    private var watchView: some View {
-        Group {
-            VStack(spacing: 0) {
-                watchTopRow
-                chartView
-            }
-            .padding(.vertical, 4)
-            .padding(.horizontal, 8)
-            .overlay(alignment: .bottomLeading) {
-                HStack(spacing: 3) {
-                    loop
-                        .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
-                        .padding(.trailing, 2)
-                    updatedLabel
-                        .font(.system(size: 13))
-                        .foregroundStyle(.white.opacity(0.7))
-                }
+    private var watchBody: some View {
+        VStack(spacing: 0) {
+            watchTopRow
+            chartView
+        }
+        .padding(.vertical, 4)
+        .padding(.horizontal, 8)
+        .overlay(alignment: .bottomLeading) {
+            WatchLoopCircleAndTimestamp(context: context)
                 .padding(.horizontal, 5)
                 .padding(.vertical, 2)
                 .background(.black.opacity(0.5), in: RoundedRectangle(cornerRadius: 4))
                 .padding(.leading, 5)
-                .padding(.bottom, 6)
-            }
+                .padding(.bottom, 5)
         }
         .foregroundStyle(.white)
         .privacySensitive()
@@ -354,24 +344,14 @@ struct LiveActivityChart: View {
     }
 
     @ViewBuilder private var timeAndEventualOverlay: some View {
-        // Eventual Glucose
-        HStack(spacing: 4) {
-            Text(EventualSymbol)
-                .font(.system(size: 16))
-                .opacity(0.7)
+        BannerEventualGlucose(context: context)
+            .font(.system(size: 16))
+            .foregroundStyle(.white)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+            .padding(.top, 10)
+            .padding(.trailing, 110)
 
-            Text(context.state.eventual)
-                .font(.system(size: 16))
-                .opacity(0.8)
-                .fontWidth(.condensed)
-        }
-        .foregroundStyle(.white)
-        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
-        .padding(.top, 10)
-        .padding(.trailing, 110)
-
-        // Timestamp
-        updatedLabel
+        BannerTimestampLabel(context: context)
             .font(.system(size: 11))
             .foregroundStyle(context.isStale ? Color(.loopRed) : .white.opacity(0.7))
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -430,11 +410,11 @@ struct LiveActivityChart: View {
                 }
                 .tracking(-1)
                 .offset(x: -2)
-                .foregroundColor(colorOfGlucose)
+                .foregroundColor(glucoseColor)
             } else {
                 Text(string)
                     .font(Font.custom("SuggestionSmallPartsFontMgDl", fixedSize: 23).width(.condensed))
-                    .foregroundColor(colorOfGlucose)
+                    .foregroundColor(glucoseColor)
                     .offset(x: -2)
             }
         }
@@ -453,23 +433,19 @@ struct LiveActivityChart: View {
                     Text(decimalSeparator).font(.system(size: 20, weight: .semibold, design: .rounded))
                     Text(decimal[1]).font(.system(size: 20, weight: .semibold, design: .rounded))
                 }
-                .foregroundColor(colorOfGlucose)
+                .foregroundColor(glucoseColor)
             } else {
                 Text(string)
                     .font(.system(size: 28, weight: .semibold, design: .rounded))
-                    .foregroundColor(colorOfGlucose)
+                    .foregroundColor(glucoseColor)
             }
 
             if let direction = context.state.direction {
                 Text(direction)
                     .font(.system(size: 16))
-                    .foregroundColor(colorOfGlucose)
+                    .foregroundColor(glucoseColor)
             }
         }
-    }
-
-    private var colorOfGlucose: Color {
-        Color.white
     }
 
     private func limitedPredictions(
@@ -545,16 +521,6 @@ struct LiveActivityChart: View {
         default:
             return (2, 0)
         }
-    }
-
-    private var loop: some View {
-        let timeAgo = abs(context.state.loopDate.timeIntervalSinceNow) / 60
-        let color: Color = timeAgo > 8 ? .loopYellow : timeAgo > 12 ? .loopRed : .loopGreen
-        return LoopActivity(stroke: color, compact: false).frame(width: 9)
-    }
-
-    private var updatedLabel: Text {
-        Text("\(dateFormatter.string(from: context.state.loopDate))")
     }
 
     private func displayValues(_ values: [Int16], conversion: Double) -> [Double] {

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -12,10 +12,7 @@ struct LiveActivityChart: View {
     private let dropWidth = CGFloat(80)
     private let dropHeight = CGFloat(80)
 
-    private let decimalString: String = {
-        let formatter = NumberFormatter()
-        return formatter.decimalSeparator
-    }()
+    private let decimalString: String = NumberFormatter().decimalSeparator
 
     private let dateFormatter: DateFormatter = {
         var formatter = DateFormatter()
@@ -78,6 +75,21 @@ struct LiveActivityChart: View {
             }
             .padding(.vertical, 4)
             .padding(.horizontal, 8)
+            .overlay(alignment: .bottomLeading) {
+                HStack(spacing: 3) {
+                    loop
+                        .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
+                        .padding(.trailing, 2)
+                    updatedLabel
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.6))
+                }
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(.black.opacity(0.5), in: RoundedRectangle(cornerRadius: 4))
+                .padding(.leading, 5)
+                .padding(.bottom, 6)
+            }
         }
         .foregroundStyle(.white)
         .privacySensitive()
@@ -89,13 +101,6 @@ struct LiveActivityChart: View {
     private var watchTopRow: some View {
         HStack(alignment: .center) {
             watchIOBCOBView
-            Spacer()
-            if context.isStale || Date().timeIntervalSince(context.state.loopDate) > 7 * 60 {
-                updatedLabel
-                    .font(.system(size: 12))
-                    .foregroundStyle(Color(.loopRed))
-                    .brightness(0.3)
-            }
             Spacer()
             glucoseDisplayWatch
         }
@@ -540,6 +545,12 @@ struct LiveActivityChart: View {
         default:
             return (2, 0)
         }
+    }
+
+    private var loop: some View {
+        let timeAgo = abs(context.state.loopDate.timeIntervalSinceNow) / 60
+        let color: Color = timeAgo > 8 ? .loopYellow : timeAgo > 12 ? .loopRed : .loopGreen
+        return LoopActivity(stroke: color, compact: false).frame(width: 9)
     }
 
     private var updatedLabel: Text {

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -11,21 +11,7 @@ struct LiveActivityChart: View {
     private let dropWidth = CGFloat(80)
     private let dropHeight = CGFloat(80)
 
-    private let decimalString: String = NumberFormatter().decimalSeparator
-
-    private let dateFormatter: DateFormatter = {
-        var formatter = DateFormatter()
-        formatter.dateStyle = .none
-        formatter.timeStyle = .short
-        return formatter
-    }()
-
-    private let minuteFormatter: NumberFormatter = {
-        var formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 0
-        return formatter
-    }()
+    private let decimalString: String = Locale.current.decimalSeparator ?? "."
 
     private let glucoseColor = Color.white
 
@@ -46,10 +32,8 @@ struct LiveActivityChart: View {
                 .padding(.trailing, 10)
                 .background(.black.opacity(0.30))
 
-            ZStack(alignment: .topTrailing) {
-                VStack(alignment: .trailing, spacing: 0) {
-                    chartRightHandView
-                }
+            VStack(alignment: .trailing, spacing: 0) {
+                chartRightHandView
             }
             .fixedSize(horizontal: true, vertical: false)
             .frame(maxHeight: .infinity)
@@ -99,15 +83,15 @@ struct LiveActivityChart: View {
 
     private var watchTopRow: some View {
         HStack(alignment: .center) {
-            watchIOBCOBView
+            WatchIOBCOBDisplay(context: context)
             Spacer()
-            glucoseDisplayWatch
+            WatchGlucoseDisplay(context: context)
         }
     }
 
     private var chartView: some View {
         let state = context.state
-        let ConversionConstant: Double = (state.mmol ? 0.0555 : 1)
+        let conversionConstant: Double = (state.mmol ? 0.0555 : 1)
 
         // on the watch, we display only up to 10 prediction points
         let predictions = isWatch ? limitedPredictions(state.predictions, to: 10) : state.predictions
@@ -119,12 +103,12 @@ struct LiveActivityChart: View {
         let uam: [Int16] = predictions?.uam?.values ?? []
 
         // Prepare for domain range
-        let lowThreshold = Double(state.chartLowThreshold) * ConversionConstant
-        let highThreshold = Double(state.chartHighThreshold) * ConversionConstant
+        let lowThreshold = Double(state.chartLowThreshold) * conversionConstant
+        let highThreshold = Double(state.chartHighThreshold) * conversionConstant
 
         // Min/max BG values
-        let minValue = state.readings?.values.min().map({ Double($0) * ConversionConstant })
-        let maxValue = state.readings?.values.max().map({ Double($0) * ConversionConstant })
+        let minValue = state.readings?.values.min().map({ Double($0) * conversionConstant })
+        let maxValue = state.readings?.values.max().map({ Double($0) * conversionConstant })
 
         // Green AreaMark low/high
         let yStart = lowThreshold
@@ -138,14 +122,14 @@ struct LiveActivityChart: View {
             state.readings?.dates.max()
         )
 
-        // Min/max Predction values
+        // Min/max Prediction values
         let maxPrediction = maxOptional(
             iob.max(), cob.max(), zt.max(), uam.max()
-        ).map({ Double($0) * ConversionConstant })
+        ).map({ Double($0) * conversionConstant })
 
         let minPrediction = minOptional(
             iob.max(), cob.max(), zt.max(), uam.max()
-        ).map({ Double($0) * ConversionConstant })
+        ).map({ Double($0) * conversionConstant })
 
         // Dymamic scaling and avoiding any fatal crashes due to out of bounds errors. Never higher than 400 mg/dl
         let yDomainMin = minOptional1(
@@ -159,7 +143,7 @@ struct LiveActivityChart: View {
             maxPrediction
         )
         let yDomain = (
-            max(yDomainMin, 0) ... min(yDomainMax, 400 * ConversionConstant)
+            max(yDomainMin, 0) ... min(yDomainMax, 400 * conversionConstant)
         )
 
         let glucoseFormatter: FloatingPointFormatStyle<Double> =
@@ -175,12 +159,12 @@ struct LiveActivityChart: View {
         let inRangeRectOpacity = 0.1
 
         let bgPoints = state.readings.map({
-            makePoints($0.dates, $0.values, conversion: ConversionConstant)
+            makePoints($0.dates, $0.values, conversion: conversionConstant)
         })
-        let iobPoints = predictions?.iob.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
-        let ztPoints = predictions?.zt.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
-        let cobPoints = predictions?.cob.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
-        let uamPoints = predictions?.uam.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
+        let iobPoints = predictions?.iob.map({ makePoints($0.dates, $0.values, conversion: conversionConstant) })
+        let ztPoints = predictions?.zt.map({ makePoints($0.dates, $0.values, conversion: conversionConstant) })
+        let cobPoints = predictions?.cob.map({ makePoints($0.dates, $0.values, conversion: conversionConstant) })
+        let uamPoints = predictions?.uam.map({ makePoints($0.dates, $0.values, conversion: conversionConstant) })
 
         let nowDate = Date()
         let xScaleEnd: Date = isWatch ? max(xEnd ?? nowDate, nowDate.addingTimeInterval(80 * 60)) : (xEnd ?? nowDate)
@@ -362,34 +346,6 @@ struct LiveActivityChart: View {
             .padding(.vertical, 10).padding(.leading, 50)
     }
 
-    @ViewBuilder private var watchIOBCOBView: some View {
-        HStack(spacing: 10) {
-            HStack(spacing: 0.5) {
-                Text(context.state.iob)
-                    .font(.system(size: 19))
-                    .tracking(-0.5)
-                    .foregroundStyle(.white)
-                Text("U")
-                    .font(.system(size: 19).smallCaps())
-                    .foregroundStyle(.white.opacity(0.7))
-            }
-            .fontWidth(.compressed)
-
-            if context.state.cob != "0" {
-                HStack(spacing: 0.5) {
-                    Text(context.state.cob)
-                        .font(.system(size: 19))
-                        .tracking(-0.5)
-                        .foregroundStyle(.white)
-                    Text("g")
-                        .font(.system(size: 19))
-                        .foregroundStyle(.white.opacity(0.7))
-                }
-                .fontWidth(.compressed)
-            }
-        }
-    }
-
     private var glucoseDrop: some View {
         ZStack {
             let degree = dropAngle
@@ -414,40 +370,12 @@ struct LiveActivityChart: View {
                 }
                 .tracking(-1)
                 .offset(x: -2)
-                .foregroundColor(glucoseColor)
+                .foregroundStyle(glucoseColor)
             } else {
                 Text(string)
                     .font(Font.custom("SuggestionSmallPartsFontMgDl", fixedSize: 23).width(.condensed))
-                    .foregroundColor(glucoseColor)
+                    .foregroundStyle(glucoseColor)
                     .offset(x: -2)
-            }
-        }
-    }
-
-    private var glucoseDisplayWatch: some View {
-        HStack(alignment: .center, spacing: 6) {
-            let string = context.state.bg
-            let decimalSeparator =
-                string.contains(decimalString) ? decimalString : "."
-
-            let decimal = string.components(separatedBy: decimalSeparator)
-            if decimal.count > 1 {
-                HStack(alignment: .firstTextBaseline, spacing: 0) {
-                    Text(decimal[0]).font(.system(size: 28, weight: .semibold, design: .rounded))
-                    Text(decimalSeparator).font(.system(size: 20, weight: .semibold, design: .rounded))
-                    Text(decimal[1]).font(.system(size: 20, weight: .semibold, design: .rounded))
-                }
-                .foregroundColor(glucoseColor)
-            } else {
-                Text(string)
-                    .font(.system(size: 28, weight: .semibold, design: .rounded))
-                    .foregroundColor(glucoseColor)
-            }
-
-            if let direction = context.state.direction {
-                Text(direction)
-                    .font(.system(size: 16))
-                    .foregroundColor(glucoseColor)
             }
         }
     }

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -81,8 +81,8 @@ struct LiveActivityChart: View {
                         .opacity(abs(context.state.loopDate.timeIntervalSinceNow) / 60 <= 8 ? 0.7 : 0.9)
                         .padding(.trailing, 2)
                     updatedLabel
-                        .font(.system(size: 11))
-                        .foregroundStyle(.white.opacity(0.6))
+                        .font(.system(size: 13))
+                        .foregroundStyle(.white.opacity(0.7))
                 }
                 .padding(.horizontal, 5)
                 .padding(.vertical, 2)

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -81,6 +81,15 @@ struct LiveActivityChart: View {
                 .padding(.leading, 5)
                 .padding(.bottom, 5)
         }
+        .overlay(alignment: .bottomTrailing) {
+            BannerEventualGlucose(context: context)
+                .font(.system(size: 16))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(.black.opacity(0.5), in: RoundedRectangle(cornerRadius: 4))
+                .padding(.trailing, 5)
+                .padding(.bottom, 5)
+        }
         .foregroundStyle(.white)
         .privacySensitive()
         .padding(0)
@@ -174,7 +183,7 @@ struct LiveActivityChart: View {
         let uamPoints = predictions?.uam.map({ makePoints($0.dates, $0.values, conversion: ConversionConstant) })
 
         let nowDate = Date()
-        let xScaleEnd: Date = isWatch ? max(xEnd ?? nowDate, nowDate) : (xEnd ?? nowDate)
+        let xScaleEnd: Date = isWatch ? max(xEnd ?? nowDate, nowDate.addingTimeInterval(80 * 60)) : (xEnd ?? nowDate)
 
         return Chart {
             if let bg = bgPoints {
@@ -287,24 +296,19 @@ struct LiveActivityChart: View {
             }
         }
         .chartYAxis {
-            if let minValue, let maxValue {
+            if !isWatch, let minValue, let maxValue {
                 AxisMarks(
-                    position: isWatch ? .trailing : .leading,
-                    values:
-                    abs(maxValue - minValue) < 0.8 ? [
+                    position: .leading,
+                    values: abs(maxValue - minValue) < 0.8 ? [
                         (maxValue + minValue) / 2
-                    ] :
-                        [
-                            minValue,
-                            maxValue
-                        ]
+                    ] : [
+                        minValue,
+                        maxValue
+                    ]
                 ) { _ in
-                    AxisValueLabel(
-                        format: glucoseFormatter,
-                        horizontalSpacing: isWatch ? 8 : 10
-                    )
-                    .foregroundStyle(.secondary)
-                    .font(isWatch ? .system(size: 12) : .caption)
+                    AxisValueLabel(format: glucoseFormatter, horizontalSpacing: 10)
+                        .foregroundStyle(.secondary)
+                        .font(.caption)
                 }
             }
         }


### PR DESCRIPTION
fixes #1846

Unified the two views (for smart stack) - BG, COB, IOB and timestamp are the same.
The difference is the chart itself vs just eventual BG.

I also made the loop status and timestamp always visible on the chart view (previously it would only show when loop is "red"), and in the same location - bottom left.

The live activity updating in the smart stack is not as reliable as I thought it was, so having the timestamp seems to be necessary - otherwise one doesn't really know if the data is up to date.
Even though smart stack does display the "last updated ... minutes ago" above the widget - it appears for just a second, and seems to be rather random and unreliable (sometimes I see the up to date chart, but the overlay says "last updated 1 hour ago" etc).

---

I added `NSSupportsLiveActivitiesFrequentUpdates=true` to the plist hoping it would improve the reliability - it doesn't seem to have affected anything. Not sure if it's worth keeping.

---

* added eventual BG to the chart view in smart stack (same as in the no-chart view)
* removed the y-axis markers on the chart in smart stack (those are min/max of the BG values that are visible on the chart)

---

<img width="200" alt="Image" src="https://github.com/user-attachments/assets/610b79ca-16b9-4f4e-95dc-80708350a056" />

<img width="200" alt="Image" src="https://github.com/user-attachments/assets/ee9d6870-b69f-4f0e-8aae-a9b440f45019" />

<br/>  

<img width="200" alt="Image" src="https://github.com/user-attachments/assets/51120b48-aabd-49d1-bb9c-e1081ae56dd3" />

<img width="200" alt="Image" src="https://github.com/user-attachments/assets/bed69054-7f85-430a-9813-ef74b4eb955e" />

<br/>

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/c89c69c5-e736-445b-ad07-066a07aa7abe" />




<details>
  <summary>previous screenshots</summary>


<img width="195" height="92" alt="image" src="https://github.com/user-attachments/assets/5527b729-d844-4382-b261-1a4028deebd9" />


<img width="196" height="92" alt="image" src="https://github.com/user-attachments/assets/271683de-159b-40a0-8f93-7c2b5e433042" />


<img width="196" height="92" alt="image" src="https://github.com/user-attachments/assets/e9fa324b-4fe6-4afe-8553-e9ba7f22db2b" />


<img width="400" height="502" alt="incoming-6C37F1FC-9F0B-48CA-A193-A6F9E652CD3D 2" src="https://github.com/user-attachments/assets/75adc561-3679-4312-8ba3-e0c9b99e88f6" />

</details>