### PR TITLE
use default installed xcode in build, fastlane stable version

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode_26.1.1.app/Contents/Developer"
+        run: "sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
       
       - name: Checkout Repo for syncing
         if: |

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,4 @@
 source "https://rubygems.org"
 
-gem "fastlane", git: "https://github.com/Artificial-Pancreas/fastlane.git", branch: "master"
+gem "fastlane", "~> 2.236.1"
 gem "abbrev", git: "https://github.com/ruby/abbrev.git", branch: "master"
-# Ruby 3.4 dropped kconv from the default gems, but CFPropertyList (a fastlane
-# dependency) still `require`s it. kconv ships inside the nkf gem, so adding nkf
-# lets the build keep running on the runner's system Ruby 3.4.x instead of pinning
-# back to 3.3. Mirrors the abbrev entry above (same bundled-gem removal).
-gem "nkf"


### PR DESCRIPTION
GitHub actions will use the default installed xcode version instead of pinning(hardcoding) a particular version.
Also, fastlane is pinned to a released version (from RubyGems) (which also fixes the missing dependencies issue after install).

test build from this branch:
https://github.com/yurique/iAPS/actions/runs/28321122221