### PR TITLE
Revert "pin CryptoSwift version to 1.10 - to prevent build failures in latest versions of xcode"

### DIFF
--- a/FreeAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FreeAPS.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/krzyzanowskim/CryptoSwift",
       "state" : {
-        "revision" : "f2a627b84c1ff96f21ac2fcb623ab36142dd5512",
-        "version" : "1.10.0"
+        "revision" : "19b3c3ceed117c5cc883517c4e658548315ba70b",
+        "version" : "1.6.0"
       }
     },
     {


### PR DESCRIPTION
Reverts Artificial-Pancreas/iAPS#1903

Unfortunately, that PR wouldn't work and would just break the build.
An additional fix needs to be applied on the OmniBLE/OmnipodKit side.
