### PR TITLE
enforce max basal rate when enacting a manual temp basal

### DIFF
--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -516,6 +516,9 @@ final class BaseAPSManager: APSManager, Injectable {
             return
         }
 
+        let maxBasal = Double(settingsManager.pumpSettings.maxBasal)
+        let rate = duration > 0 ? min(rate, maxBasal) : rate
+
         debug(.apsManager, "Enact temp basal \(rate) - \(duration)")
 
         let roundedAmout = pump.roundToSupportedBasalRate(unitsPerHour: rate)

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -670,14 +670,6 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
         dispatchPrecondition(condition: .onQueue(processQueue))
         debug(.deviceManager, "New pump events:\n\(events.map(\.title).joined(separator: "\n"))")
 
-        // TODO: [loopkit] is this filtering still needed?
-        // filter buggy TBRs > maxBasal from MDT
-        let pumpMaxBasal = Double(settingsManager.pumpSettings.maxBasal)
-        let events = events.filter {
-            // type is optional...
-            guard let type = $0.type, type == .tempBasal else { return true }
-            return $0.dose?.unitsPerHour ?? 0 <= pumpMaxBasal
-        }
         pumpHistoryStorage.storePumpEvents(events)
         lastEventDate = events.last?.date
         completion(nil)

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -3976,3 +3976,9 @@ Enact a temp Basal or a temp target */
 
 /* name of complete meals when saving */
 "Complete Meal" = "Complete Meal";
+
+/* Alert title when manual temp basal rate exceeds Max Basal setting */
+"Max Basal Exceeded" = "Max Basal Exceeded";
+
+/* Alert message when manual temp basal rate exceeds Max Basal setting. Args: entered rate, configured max basal */
+"The rate %.2f U/hr exceeds your Max Basal setting of %.2f U/hr." = "The rate %.2f U/hr exceeds your Max Basal setting of %.2f U/hr.";

--- a/FreeAPS/Sources/Modules/ManualTempBasal/ManualTempBasalStateModel.swift
+++ b/FreeAPS/Sources/Modules/ManualTempBasal/ManualTempBasalStateModel.swift
@@ -5,6 +5,7 @@ extension ManualTempBasal {
         @Injected() var apsManager: APSManager!
         @Published var rate: Decimal = 0
         @Published var durationIndex = 0
+        @Published var maxBasalExceeded = false
 
         let durationValues = stride(from: 30.0, to: 720.1, by: 30.0).map { $0 }
 
@@ -16,6 +17,10 @@ extension ManualTempBasal {
         }
 
         func enact() {
+            guard rate <= settingsManager.pumpSettings.maxBasal else {
+                maxBasalExceeded = true
+                return
+            }
             let duration = durationValues[durationIndex]
             apsManager.enactTempBasal(rate: Double(rate), duration: duration * 60)
             showModal(for: nil)

--- a/FreeAPS/Sources/Modules/ManualTempBasal/View/ManualTempBasalRootView.swift
+++ b/FreeAPS/Sources/Modules/ManualTempBasal/View/ManualTempBasalRootView.swift
@@ -51,6 +51,23 @@ extension ManualTempBasal {
             .navigationTitle("Manual Temp Basal")
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarItems(trailing: Button("Close", action: state.hideModal))
+            .alert(
+                Text("Max Basal Exceeded"),
+                isPresented: $state.maxBasalExceeded
+            ) {
+                Button("OK") { state.maxBasalExceeded = false }
+            } message: {
+                Text(
+                    String(
+                        format: NSLocalizedString(
+                            "The rate %.2f U/hr exceeds your Max Basal setting of %.2f U/hr.",
+                            comment: "Alert message when manual temp basal rate exceeds Max Basal"
+                        ),
+                        Double(state.rate),
+                        Double(state.settingsManager.pumpSettings.maxBasal)
+                    )
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
Fixing the issue reported in [Discord](https://discord.com/channels/1120154740857245808/1124371739544125522/1502752963477770366)

* before enacting a manual TBR (in Open Loop) - validate it, do not allow values greater than the Max Basal setting
* if it is greater - show an error message

Additionally:
* added a clamp to the `APSManager.swift#enactTempBasal` - even if a TBR greater than max is requested (which would be a bug somewhere else) - clamp it to Max Basal
* removed the filtering of pump manager events in `DeviceDataManager` - previously, it would filter out TBRs greater than Max Basal (looks like a workaround for an issue from years ago) - this was masking the issue and the user would not see the large manual TBR in the pump history (nor on the chart) after accidentally enacting it.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f82ed9d5-8b9d-401c-a007-eb33036fad13" />