### PR TITLE
Debug omnipod

### DIFF
--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -1097,6 +1097,10 @@ final class BaseAPSManager: APSManager, Injectable {
             let branch = branch()
             let copyrightNotice_ = Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String ?? ""
             let pump_ = pumpManager?.localizedTitle ?? ""
+            let omniBLE = pumpManager as? OmniBLEPumpManager
+            let podBLE = omniBLE?.deviceBLEName
+            let podFirmware = omniBLE?.state.podState?.firmwareVersion
+            let podBLEFirmware = omniBLE?.state.podState?.bleFirmwareVersion
 //            let cgm = settings.cgm
             let file = OpenAPS.Monitor.statistics
             var iPa: Decimal = 75
@@ -1279,6 +1283,9 @@ final class BaseAPSManager: APSManager, Injectable {
                 AdjustmentFactor: af,
                 Pump: pump_,
                 CGM: KnownPlugins.cgmIdForStatistics(for: deviceDataManager.cgmManager) ?? "",
+                PodBLE: podBLE,
+                PodFirmware: podFirmware,
+                PodBLEFirmware: podBLEFirmware,
                 insulinType: insulin_type.rawValue,
                 peakActivityTime: iPa,
                 Carbs_24h: carbTotal,

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -2,6 +2,7 @@ import Combine
 import CoreData
 import Foundation
 import LoopKit
+import OmniBLE
 import LoopKitUI
 import SwiftDate
 import SwiftUI

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -568,6 +568,18 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
             self.pumpManager = newPumpManager
         }
         pumpName.send(pumpManager.localizedTitle)
+
+        if let omniBLE = pumpManager as? OmniBLEPumpManager,
+           let podState = omniBLE.state.podState,
+           podState.isFaulted,
+           let fault = podState.fault
+        {
+            let faultId = "\(podState.address):\(fault.faultEventCode.rawValue)"
+            if UserDefaults.standard.string(forKey: "iaps.lastLoggedPodFault") != faultId {
+                UserDefaults.standard.set(faultId, forKey: "iaps.lastLoggedPodFault")
+                debug(.deviceManager, "Pod fault detected: \(fault.faultEventCode) (\(fault.faultEventCode.rawValue))")
+            }
+        }
     }
 
     func pumpManagerBLEHeartbeatDidFire(_: PumpManager) {

--- a/FreeAPS/Sources/Models/Statistics.swift
+++ b/FreeAPS/Sources/Models/Statistics.swift
@@ -13,6 +13,9 @@ struct Statistics: JSON, Equatable {
     var AdjustmentFactor: Decimal
     var Pump: String
     var CGM: String
+    var PodBLE: String?
+    var PodFirmware: String?
+    var PodBLEFirmware: String?
     var insulinType: String
     var peakActivityTime: Decimal
     var Carbs_24h: Decimal
@@ -35,6 +38,9 @@ struct Statistics: JSON, Equatable {
         AdjustmentFactor: Decimal,
         Pump: String,
         CGM: String,
+        PodBLE: String? = nil,
+        PodFirmware: String? = nil,
+        PodBLEFirmware: String? = nil,
         insulinType: String,
         peakActivityTime: Decimal,
         Carbs_24h: Decimal,
@@ -56,6 +62,9 @@ struct Statistics: JSON, Equatable {
         self.AdjustmentFactor = AdjustmentFactor
         self.Pump = Pump
         self.CGM = CGM
+        self.PodBLE = PodBLE
+        self.PodFirmware = PodFirmware
+        self.PodBLEFirmware = PodBLEFirmware
         self.insulinType = insulinType
         self.peakActivityTime = peakActivityTime
         self.Carbs_24h = Carbs_24h
@@ -89,6 +98,9 @@ extension Statistics {
         case AdjustmentFactor
         case Pump
         case CGM
+        case PodBLE
+        case PodFirmware
+        case PodBLEFirmware
         case insulinType
         case peakActivityTime
         case Carbs_24h


### PR DESCRIPTION
Built and running on my phone ... the idea is that we can get a bit more details about the Dash pods being run ... I posted a question to #dash asking if anyone with the 203 errors has uploaded logs yet, since on the device diagnostics page, I haven't seen anything that appears to be related, so either

- nobody has uploaded logs that is having the problem
- the logs don't actually record the problem, which would be weird as it records pretty much everything else

If we have that info in the logs though, then we might be able to more easily focus in on if there are specific BLE or Firmware ersions that the problem is manifesting in.



    Add pod hardware details (BLE chip, firmware versions) to statistics upload

    Reads PodBLE (peripheral name), PodFirmware, and PodBLEFirmware from
    OmniBLEPumpManager at statistics build time and includes them in the
    statistics.json payload sent to open-iaps.app. Fields are optional <E2><80><94>
    nil for all non-DASH pump types <E2><80><94> so no other devices are affected.

    Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>