### PR TITLE
do not exchange the blood glucose `unfiltered` field with nightscout

### DIFF
--- a/FreeAPS/Sources/Models/BloodGlucose.swift
+++ b/FreeAPS/Sources/Models/BloodGlucose.swift
@@ -100,7 +100,7 @@ struct BloodGlucose: JSON, Identifiable, Hashable, Codable {
     let date: Decimal
     let dateString: Date
     /// raw, un-smoothed value
-    let unfiltered: Decimal?
+    var unfiltered: Decimal?
     let uncalibrated: Decimal?
     let filtered: Decimal?
     let noise: Int?

--- a/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
@@ -111,6 +111,7 @@ extension NightscoutAPI {
                     .map {
                         var reading = $0
                         reading.glucose = $0.sgv
+                        reading.unfiltered = $0.sgv.map { sgv in Decimal(sgv) }
                         return reading
                     }
             }
@@ -510,7 +511,13 @@ extension NightscoutAPI {
             request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
         }
         debug(.nightscout, "NS Client: uploading \(glucose.count) glucose entries")
-        request.httpBody = try! JSONCoding.encoder.encode(glucose)
+        request.httpBody = try! JSONCoding.encoder.encode(
+            glucose.map {
+                var entry = $0
+                entry.unfiltered = nil
+                return entry
+            }
+        )
         request.httpMethod = "POST"
 
         return service.run(request)


### PR DESCRIPTION
When writing/fetching glucose from Nightscout - the `unfiltered` value will no longer be exchanged.

---
* iAPS uses the `unfiltered` field to store the original, un-smoothed value,
* other systems happen to store a completely different value in this field,
* this results in incorrect blood glucose records in iAPS after a backfill.