### PR TITLE
fix for medtronic pumps configured before version 8 

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -32,6 +32,8 @@ protocol DeviceDataManager {
 
     func removePumpAsCGM()
 
+    func removePump()
+
     var alertHistoryStorage: AlertHistoryStorage! { get }
 
     var cgmManager: CGMManager? { get }
@@ -433,6 +435,12 @@ final class BaseDeviceDataManager: Injectable, DeviceDataManager {
     func removePumpAsCGM() {
         if cgmManager is PumpManagerUI, cgmManager?.pluginIdentifier == pumpManager?.pluginIdentifier {
             cgmManager = nil
+        }
+    }
+
+    func removePump() {
+        DispatchQueue.main.async {
+            self.pumpManager = nil
         }
     }
 

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -465,6 +465,15 @@ Enact a temp Basal or a temp target */
 "Pump config" = "Pump config";
 
 /*  */
+"Incomplete pump setup" = "Incomplete pump setup";
+
+/*  */
+"The previous setup for %@ did not finish fully/correctly. Remove it and restart iAPS before adding your pump again (otherwise your RileyLink device may not show up in the device list)." = "The previous setup for %@ did not finish fully/correctly. Remove it and restart iAPS before adding your pump again (otherwise your RileyLink device may not show up in the device list).";
+
+/*  */
+"Remove pump" = "Remove pump";
+
+/*  */
 "Delivery limits" = "Delivery limits";
 
 /*  */

--- a/FreeAPS/Sources/Modules/PumpConfig/PumpConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/PumpConfig/PumpConfigStateModel.swift
@@ -46,6 +46,10 @@ extension PumpConfig {
             pumpSetupPresented = identifier != nil
         }
 
+        func removePump() {
+            deviceManager.removePump()
+        }
+
         func ack() {
             provider.deviceManager.alertHistoryStorage.forceNotification()
         }

--- a/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
+++ b/FreeAPS/Sources/Modules/PumpConfig/View/PumpConfigRootView.swift
@@ -45,6 +45,32 @@ extension PumpConfig {
                                 Button("Acknowledge all alerts") { state.ack() }
                             }
                         }
+                    } else if let pumpManager = state.deviceManager.pumpManager {
+                        // This corresponds to the "Re-connect pump!" message on the home screen.
+                        // Before version 8, iAPS had a bug preventing the Medtronic pump manager from completing the onboarding.
+                        // So the pump ended up in a state with `onboarded=false` forever.
+                        // The pump kept working correctly, but the state was inconsistent.
+                        // In version 8, we introduced a check for this situation instructing the user to re-connect the pump.
+                        // But since the pump manager is already initialized (restored from state at app start), and already remembers/holds the RileyLink connection,
+                        // that RileyLink device would never show up in the list.
+                        // The fix for this is to remove the pump manager completely and restart iAPS to clear the pump manager in-memory state.
+                        Section {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Incomplete pump setup")
+                                    .font(.headline)
+                                    .foregroundColor(.orange)
+                                Text(
+                                    "The previous setup for \(pumpManager.localizedTitle) did not finish fully/correctly. Remove it and restart iAPS before adding your pump again (otherwise your RileyLink device may not show up in the device list)."
+                                )
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                            }
+                            Button(role: .destructive) {
+                                state.removePump()
+                            } label: {
+                                Text("Remove pump")
+                            }
+                        }
                     } else {
                         Section {
                             ForEach(state.deviceManager.availablePumpManagers, id: \.identifier) { pump in


### PR DESCRIPTION
fix for medtronic pumps configured before version 8:
* pump manager is configured, 
* onboarded=false, 
* RileyLink device not showing up in the list when connecting the pump from scratch,
* need to remove the pump state and restart iAPS 

--- 
the issue is when the user tries to connect the pump from scratch - the pump manager is already initialized (with onboarded=true) and holds the connection to the RileyLink device, thus this device is not showing up in the list. The fix here is to let the user remove the pump so that it doesn't get initialized after iAPS is restarted and the RIleyLink device will advertise itself.