### PR TITLE
Search bar

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -148,6 +148,7 @@
 		3811DE3225C9D49500A708ED /* HomeDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE2A25C9D49500A708ED /* HomeDataFlow.swift */; };
 		3811DE3525C9D49500A708ED /* HomeRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE2E25C9D49500A708ED /* HomeRootView.swift */; };
 		3811DE3F25C9D4A100A708ED /* SettingsStateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE3925C9D4A100A708ED /* SettingsStateModel.swift */; };
+		CC1A00012A000001000A708ED /* SettingsCatalogue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1A00002A000001000A708ED /* SettingsCatalogue.swift */; };
 		3811DE4125C9D4A100A708ED /* SettingsRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */; };
 		3811DE4225C9D4A100A708ED /* SettingsDataFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE3D25C9D4A100A708ED /* SettingsDataFlow.swift */; };
 		3811DE4325C9D4A100A708ED /* SettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3811DE3E25C9D4A100A708ED /* SettingsProvider.swift */; };
@@ -828,6 +829,7 @@
 		3811DE2A25C9D49500A708ED /* HomeDataFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeDataFlow.swift; sourceTree = "<group>"; };
 		3811DE2E25C9D49500A708ED /* HomeRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeRootView.swift; sourceTree = "<group>"; };
 		3811DE3925C9D4A100A708ED /* SettingsStateModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsStateModel.swift; sourceTree = "<group>"; };
+		CC1A00002A000001000A708ED /* SettingsCatalogue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsCatalogue.swift; sourceTree = "<group>"; };
 		3811DE3C25C9D4A100A708ED /* SettingsRootView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsRootView.swift; sourceTree = "<group>"; };
 		3811DE3D25C9D4A100A708ED /* SettingsDataFlow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsDataFlow.swift; sourceTree = "<group>"; };
 		3811DE3E25C9D4A100A708ED /* SettingsProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsProvider.swift; sourceTree = "<group>"; };
@@ -1817,6 +1819,7 @@
 				3811DE3D25C9D4A100A708ED /* SettingsDataFlow.swift */,
 				3811DE3E25C9D4A100A708ED /* SettingsProvider.swift */,
 				3811DE3925C9D4A100A708ED /* SettingsStateModel.swift */,
+				CC1A00002A000001000A708ED /* SettingsCatalogue.swift */,
 				3811DE3B25C9D4A100A708ED /* View */,
 			);
 			path = Settings;
@@ -3454,6 +3457,7 @@
 				194D7E6E2B974F9F007A38C1 /* LoopsView.swift in Sources */,
 				383948D625CD4D8900E91849 /* FileStorage.swift in Sources */,
 				3811DE4125C9D4A100A708ED /* SettingsRootView.swift in Sources */,
+				CC1A00012A000001000A708ED /* SettingsCatalogue.swift in Sources */,
 				38192E04261B82FA0094D973 /* ReachabilityManager.swift in Sources */,
 				38E44539274E411700EC9A94 /* Disk+UIImage.swift in Sources */,
 				388E595C25AD948C0019842D /* FreeAPSApp.swift in Sources */,

