### PR TITLE
fastlane tweaks

### DIFF
--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -19,9 +19,14 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set special variables
+        env:
+          # APP_IDENTIFIER may be set as a secret (preferred) or a repository variable (fallback).
+          APP_IDENTIFIER_SECRET: ${{ secrets.APP_IDENTIFIER }}
+          APP_IDENTIFIER_VAR: ${{ vars.APP_IDENTIFIER }}
         run: |
-          if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
-            echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+          APP_ID="${APP_IDENTIFIER_SECRET:-$APP_IDENTIFIER_VAR}"
+          if [ -n "$APP_ID" ]; then
+            echo "APP_IDENTIFIER=$APP_ID" >> "$GITHUB_ENV"
           fi
 
       # Ensure compatible Bundler version for Fastlane (fastlane requires bundler < 3)

--- a/.github/workflows/add_identifiers.yml
+++ b/.github/workflows/add_identifiers.yml
@@ -17,7 +17,13 @@ jobs:
       # Checks-out the repo
       - name: Checkout Repo
         uses: actions/checkout@v5
-      
+
+      - name: Set special variables
+        run: |
+          if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
+            echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+          fi
+
       # Ensure compatible Bundler version for Fastlane (fastlane requires bundler < 3)
       - name: Install Bundler 2.x
         run: |

--- a/.github/workflows/build_iAPS.yml
+++ b/.github/workflows/build_iAPS.yml
@@ -73,12 +73,19 @@ jobs:
       contents: write
     steps:
       - name: Set special variables
+        env:
+          # APP_IDENTIFIER may be set as a secret (preferred, since it embeds the team id)
+          # or as a repository variable (fallback). The secret wins when both are set.
+          APP_IDENTIFIER_SECRET: ${{ secrets.APP_IDENTIFIER }}
+          APP_IDENTIFIER_VAR: ${{ vars.APP_IDENTIFIER }}
+          BUILD_GROUP_VAR: ${{ vars.BUILD_GROUP }}
         run: |
-          if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
-            echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+          APP_ID="${APP_IDENTIFIER_SECRET:-$APP_IDENTIFIER_VAR}"
+          if [ -n "$APP_ID" ]; then
+            echo "APP_IDENTIFIER=$APP_ID" >> "$GITHUB_ENV"
           fi
-          if [ ! -z ${{ vars.BUILD_GROUP }}  ]; then
-            echo "BUILD_GROUP=${{ vars.BUILD_GROUP }}" >> $GITHUB_ENV
+          if [ -n "$BUILD_GROUP_VAR" ]; then
+            echo "BUILD_GROUP=$BUILD_GROUP_VAR" >> "$GITHUB_ENV"
           fi
 
       - name: Select Xcode version
@@ -169,7 +176,10 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
       
       # Upload to TestFlight
+      # Set repository variable SKIP_TESTFLIGHT_UPLOAD=true to build & archive without
+      # publishing to TestFlight (when testing).
       - name: Fastlane upload to TestFlight
+        if: ${{ vars.SKIP_TESTFLIGHT_UPLOAD != 'true' }}
         run: bundle _${{ env.BUNDLER_VER }}_ exec fastlane release
         env:
           TEAMID: ${{ secrets.TEAMID }}

--- a/.github/workflows/create_certs.yml
+++ b/.github/workflows/create_certs.yml
@@ -35,9 +35,14 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set special variables
+        env:
+          # APP_IDENTIFIER may be set as a secret (preferred) or a repository variable (fallback).
+          APP_IDENTIFIER_SECRET: ${{ secrets.APP_IDENTIFIER }}
+          APP_IDENTIFIER_VAR: ${{ vars.APP_IDENTIFIER }}
         run: |
-          if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
-            echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+          APP_ID="${APP_IDENTIFIER_SECRET:-$APP_IDENTIFIER_VAR}"
+          if [ -n "$APP_ID" ]; then
+            echo "APP_IDENTIFIER=$APP_ID" >> "$GITHUB_ENV"
           fi
 
       # Ensure compatible Bundler version for Fastlane (fastlane requires bundler < 3)
@@ -116,9 +121,14 @@ jobs:
           uses: actions/checkout@v5
 
         - name: Set special variables
+          env:
+            # APP_IDENTIFIER may be set as a secret (preferred) or a repository variable (fallback).
+            APP_IDENTIFIER_SECRET: ${{ secrets.APP_IDENTIFIER }}
+            APP_IDENTIFIER_VAR: ${{ vars.APP_IDENTIFIER }}
           run: |
