### PR TITLE
live activity tweaks/fixes

### DIFF
--- a/LiveActivity/LiveActivity.swift
+++ b/LiveActivity/LiveActivity.swift
@@ -320,6 +320,7 @@ struct WatchIOBCOBDisplay: View {
                 .fontWidth(.compressed)
             }
         }
+        .fixedSize(horizontal: true, vertical: false)
     }
 }
 

--- a/LiveActivity/Views/LiveActivityChart.swift
+++ b/LiveActivity/Views/LiveActivityChart.swift
@@ -315,6 +315,7 @@ struct LiveActivityChart: View {
                         .foregroundStyle(Color(.insulin))
                 }
                 .fontWidth(.condensed)
+                .fixedSize(horizontal: true, vertical: false)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 HStack(spacing: 0.5) {
@@ -325,6 +326,7 @@ struct LiveActivityChart: View {
                 }
                 .font(.system(size: 20))
                 .fontWidth(.condensed)
+                .fixedSize(horizontal: true, vertical: false)
                 .frame(maxWidth: .infinity, alignment: .trailing)
             }
         }


### PR DESCRIPTION
(fixes https://github.com/Artificial-Pancreas/iAPS/issues/1868)

Attempting to fix a couple of layout issues:

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/dc083a20-d02f-45dc-be11-89644753112e" />

(reported on Discord)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/74bf2cca-1fd6-41e9-af7c-0ef9d551d97d" />

The fix is the same in both cases: `.fixedSize(horizontal: true, vertical: false)` to tell swiftui to give those elements as much horizontal space as they need (collapsing the neighboring `Spacer()` instead).


I was not able to reproduce the issue on my devices nor on the simulator, so it will have to be confirmed by the folks who reported the issues.