### PR TITLE
Add TestFlight build expiration alert

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -539,6 +539,7 @@
 		FA630397F76B582C8D8681A7 /* BasalProfileEditorProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42369F66CF91F30624C0B3A6 /* BasalProfileEditorProvider.swift */; };
 		FE22BF6B2E04080100231496 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = FEBEEC142E03F45B005473DC /* Settings.bundle */; };
 		FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */; };
+		CC1A00032A000002000A708ED /* BuildExpirationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC1A00022A000002000A708ED /* BuildExpirationManager.swift */; };
 		FEB27EA62E07D9310047CB66 /* NSUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEB27EA52E07D90F0047CB66 /* NSUserDefaults.swift */; };
 		FEFA5C0F299F810B00765C17 /* Core_Data.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = FEFA5C0D299F810B00765C17 /* Core_Data.xcdatamodeld */; };
 		FEFA5C11299F814A00765C17 /* CoreDataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFA5C10299F814A00765C17 /* CoreDataStack.swift */; };
@@ -1242,6 +1243,7 @@
 		F90692D5274B9A450037068D /* HealthKitStateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitStateModel.swift; sourceTree = "<group>"; };
 		FBB3BAE7494CB771ABAC7B8B /* ISFEditorRootView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ISFEditorRootView.swift; sourceTree = "<group>"; };
 		FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
+		CC1A00022A000002000A708ED /* BuildExpirationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BuildExpirationManager.swift; sourceTree = "<group>"; };
 		FEB27EA52E07D90F0047CB66 /* NSUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSUserDefaults.swift; sourceTree = "<group>"; };
 		FEBEEC142E03F45B005473DC /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
 		FEFA5C0E299F810B00765C17 /* Core_Data.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Core_Data.xcdatamodel; sourceTree = "<group>"; };
@@ -2229,6 +2231,7 @@
 				E06B9119275B5EEA003C04B6 /* Array+Extension.swift */,
 				CEB434E428B8FF5D00B70274 /* UIColor.swift */,
 				FE66D16A291F74F8005D6F77 /* Bundle+Extensions.swift */,
+				CC1A00022A000002000A708ED /* BuildExpirationManager.swift */,
 				FEFFA7A12929FE49007B8193 /* UIDevice+Extensions.swift */,
 				CEA4F62229BE10F70011ADF7 /* SavitzkyGolayFilter.swift */,
 				056EB47D2B4C8B3D00CDE36E /* SystemSoundsManager.swift */,
@@ -3574,6 +3577,7 @@
 				38A504A425DD9C4000C5B9E8 /* UserDefaultsExtensions.swift in Sources */,
 				38FE826A25CC82DB001FF17A /* NetworkService.swift in Sources */,
 				FE66D16B291F74F8005D6F77 /* Bundle+Extensions.swift in Sources */,
+				CC1A00032A000002000A708ED /* BuildExpirationManager.swift in Sources */,
 				F2C73D622EB6602D00B700AB /* MainChartConfigDataFlow.swift in Sources */,
 				3883581C25EE79BB00E024B2 /* DecimalTextField.swift in Sources */,
 				6B1A8D2E2B156EEF00E76752 /* LiveActivityBridge.swift in Sources */,

