### PR TITLE
Resolve line break

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -165,7 +165,7 @@ extension Home {
                     state.setupPump = true
                 }
             }
-            .offset(y: 1)
+            .offset(y: 2)
         }
 
         var loopView: some View {

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -702,9 +702,9 @@ extension Home {
                                 HStack {
                                     carbsAndInsulinView
                                         .frame(maxHeight: .infinity, alignment: .bottom)
-                                    Spacer()
+                                    // Spacer()
                                     pumpView
-                                        .frame(maxHeight: .infinity, alignment: .bottom)
+                                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
                                 }
                                 .dynamicTypeSize(...DynamicTypeSize.xLarge)
                                 .padding(.horizontal, 10)


### PR DESCRIPTION
Remove Spacer(), which sometimes takes up too much space.

Resolves an issue reported in Discord, but needs more testing, as issue is difficult to reproduce.