-            if [ ! -z ${{ vars.APP_IDENTIFIER }}  ]; then
-              echo "APP_IDENTIFIER=${{ vars.APP_IDENTIFIER }}" >> $GITHUB_ENV
+            APP_ID="${APP_IDENTIFIER_SECRET:-$APP_IDENTIFIER_VAR}"
+            if [ -n "$APP_ID" ]; then
+              echo "APP_IDENTIFIER=$APP_ID" >> "$GITHUB_ENV"
             fi
 
         # Ensure compatible Bundler version for Fastlane (fastlane requires bundler < 3)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,7 +100,8 @@ platform :ios do
         UI.user_error!(
           "The provisioning profile for #{id} does not include the App Group #{app_group_id}. " \
           "Assign it in the Apple Developer portal (Identifiers -> #{id} -> App Groups -> Configure -> select \"Loop App Group\"), " \
-          "then delete the stale AppStore_#{id}.mobileprovision from your Match-Secrets repo (match reuses the existing profile, so it must be removed to force a fresh one) and re-run '3. Create Certificates' before building again. " \
+          "then run the build again: assigning the App Group invalidates the old profile, so it is normally regenerated automatically. " \
+          "If the build still fails with this error, delete AppStore_#{id}.mobileprovision from your Match-Secrets repo to force a fresh profile, then build again. " \
           "See the \"Add App Group to Bundle Identifiers\" section in fastlane/testflight.md."
         )
       end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -29,7 +29,7 @@ if ENV['BUILD_GROUP']
   File.write('../ConfigOverride.xcconfig', "COPYRIGHT_NOTICE = #{ENV['BUILD_GROUP']}\n", mode: 'a')
 end
 
-if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
+if APP_IDENTIFIER != "ru.artpancreas.#{TEAMID}.FreeAPS"
   File.write('../ConfigOverride.xcconfig', "BUNDLE_IDENTIFIER = #{APP_IDENTIFIER}\n", mode: 'a')
 end
 
@@ -78,6 +78,33 @@ platform :ios do
         "#{APP_IDENTIFIER}.LiveActivity"
       ]
     )