--- a/FreeAPS/Sources/Modules/Settings/SettingsCatalogue.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsCatalogue.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+struct SettingsSearchEntry: Identifiable {
+    let id = UUID()
+    let name: String
+    let section: String
+    let destination: Screen
+}
+
+enum SettingsCatalogue {
+    static let entries: [SettingsSearchEntry] =
+        devices + services + configuration + openAPSMain + openAPSSMB + openAPSTargets + openAPSOther +
+        autotuneSettings + autoISFToggles + autoISFNighttime + autoISFSettings + autoISFB30 + autoISFKeto +
+        dynamicISF + bolusCalculator + fpuConversion + uiuxSettings
+}
+
+// MARK: - Devices
+
+private let devices: [SettingsSearchEntry] = [
+    .init(name: "Pump", section: "Devices", destination: .pumpConfig),
+    .init(name: "CGM", section: "Devices", destination: .cgm),
+    .init(name: "Watch", section: "Devices", destination: .watch),
+]
+
+// MARK: - Services
+
+private let services: [SettingsSearchEntry] = [
+    .init(name: "Nightscout", section: "Services", destination: .nighscoutConfig),
+    .init(name: "Apple Health", section: "Services", destination: .healthkit),
+    .init(name: "Notifications", section: "Services", destination: .notificationsConfig),
+]
+
+// MARK: - Configuration
+
+private let configuration: [SettingsSearchEntry] = [
+    .init(name: "Pump Settings", section: "Configuration", destination: .pumpSettingsEditor),
+    .init(name: "Basal Profile", section: "Configuration", destination: .basalProfileEditor(saveNewConcentration: false)),
+    .init(name: "Insulin Sensitivities", section: "Configuration", destination: .isfEditor),
+    .init(name: "Carb Ratios", section: "Configuration", destination: .crEditor),
+    .init(name: "Target Glucose", section: "Configuration", destination: .targetsEditor),
+]
+
+// MARK: - OpenAPS
+
+private let openAPSMain: [SettingsSearchEntry] = [
+    .init(name: "Max IOB", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Max COB", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Max Daily Safety Multiplier", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Current Basal Safety Multiplier", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Threshold Setting", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Autosens Maximum", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Autosens Minimum", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Autotune ISF Adjustment Fraction", section: "OpenAPS", destination: .preferencesEditor),
+]
+
+private let openAPSSMB: [SettingsSearchEntry] = [
+    .init(name: "Enable SMB Always", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Max Delta-BG Threshold SMB", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Enable SMB With COB", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Enable SMB With Temptarget", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Enable SMB After Carbs", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Allow SMB With High Temptarget", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Enable SMB With High BG", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Enable UAM", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Max SMB Basal Minutes", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Max UAM SMB Basal Minutes", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "SMB DeliveryRatio", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "SMB Interval", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Bolus Increment", section: "OpenAPS", destination: .preferencesEditor),
+]
+
+private let openAPSTargets: [SettingsSearchEntry] = [
+    .init(name: "Sensitivity Raises Target", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Resistance Lowers Target", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "High Temptarget Raises Sensitivity", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Low Temptarget Lowers Sensitivity", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Half Basal Exercise Target", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Rewind Resets Autosens", section: "OpenAPS", destination: .preferencesEditor),
+]
+
+private let openAPSOther: [SettingsSearchEntry] = [
+    .init(name: "Use Custom Peak Time", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Insulin Peak Time", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Skip Neutral Temps", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Unsuspend If No Temp", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Suspend Zeros IOB", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Min 5m Carbimpact", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Remaining Carbs Fraction", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Remaining Carbs Cap", section: "OpenAPS", destination: .preferencesEditor),
+    .init(name: "Noisy CGM Target Multiplier", section: "OpenAPS", destination: .preferencesEditor),
+]
+
+// MARK: - Autotune
+
+private let autotuneSettings: [SettingsSearchEntry] = [
+    .init(name: "Use Autotune", section: "Autotune", destination: .autotuneConfig),
+    .init(name: "Only Autotune Basal Insulin", section: "Autotune", destination: .autotuneConfig),
+    .init(name: "Calculate ISF Suggestions", section: "Autotune", destination: .autotuneConfig),
+    .init(name: "ISF Scale", section: "Autotune", destination: .autotuneConfig),
+    .init(name: "Calculated Basal", section: "Autotune", destination: .autotuneConfig),
+    .init(name: "Calculated ISF", section: "Autotune", destination: .autotuneConfig),
+]
+
+// MARK: - Auto ISF
+
+private let autoISFToggles: [SettingsSearchEntry] = [
+    .init(name: "Enable Auto ISF", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Enable BG Acceleration", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Enable Auto CR", section: "Auto ISF", destination: .autoISF),
+]
+
+private let autoISFNighttime: [SettingsSearchEntry] = [
+    .init(name: "Disable Auto ISF During Nighttime", section: "Auto ISF", destination: .autoISF),
+]
+
+private let autoISFSettings: [SettingsSearchEntry] = [
+    .init(name: "Auto ISF Max", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Auto ISF Min", section: "Auto ISF", destination: .autoISF),
+    .init(name: "SMB Delivery Ratio Minimum", section: "Auto ISF", destination: .autoISF),
+    .init(name: "SMB Delivery Ratio Maximum", section: "Auto ISF", destination: .autoISF),
+    .init(name: "SMB Delivery Ratio BG Range", section: "Auto ISF", destination: .autoISF),
+    .init(name: "ISF Weight for Higher BG", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Duration Weight", section: "Auto ISF", destination: .autoISF),
+    .init(name: "ISF Weight for Lower BG", section: "Auto ISF", destination: .autoISF),
+    .init(name: "ISF Weight for Postprandial BG Rise", section: "Auto ISF", destination: .autoISF),
+    .init(name: "ISF Weight While BG Accelerates", section: "Auto ISF", destination: .autoISF),
+    .init(name: "ISF Weight While BG Decelerates", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Max IOB Threshold Percent", section: "Auto ISF", destination: .autoISF),
+]
+
+private let autoISFB30: [SettingsSearchEntry] = [
+    .init(name: "Activate B30", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Minimum Start Bolus Size", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Target Level for B30", section: "Auto ISF", destination: .autoISF),
+    .init(name: "B30 Upper BG Limit", section: "Auto ISF", destination: .autoISF),
+    .init(name: "B30 Upper Delta Limit", section: "Auto ISF", destination: .autoISF),
+    .init(name: "B30 Basal Rate Increase Factor", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Duration of Increased B30 Basal Rate", section: "Auto ISF", destination: .autoISF),
+]
+
+private let autoISFKeto: [SettingsSearchEntry] = [
+    .init(name: "Enable Keto Protection", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Variable Keto Protection", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Keto Protection Safety TBR %", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Enable Keto Protection With Pre-Defined TBR", section: "Auto ISF", destination: .autoISF),
+    .init(name: "Absolute Safety TBR", section: "Auto ISF", destination: .autoISF),
+]
+
+// MARK: - Dynamic ISF
+
+private let dynamicISF: [SettingsSearchEntry] = [
+    .init(name: "Activate Dynamic Sensitivity (ISF)", section: "Dynamic ISF", destination: .dynamicISF),
+    .init(name: "Activate Dynamic Carb Ratio (CR)", section: "Dynamic ISF", destination: .dynamicISF),
+    .init(name: "Use Sigmoid Function", section: "Dynamic ISF", destination: .dynamicISF),
+    .init(name: "Adjustment Factor", section: "Dynamic ISF", destination: .dynamicISF),
+    .init(name: "Weighted Average of TDD", section: "Dynamic ISF", destination: .dynamicISF),
+]
+
+// MARK: - Bolus Calculator
+
+private let bolusCalculator: [SettingsSearchEntry] = [
+    .init(name: "Use Bolus Calculator", section: "Bolus Calculator", destination: .bolusCalculatorConfig),
+    .init(name: "Bolus Calculator Override Factor", section: "Bolus Calculator", destination: .bolusCalculatorConfig),
+    .init(name: "Apply Factor for Fatty Meals", section: "Bolus Calculator", destination: .bolusCalculatorConfig),
+    .init(name: "Display Predictions", section: "Bolus Calculator", destination: .bolusCalculatorConfig),
+    .init(name: "Don't Use 15 Min Trend", section: "Bolus Calculator", destination: .bolusCalculatorConfig),
+]
+
+// MARK: - Fat and Protein Conversion
+
+private let fpuConversion: [SettingsSearchEntry] = [
+    .init(name: "FPU Delay In Minutes", section: "Fat & Protein", destination: .fpuConfig),
+    .init(name: "FPU Maximum Duration In Hours", section: "Fat & Protein", destination: .fpuConfig),
+    .init(name: "FPU Interval In Minutes", section: "Fat & Protein", destination: .fpuConfig),
+    .init(name: "FPU Individual Adjustment Factor", section: "Fat & Protein", destination: .fpuConfig),
+]
+
+// MARK: - UI/UX
+
+private let uiuxSettings: [SettingsSearchEntry] = [
+    .init(name: "Display Temp Targets Button", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Display Profile Override Button", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Display Meal Button", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Never Display Small Glucose Chart", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Always Color Glucose Value", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Display Glucose Delta", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Hide Concentration Badge", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Display Sensor Age", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Display Sensor Time Remaining", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Override HbA1c Unit", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Standing / Laying TIR Chart", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Skip Bolus Screen After Carbs", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Display Fat and Protein Entries", section: "UI/UX", destination: .uiConfig),
+    .init(name: "AI Food Search", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Color Scheme", section: "UI/UX", destination: .uiConfig),
+    .init(name: "Main Chart Settings", section: "UI/UX", destination: .mainChartConfig),
+]

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -10,6 +10,16 @@ extension Settings {
         @State private var showShareSheet = false
         @State private var entity: String = "Readings"
         @State private var deletionAlert = false
+        @State private var searchText = ""
+
+        private var searchResults: [SettingsSearchEntry] {
+            guard !searchText.isEmpty else { return [] }
+            let query = searchText.lowercased()
+            return SettingsCatalogue.entries.filter {
+                $0.name.lowercased().contains(query) ||
+                    $0.section.lowercased().contains(query)
+            }
+        }
 
         @FetchRequest(
             entity: VNr.entity(),
@@ -32,6 +42,21 @@ extension Settings {
 
         var body: some View {
             Form {
+                if !searchText.isEmpty {
+                    Section {
+                        if searchResults.isEmpty {
+                            Text("No results for \"\(searchText)\"")
+                                .foregroundColor(.secondary)
+                        } else {
+                            ForEach(searchResults) { entry in
+                                searchResultRow(entry)
+                            }
+                        }
+                    } header: {
+                        Text(searchResults.isEmpty ? "" : "Results")
+                    }
+                }
+
                 Section {
                     Toggle("Closed loop", isOn: $state.closedLoop)
                 }
@@ -226,6 +251,11 @@ extension Settings {
                     }
                 }
             }
+            .searchable(
+                text: $searchText,
+                placement: .navigationBarDrawer(displayMode: .always),
+                prompt: "Search settings…"
+            )
             .sheet(isPresented: $showShareSheet) {
                 ShareSheet(activityItems: state.logItems())
             }
@@ -237,6 +267,19 @@ extension Settings {
             .navigationBarItems(trailing: Button("Close", action: state.hideSettingsModal))
             .navigationBarTitleDisplayMode(.inline)
             .onDisappear(perform: { state.uploadProfileAndSettings(false) })
+        }
+
+        private func searchResultRow(_ entry: SettingsSearchEntry) -> some View {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.name)
+                    Text(entry.section)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+            .navigationLink(to: entry.destination, from: self)
         }
 
         private func clearEntity(entity: String) {


### PR DESCRIPTION
Builds and run / search works ... minimal testing though, as my live version is the autotune one, just flipped to this to make sure it actually works ...   

Closes #1852 

 Add search bar to Settings view

    Users with a specific setting in mind currently have to remember which
    section it lives in and scroll through up to 40+ options across 7 groups.
    A search bar significantly reduces that friction for both new users
    exploring the app and experienced users doing quick parameter checks.

    Implementation:
    - New SettingsCatalogue.swift: a static index of ~100 searchable entries
      across all settings areas (Devices, Services, Configuration, OpenAPS
      main/SMB/target/other, Autotune, Auto ISF, Dynamic ISF, Bolus Calculator,
      Fat & Protein, UI/UX). Each entry carries a display name, section label,
      and the Screen destination it navigates to.
    - SettingsRootView: adds .searchable() with displayMode .always so the
      field is immediately visible without pulling down the list. While the
      query is non-empty a results section appears above the regular settings
      showing each match with its setting name and a section subtitle. Tapping
      any result navigates directly to the containing settings screen via the
      existing .navigationLink(to:from:) mechanism. The normal settings layout
      is untouched when the search field is empty.

    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>