--- a/FreeAPS/Sources/Helpers/BuildExpirationManager.swift
+++ b/FreeAPS/Sources/Helpers/BuildExpirationManager.swift
@@ -45,17 +45,42 @@ final class BuildExpirationManager {
     // MARK: - Alert content
 
     var alertTitle: String {
-        hoursRemaining < 24 ? "Build Expires Soon!" : "Build Expiring in \(daysRemaining) Day\(daysRemaining == 1 ? "" : "s")"
+        if hoursRemaining < 24 {
+            return NSLocalizedString(
+                "Build Expires Soon!",
+                comment: "Build expiration alert title when less than a day remains"
+            )
+        }
+        let format = daysRemaining == 1
+            ? NSLocalizedString("Build Expiring in %d Day", comment: "Build expiration alert title, singular day")
+            : NSLocalizedString("Build Expiring in %d Days", comment: "Build expiration alert title, plural days")
+        return String(format: format, daysRemaining)
     }
 
     var alertMessage: String {
-        let dateStr = expirationDate.formatted(date: .abbreviated, time: .omitted)
         if hoursRemaining < 24 {
             let h = hoursRemaining
-            return "Your iAPS build expires in \(h) hour\(h == 1 ? "" : "s"). " +
-                "After expiration the app will not launch until you rebuild."
+            let format = h == 1
+                ? NSLocalizedString(
+                    "Your iAPS build expires in %d hour. After expiration the app will not launch until you rebuild.",
+                    comment: "Build expiration alert message under a day, singular hour"
+                )
+                : NSLocalizedString(
+                    "Your iAPS build expires in %d hours. After expiration the app will not launch until you rebuild.",
+                    comment: "Build expiration alert message under a day, plural hours"
+                )
+            return String(format: format, h)
         }
-        return "Your iAPS build expires on \(dateStr) (\(daysRemaining) day\(daysRemaining == 1 ? "" : "s") remaining). " +
-            "TestFlight builds must be renewed every 90 days."
+        let dateStr = expirationDate.formatted(date: .abbreviated, time: .omitted)
+        let format = daysRemaining == 1
+            ? NSLocalizedString(
+                "Your iAPS build expires on %1$@ (%2$d day remaining). TestFlight builds must be renewed every 90 days.",
+                comment: "Build expiration alert message, singular day; %1$@ is the date, %2$d the days remaining"
+            )
+            : NSLocalizedString(
+                "Your iAPS build expires on %1$@ (%2$d days remaining). TestFlight builds must be renewed every 90 days.",
+                comment: "Build expiration alert message, plural days; %1$@ is the date, %2$d the days remaining"
+            )
+        return String(format: format, dateStr, daysRemaining)
     }
 }

--- a/FreeAPS/Sources/Helpers/BuildExpirationManager.swift
+++ b/FreeAPS/Sources/Helpers/BuildExpirationManager.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Tracks the 90-day TestFlight build lifetime and throttles expiration alerts.
+///
+/// Alert cadence (matching Loop's behaviour):
+///   ≤ 20 days remaining  → show at most once every 2 days
+///   <  24 hours remaining → show at most once per hour
+final class BuildExpirationManager {
+    static let shared = BuildExpirationManager()
+
+    private let defaults = UserDefaults.standard
+    private static let lastAlertKey = "iaps.buildExpirationLastAlertDate"
+    private static let lifespanDays = 90
+    private static let warningDays = 20
+
+    // MARK: - Computed properties
+
+    var expirationDate: Date {
+        Calendar.current.date(byAdding: .day, value: Self.lifespanDays, to: Bundle.main.buildDate)
+            ?? .distantFuture
+    }
+
+    var daysRemaining: Int {
+        Calendar.current.dateComponents([.day], from: Date(), to: expirationDate).day ?? 0
+    }
+
+    var hoursRemaining: Int {
+        max(0, Calendar.current.dateComponents([.hour], from: Date(), to: expirationDate).hour ?? 0)
+    }
+
+    // MARK: - Alert gating
+
+    var shouldShowAlert: Bool {
+        let days = daysRemaining
+        guard days >= 0, days <= Self.warningDays else { return false }
+        let minInterval: TimeInterval = hoursRemaining < 24 ? 3600 : 2 * 86400
+        let last = defaults.object(forKey: Self.lastAlertKey) as? Date ?? .distantPast
+        return Date().timeIntervalSince(last) >= minInterval
+    }
+
+    func markAlertShown() {
+        defaults.set(Date(), forKey: Self.lastAlertKey)
+    }
+
+    // MARK: - Alert content
+
+    var alertTitle: String {
+        hoursRemaining < 24 ? "Build Expires Soon!" : "Build Expiring in \(daysRemaining) Day\(daysRemaining == 1 ? "" : "s")"
+    }
+
+    var alertMessage: String {
+        let dateStr = expirationDate.formatted(date: .abbreviated, time: .omitted)
+        if hoursRemaining < 24 {
+            let h = hoursRemaining
+            return "Your iAPS build expires in \(h) hour\(h == 1 ? "" : "s"). " +
+                "After expiration the app will not launch until you rebuild."
+        }
+        return "Your iAPS build expires on \(dateStr) (\(daysRemaining) day\(daysRemaining == 1 ? "" : "s") remaining). " +
+            "TestFlight builds must be renewed every 90 days."
+    }
+}

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -4035,3 +4035,22 @@ Enact a temp Basal or a temp target */
 
 /* Alert message when manual temp basal rate exceeds Max Basal setting. Args: entered rate, configured max basal */
 "The rate %.2f U/hr exceeds your Max Basal setting of %.2f U/hr." = "The rate %.2f U/hr exceeds your Max Basal setting of %.2f U/hr.";
