### PR TITLE
Fix mmol/L display showing ~4884 after Nightscout backfill

### DIFF
--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -432,12 +432,11 @@ extension Home {
                 self.readings = CoreDataStorage().fetchGlucose(interval: DateFilter().today)
                 self.recentGlucose = self.data.glucose.last
                 if self.data.glucose.count >= 2 {
-                    self.glucoseDelta =
-                        NSDecimalNumber(
-                            decimal:
-                            (self.recentGlucose?.unfiltered ?? 0) -
-                                (self.data.glucose[self.data.glucose.count - 2].unfiltered ?? 0)
-                        ).intValue
+                    let recent = self.recentGlucose
+                    let previous = self.data.glucose[self.data.glucose.count - 2]
+                    let recentValue = Decimal(recent?.glucose ?? recent?.sgv ?? 0)
+                    let previousValue = Decimal(previous.glucose ?? previous.sgv ?? 0)
+                    self.glucoseDelta = NSDecimalNumber(decimal: recentValue - previousValue).intValue
                 } else {
                     self.glucoseDelta = nil
                 }

--- a/FreeAPS/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
@@ -102,9 +102,9 @@ struct CurrentGlucoseView: View {
                 }
                 VStack(spacing: 15) {
                     let formatter = recent.type == GlucoseType.manual.rawValue ? manualGlucoseFormatter : glucoseFormatter
-                    if let string = recent.unfiltered.map({
+                    if let string = (recent.glucose ?? recent.sgv).map({
                         formatter
-                            .string(from: Double(units == .mmolL ? $0.asMmolL : $0) as NSNumber) ?? "" })
+                            .string(from: Double(units == .mmolL ? Decimal($0).asMmolL : Decimal($0)) as NSNumber) ?? "" })
                     {
                         glucoseText(string).asAny()
                             .background { glucoseDrop }


### PR DESCRIPTION


Nightscout entries carry a raw Dexcom ADC value in the `unfiltered` JSON field (e.g. 88000 for a calibrated glucose of 88 mg/dL). The glucose display and delta calculation were both reading `unfiltered` and converting it with ×0.0555 (mg/dL → mmol/L), yielding absurd values like 4,884.0 mmol/L.

For real-time CGM readings DeviceDataManager sets `unfiltered` to the same mg/dL integer as `glucose`, so the bug was invisible in normal use and only surfaced after a backfill.

Fix both sites to use `glucose ?? sgv` (the calibrated, smoothed value) instead of `unfiltered`.