### PR TITLE
Fastlane: enable HealthKit capability on FreeAPSWatch (watchkitapp) App ID

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -189,7 +189,8 @@ platform :ios do
     ])
     
     configure_bundle_id("FreeAPSWatch", "#{APP_IDENTIFIER}.watchkitapp", [
-      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS
+      Spaceship::ConnectAPI::BundleIdCapability::Type::APP_GROUPS,
+      Spaceship::ConnectAPI::BundleIdCapability::Type::HEALTHKIT
     ])
 
     configure_bundle_id("LiveActivityExtension", "#{APP_IDENTIFIER}.LiveActivity", [


### PR DESCRIPTION
## Summary

- Add `HEALTHKIT` to the `configure_bundle_id` call for `FreeAPSWatch` (`watchkitapp`) in `fastlane/Fastfile` so `fastlane identifiers` enables HealthKit on the App ID automatically.
- Fixes the Xcode 26 build failure where `gym` errors out with: `Provisioning profile "match AppStore <bundle>.watchkitapp" doesn't support the HealthKit capability` / `doesn't include the com.apple.developer.healthkit` entitlement.
- Without this, every forker has to manually enable HealthKit on the watch App ID in the Apple Developer portal (see #1864) before TestFlight builds will succeed.

## Why this is needed

The watch extension target (`watchkitapp.watchkitextension`) already has HEALTHKIT in its `configure_bundle_id` call, but starting with Xcode 26 the parent watch container target (`watchkitapp`) is also required to have the HealthKit entitlement — its provisioning profile is checked by `xcodebuild -exportArchive`, and the build fails if the App ID was created without the capability. Several users hit this on 8.2.0 (#1864); the documented manual workaround is to tick the HealthKit box on the `FreeAPSWatch` identifier in the Apple Developer portal. Codifying it in the `identifiers` lane makes that automatic on first build.

## Test plan

- [ ] Run the `2. Add Identifiers` workflow on a fork whose `FreeAPSWatch` App ID does not yet have HealthKit — verify the capability is enabled afterwards.
- [ ] Run the `3. Create Certificates` workflow (with `ENABLE_NUKE_CERTS=true` if needed) so match regenerates the watchkitapp provisioning profile.
- [ ] Run the `4. Build iAPS` workflow — verify it completes through `gym` and uploads to TestFlight without the HealthKit capability error.
- [ ] Re-running `2. Add Identifiers` on a fork that already has HealthKit enabled is a no-op (idempotent).

Refs: #1864

🤖 Generated with [Claude Code](https://claude.com/claude-code)