+
+/* --- Build expiration alert (TestFlight 90-day lifetime) --- */
+"OK" = "OK";
+
+"More Info" = "More Info";
+
+"Build Expires Soon!" = "Build Expires Soon!";
+
+"Build Expiring in %d Day" = "Build Expiring in %d Day";
+
+"Build Expiring in %d Days" = "Build Expiring in %d Days";
+
+"Your iAPS build expires in %d hour. After expiration the app will not launch until you rebuild." = "Your iAPS build expires in %d hour. After expiration the app will not launch until you rebuild.";
+
+"Your iAPS build expires in %d hours. After expiration the app will not launch until you rebuild." = "Your iAPS build expires in %d hours. After expiration the app will not launch until you rebuild.";
+
+"Your iAPS build expires on %1$@ (%2$d day remaining). TestFlight builds must be renewed every 90 days." = "Your iAPS build expires on %1$@ (%2$d day remaining). TestFlight builds must be renewed every 90 days.";
+
+"Your iAPS build expires on %1$@ (%2$d days remaining). TestFlight builds must be renewed every 90 days." = "Your iAPS build expires on %1$@ (%2$d days remaining). TestFlight builds must be renewed every 90 days.";

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -13,6 +13,7 @@ extension Home {
         @State var isStatusPopupPresented = false
         @State var showCancelAlert = false
         @State var showCancelTTAlert = false
+        @State var showExpirationAlert = false
         @State var triggerUpdate = false
         @State var display = false
         @State var displayGlucose = false
@@ -1236,6 +1237,7 @@ extension Home {
                         switch scenePhase {
                         case .active:
                             state.startTimer()
+                            checkBuildExpiration()
                         case .background,
                              .inactive:
                             state.stopTimer()
@@ -1249,6 +1251,20 @@ extension Home {
                 if onboarded.first?.firstRun ?? true {
                     state.fetchPreferences()
                 }
+                checkBuildExpiration()
+            }
+            .alert(
+                BuildExpirationManager.shared.alertTitle,
+                isPresented: $showExpirationAlert
+            ) {
+                Button("OK", role: .cancel) {}
+                Button("More Info") {
+                    if let url = URL(string: "https://github.com/Artificial-Pancreas/iAPS/releases") {
+                        UIApplication.shared.open(url)
+                    }
+                }
+            } message: {
+                Text(BuildExpirationManager.shared.alertMessage)
             }
             .navigationTitle("Home")
             .navigationBarHidden(true)
@@ -1280,6 +1296,13 @@ extension Home {
                             }
                     )
             }
+        }
+
+        private func checkBuildExpiration() {
+            let manager = BuildExpirationManager.shared
+            guard manager.shouldShowAlert else { return }
+            manager.markAlertShown()
+            showExpirationAlert = true
         }
 
         private var popup: some View {


### PR DESCRIPTION
TestFlight builds expire 90 days after the build date. Users have no in-app warning today — the app simply stops launching once the deadline passes. This adds a Loop-style alert that fires when the home screen appears or the app returns to the foreground:

  ≤ 20 days remaining  → alert at most once every 2 days
  <  24 hours remaining → alert at most once per hour

BuildExpirationManager (new, Helpers/) computes the expiry as buildDate + 90 days using the existing Bundle.main.buildDate helper, gates alerts via a UserDefaults timestamp, and provides the alert title and message text. HomeRootView checks the manager on onAppear and on every .active scenePhase transition, then shows a native SwiftUI alert with an OK button and a "More Info" button that opens the iAPS releases page. Both new source files are registered in project.pbxproj.

Closes: #208 