### PR TITLE
github actions - select xcode 26.x

### DIFF
--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -82,7 +82,17 @@ jobs:
           fi
 
       - name: Select Xcode version
-        run: "sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
+        run: |
+          echo "Available Xcode versions:"
+          ls -d /Applications/Xcode*.app
+          XCODE=$(ls -d /Applications/Xcode_26*.app | sort -V | tail -1)
+          if [ -z "$XCODE" ]; then
+            echo "::error::Xcode 26.x NOT found on this runner"
+            exit 1
+          fi
+          echo "Selecting $XCODE"
+          sudo xcode-select --switch "$XCODE/Contents/Developer"
+          xcodebuild -version
       
       - name: Checkout Repo for syncing
         if: |


### PR DESCRIPTION
There was a report in Discord about a failed build with the following error:
> Validation failed SDK version issue. This app was built with the iOS 18.5 SDK. All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution.

Which suggests that xcode selected during that build was not 26.x (for some reason).


This PR changes the `Select xcode` build step to be a little bit smarter:
* it will print all available xcode versions (just for debug purposes)
* will find a newest 26.x version
* will select this version for the build (instead of using the default version configured in the runner)
* or it will fail fast if 26.x is not available for some reason


(test build with this branch: https://github.com/yurique/iAPS/actions/runs/28403114824)

<img width="684" height="890" alt="image" src="https://github.com/user-attachments/assets/1ad1d0de-90c2-4ad5-9325-eed6777ab476" />
