### PR TITLE
detect if a manual TBR is active on all pumps, not just omni

### DIFF
--- a/FreeAPS/Sources/APS/KnownPlugins.swift
+++ b/FreeAPS/Sources/APS/KnownPlugins.swift
@@ -91,19 +91,8 @@ enum KnownPlugins {
     }
 
     static func isManualTempBasalActive(_ pumpManager: PumpManager) -> Bool? {
-        switch pumpManager.pluginIdentifier {
-        case OmniPumpManager.pluginIdentifier:
-            if let omnipod = pumpManager as? OmniPumpManager,
-               let tempBasal = omnipod.state.podState?.unfinalizedTempBasal,
-               !tempBasal.isFinished(),
-               !tempBasal.automatic
-            {
-                return true
-            } else {
-                return false
-            }
-        default: return nil
-        }
+        guard case let .tempBasal(dose) = pumpManager.status.basalDeliveryState else { return false }
+        return !(dose.automatic ?? true)
     }
 
     static func pumpActivationDate(_ pumpManager: PumpManager) -> Date? {


### PR DESCRIPTION
Manual temp basals are coming to MedtrumKit: https://github.com/jbr7rr/MedtrumKit/pull/158

This PR changes the manual TBR detection to look at the standard pump manager status / basalDeliveryState instead of looking inside omnipod pump manager internals and will work with all pumps.