### PR TITLE
Add nkf gem so the build runs on Ruby 3.4 (fixes kconv LoadError)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,8 @@ source "https://rubygems.org"
 
 gem "fastlane", git: "https://github.com/Artificial-Pancreas/fastlane.git", branch: "dev"
 gem "abbrev", git: "https://github.com/ruby/abbrev.git", branch: "master"
+# Ruby 3.4 dropped kconv from the default gems, but CFPropertyList (a fastlane
+# dependency) still `require`s it. kconv ships inside the nkf gem, so adding nkf
+# lets the build keep running on the runner's system Ruby 3.4.x instead of pinning
+# back to 3.3. Mirrors the abbrev entry above (same bundled-gem removal).
+gem "nkf"


### PR DESCRIPTION
The certificate/build jobs fail on runners with Ruby 3.4 (currently Homebrew Ruby 3.4.9):

```
cannot load such file -- kconv (LoadError)   # from CFPropertyList
uninitialized constant FastlaneCore::UpdateChecker (NameError)
```

Ruby 3.4 dropped `kconv` from the default gems, but `CFPropertyList` (a fastlane dependency) still `require`s it; that cascades into the `UpdateChecker` error as `FastlaneCore` fails to finish loading.

`kconv` ships inside the `nkf` gem, so adding it lets the build keep running on the runner's Ruby 3.4.x rather than pinning back to 3.3. This mirrors the existing `abbrev` entry, which was added for the same Ruby 3.4 bundled-gem removal.

Verified on a fork build: the cert job passes and the build reaches the archive stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
