### PR TITLE
saving the complete meal - fix the meal name

### DIFF
--- a/FreeAPS/Sources/Modules/AddCarbs/View/SearchResultsView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/SearchResultsView.swift
@@ -334,8 +334,13 @@ struct SearchResultsView: View {
         }
         .sorted { $0.name < $1.name }
 
+        var name = state.searchResultsState.searchResults.prefix(2).map(\.title).joined(separator: ", ")
+        if state.searchResultsState.searchResults.count > 2 {
+            name = "\(name) +\(state.searchResultsState.searchResults.count - 2)"
+        }
+
         let savedItem = FoodItemDetailed(
-            name: state.searchResultsState.searchResults.description,
+            name: name,
             nutrition: .perServing(
                 values: state.searchResultsState.mealNutritionValues,
                 servingsMultiplier: 1

--- a/FreeAPS/Sources/Views/DismissableTextField.swift
+++ b/FreeAPS/Sources/Views/DismissableTextField.swift
@@ -68,6 +68,11 @@ public struct DismissableTextField: UIViewRepresentable {
         textField.setContentHuggingPriority(.required, for: .vertical)
         textField.setContentCompressionResistancePriority(.required, for: .vertical)
 
+        // Allow the field to be compressed/stretched horizontally to fit its
+        // container instead of growing to its full text width and overflowing.
+        textField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        textField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
         return textField
     }
 


### PR DESCRIPTION
When saving the full meal, there is a bug where a `.description` on an array is used for the meal name (this produced a "debug" description of the array and structs inside).

This PR fixes this and changes the meal name to be this:
* names of first 1 or 2 foods in the list
* ` +X` at the end, if there is more than 2 foods

Additionally, the `DismissableTextField` is now configured to prevent it from expanding beyond available screen space.


<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-24 at 16 45 01" src="https://github.com/user-attachments/assets/c68ec90f-b8ba-484b-8fc1-61665ce925dc" />

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-24 at 16 46 03" src="https://github.com/user-attachments/assets/62d22c33-5055-4195-ac24-d8a9a65b5315" />

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-24 at 16 46 53" src="https://github.com/user-attachments/assets/aab2a24a-f027-4fb0-ad39-f8df621f7a67" />