+
+    # Fail fast if the App Group is not assigned to the bundle identifiers.
+    # match downloads/creates profiles but does not validate their entitlements, so a
+    # missing App Group otherwise only surfaces ~10 min later in `gym` as a cryptic
+    # "Provisioning profile ... doesn't support the ... App Group" xcodebuild error.
+    app_group_id = "group.com.#{TEAMID}.loopkit.LoopGroup"
+    [
+      "#{APP_IDENTIFIER}",
+      "#{APP_IDENTIFIER}.watchkitapp",
+      "#{APP_IDENTIFIER}.watchkitapp.watchkitextension"
+    ].each do |id|
+      profile_path = ENV["sigh_#{id}_appstore_profile-path"]
+      if profile_path.nil? || !File.exist?(profile_path)
+        UI.user_error!("Could not locate the provisioning profile for #{id} to verify its App Group. Re-run '3. Create Certificates' and try again.")
+      end
+      groups = FastlaneCore::ProvisioningProfile.parse(profile_path)
+        .fetch("Entitlements", {})
+        .fetch("com.apple.security.application-groups", [])
+      unless groups.include?(app_group_id)
+        UI.user_error!(
+          "The provisioning profile for #{id} does not include the App Group #{app_group_id}. " \
+          "Assign it in the Apple Developer portal (Identifiers -> #{id} -> App Groups -> Configure -> select \"Loop App Group\"), " \
+          "then delete the stale AppStore_#{id}.mobileprovision from your Match-Secrets repo (match reuses the existing profile, so it must be removed to force a fresh one) and re-run '3. Create Certificates' before building again. " \
+          "See the \"Add App Group to Bundle Identifiers\" section in fastlane/testflight.md."
+        )
+      end
+    end
 
     previous_build_number = latest_testflight_build_number(
       app_identifier: "#{APP_IDENTIFIER}",

--- a/fastlane/docs/github.md
+++ b/fastlane/docs/github.md
@@ -35,9 +35,9 @@ Follow these steps to fork the repository:
     * Go to Settings -> Secrets and variables -> Actions and make sure the Variables tab is open
 4. Tap on "Create new organization variable" or "Create new repository variable", then add the name below and enter the value *true*. Unlike secrets these variables are visible and can be edited.
     * `ENABLE_NUKE_CERTS`
-5.  Under the **Variables** tab, set the following two variables:
-    * `APP_IDENTIFIER`: This defaults to `ru.artpancreas.#{TEAMID}.FreeAPS` if you don't set it.
-    * `BUILD_GROUP`: This variable is typically left blank unless you're labeling a distribution or build shared by multiple users.
+5.  **Optional: most people should skip this step.** Neither of the following is needed for a normal build. Only add them if you specifically need the behaviour described:
+    * `APP_IDENTIFIER` (secret *or* variable) - the app's bundle identifier. **Leave it unset** (do not create the secret/variable) unless you are deliberately building with a non-default bundle id (for example a second, separate app). If you don't set it, the build automatically uses `ru.artpancreas.<your team id>.FreeAPS`, with your team id filled in for you - you do **not** need to create anything or type that value anywhere (in particular, do not paste `<your team id>` or `#{TEAMID}` literally, and do not include the extra symbols: `<>`, `${}`, etc; it is just a placeholder for your team id). If you *do* need a custom value, add it as a **secret** named `APP_IDENTIFIER` (preferred, because the bundle id contains your team id, which is best kept private); a repository **variable** of the same name is still supported as a fallback.
+    * `BUILD_GROUP` (variable) - leave it unset unless you're labeling a distribution or build shared by multiple users.
       
 ---
 

--- a/fastlane/testflight.md
+++ b/fastlane/testflight.md
@@ -55,15 +55,18 @@ This is also a common step for all "browser builds", do this step only once
 
 ## Create App Group
 
-If you have already built iAPS via Xcode using this Apple ID, you can skip on to [Create iAPS App in App Store Connect](#create-FreeAPS-X-app-in-app-store-connect).
+If you have already built iAPS (or Loop) via Xcode using this Apple ID, the "Loop App Group" likely already exists in your account. In that case skip ahead to [Add App Group to Bundle Identifiers](#add-app-group-to-bundle-identifiers) — **do not** skip past it. The App Group existing in your account is not the same as it being assigned to the iAPS bundle identifiers, and the identifiers created by "2. Add Identifiers" start out with no group assigned. Skipping that section is the most common cause of a build failing with `Provisioning profile ... doesn't support the ... LoopGroup App Group`.
 _Please note that in default builds of iAPS, the app group is actually identical to the one used with Loop, so please enter these details exactly as described below. This is to ease the setup of apps such as Xdrip4iOS. It may require some caution if transfering between iAPS and Loop._
 
 1. Go to [Register an App Group](https://developer.apple.com/account/resources/identifiers/applicationGroup/add/) on the apple developer site.
 1. For Description, use "Loop App Group".
 1. For Identifier, enter "group.com.TEAMID.loopkit.LoopGroup", substituting your team id for `TEAMID`.
 1. Click "Continue" and then "Register".
+1. If you are told the group already exists, that is fine — continue to the next section to assign it.
 
 ## Add App Group to Bundle Identifiers
+
+> This section is required even if the App Group already existed. The identifiers created by "2. Add Identifiers" have the App Groups capability enabled but no group assigned yet, so you must assign it here.
 
 1. Go to [Certificates, Identifiers & Profiles](https://developer.apple.com/account/resources/identifiers/list) on the Apple developer site.
 1. For each of the following identifier names:


### PR DESCRIPTION
* fix an invalid line in the `Fastfile`: `#` made the whole line after `if` to be a comment:
```rb
if #{APP_IDENTIFIER} != "ru.artpancreas.#{TEAMID}.FreeAPS"
```

* some clarifications in `testflight.md` about the importance of adding the `LoopGroup` to the app identifier (some users skip this step and have failing builds)
* add a fail-fast check to the `Fastfile` - if `LoopGroup` is not added to the app identifier, the build will fail early, instead of failing after the full build is completed (20 minutes later)
* add support for a new github actions env variable: `SKIP_TESTFLIGHT_UPLOAD`, if it is set to `true`, the full build will run, but will not be pushed to TestFlight (useful just for testing the browser build)
* `APP_IDENTIFIER` - can now be specified as a repository secret (it is still possible to define it as an env variable, not secret - but since it often contains the TEAM_ID, and we treat TEAM_ID as a secret - it's better to keep the `APP_IDENTIFIER` override in secrets as well)
* updated the instructions about the custom `APP_IDENTIFIER` - tell the user to put it into secrets, and clarify that this is an *optional* variable needed only if the user wants a custom identifier (hopefully there will be less issues with folks accidentally leaving `#{}` in the variable, etc)