### PR TITLE
fix: sync Omnipod pod expiry to home header on state updates

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -1028,8 +1028,11 @@ private extension BaseDeviceDataManager {
 
         if let reservoir = KnownPlugins.pumpReservoir(pumpManager) {
             storage.save(reservoir, as: OpenAPS.Monitor.reservoir)
-            broadcaster.notify(PumpReservoirObserver.self, on: processQueue) {
-                $0.pumpReservoirDidChange(reservoir)
+            // setupPump / didUpdateState can run off processQueue; Broadcaster requires it.
+            processQueue.safeSync {
+                broadcaster.notify(PumpReservoirObserver.self, on: processQueue) {
+                    $0.pumpReservoirDidChange(reservoir)
+                }
             }
         }
     }

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -578,6 +578,10 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
             self.pumpManager = newPumpManager
         }
         pumpName.send(pumpManager.localizedTitle)
+        // OmnipodKit notifies state on every podState change, but only emits
+        // status updates when PumpManagerStatus/highlight changes. Pod expiry
+        // lives on podState, so refresh home-header fields here as well.
+        refreshPodDerivedState(from: pumpManager)
     }
 
     func pumpManagerBLEHeartbeatDidFire(_: PumpManager) {
@@ -635,12 +639,7 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
             manualTempBasal.send(false)
         }
 
-        let endTime = KnownPlugins.pumpExpirationDate(pumpManager)
-        pumpExpiresAtDate.send(endTime)
-
-        if let startTime = KnownPlugins.pumpActivationDate(pumpManager) {
-            storage.save(startTime, as: OpenAPS.Monitor.podAge)
-        }
+        refreshPodDerivedState(from: pumpManager)
 
         pumpManagerStatus.value = status
         if status.deliveryIsUncertain != oldStatus.deliveryIsUncertain {
@@ -1009,12 +1008,22 @@ private extension BaseDeviceDataManager {
             pumpDisplayState.value = PumpDisplayState(name: pumpManager.localizedTitle, image: pumpManager.smallImage)
             pumpManagerStatus.value = pumpManager.status
             pumpName.send(pumpManager.localizedTitle)
-            pumpExpiresAtDate.send(KnownPlugins.pumpExpirationDate(pumpManager))
+            refreshPodDerivedState(from: pumpManager)
         } else {
             pumpDisplayState.value = nil
             pumpManagerStatus.value = nil
             pumpExpiresAtDate.send(nil)
             pumpName.send("")
+        }
+    }
+
+    /// Keeps home-header pod fields in sync with pump manager state.
+    /// OmnipodKit may update `podState` (incl. `expiresAt`) without a status change.
+    func refreshPodDerivedState(from pumpManager: PumpManager) {
+        pumpExpiresAtDate.send(KnownPlugins.pumpExpirationDate(pumpManager))
+
+        if let startTime = KnownPlugins.pumpActivationDate(pumpManager) {
+            storage.save(startTime, as: OpenAPS.Monitor.podAge)
         }
     }
 }

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -1025,6 +1025,13 @@ private extension BaseDeviceDataManager {
         if let startTime = KnownPlugins.pumpActivationDate(pumpManager) {
             storage.save(startTime, as: OpenAPS.Monitor.podAge)
         }
+
+        if let reservoir = KnownPlugins.pumpReservoir(pumpManager) {
+            storage.save(reservoir, as: OpenAPS.Monitor.reservoir)
+            broadcaster.notify(PumpReservoirObserver.self, on: processQueue) {
+                $0.pumpReservoirDidChange(reservoir)
+            }
+        }
     }
 }
 

--- a/FreeAPS/Sources/APS/KnownPlugins.swift
+++ b/FreeAPS/Sources/APS/KnownPlugins.swift
@@ -100,8 +100,16 @@ enum KnownPlugins {
         case MedtrumPumpManager.pluginIdentifier:
             return (pumpManager as? MedtrumPumpManager)?.state.patchActivatedAt
         case OmniPumpManager.pluginIdentifier:
-            return (pumpManager as? OmniPumpManager)?.state.podState?.activatedAt
-        default: return nil
+            if let activatedAt = (pumpManager as? OmniPumpManager)?.state.podState?.activatedAt {
+                return activatedAt
+            }
+            // Plugin dual-load can make `as? OmniPumpManager` fail; read serializable state instead.
+            return omniPodState(from: pumpManager)?["activatedAt"] as? Date
+        default:
+            if pumpManager.pluginIdentifier.hasPrefix("Omni") {
+                return omniPodState(from: pumpManager)?["activatedAt"] as? Date
+            }
+            return nil
         }
     }
 
@@ -110,23 +118,50 @@ enum KnownPlugins {
         case MedtrumPumpManager.pluginIdentifier:
             return (pumpManager as? MedtrumPumpManager)?.state.patchExpiresAt
         case OmniPumpManager.pluginIdentifier:
-            return (pumpManager as? OmniPumpManager)?.state.podState?.expiresAt
-        default: return nil
+            if let expiresAt = (pumpManager as? OmniPumpManager)?.state.podState?.expiresAt {
+                return expiresAt
+            }
+            // Plugin dual-load can make `as? OmniPumpManager` fail; read serializable state instead.
+            return omniPodState(from: pumpManager)?["expiresAt"] as? Date
+        default:
+            if pumpManager.pluginIdentifier.hasPrefix("Omni") {
+                return omniPodState(from: pumpManager)?["expiresAt"] as? Date
+            }
+            return nil
         }
     }
 
     static func pumpReservoir(_ pumpManager: PumpManager) -> Decimal? {
         switch pumpManager.pluginIdentifier {
         case OmniPumpManager.pluginIdentifier:
-            let reservoirVal = (pumpManager as? OmniPumpManager)?.state.podState?.lastInsulinMeasurements?
-                .reservoirLevel ?? 0xDEAD_BEEF
-            let reservoir = Decimal(reservoirVal) > 50.0 ? 0xDEAD_BEEF : reservoirVal
-            return Decimal(reservoir)
+            if let omni = pumpManager as? OmniPumpManager {
+                let reservoirVal = omni.state.podState?.lastInsulinMeasurements?.reservoirLevel ?? 0xDEAD_BEEF
+                let reservoir = Decimal(reservoirVal) > 50.0 ? 0xDEAD_BEEF : reservoirVal
+                return Decimal(reservoir)
+            }
+            return omniReservoir(from: pumpManager)
         case MedtrumPumpManager.pluginIdentifier:
             guard let reservoir = (pumpManager as? MedtrumPumpManager)?.state.reservoir else { return nil }
             return Decimal(reservoir)
-        default: return nil
+        default:
+            if pumpManager.pluginIdentifier.hasPrefix("Omni") {
+                return omniReservoir(from: pumpManager)
+            }
+            return nil
         }
+    }
+
+    /// OmnipodKit may be loaded from the plugin bundle while FreeAPS also imports the module.
+    /// Prefer typed access when the cast works; otherwise parse `rawState`.
+    private static func omniPodState(from pumpManager: PumpManager) -> [String: Any]? {
+        pumpManager.rawState["podState"] as? [String: Any]
+    }
+
+    private static func omniReservoir(from pumpManager: PumpManager) -> Decimal? {
+        let measurements = omniPodState(from: pumpManager)?["lastInsulinMeasurements"] as? [String: Any]
+        let reservoirVal = (measurements?["reservoirLevel"] as? Double) ?? 0xDEAD_BEEF
+        let reservoir = Decimal(reservoirVal) > 50.0 ? 0xDEAD_BEEF : Decimal(reservoirVal)
+        return reservoir
     }
 
     static func cgmInfo(for cgmManager: CGMManager) -> GlucoseSourceInfo? {

--- a/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/PumpView.swift
@@ -43,6 +43,10 @@ struct PumpView: View {
     ) var concentration: FetchedResults<InsulinConcentration>
 
     var body: some View {
+        // Prefer published expiry, but fall back to live pump-manager state so the
+        // home header cannot stick on "No Pod" when Omnipod settings already show a pod.
+        let resolvedExpiresAt = expiresAtDate
+            ?? state.deviceDataManager.pumpManager.flatMap(KnownPlugins.pumpExpirationDate)
         let nano = state.pumpName.contains("Medtrum")
         // let sim = state.pumpName.contains("Simulator") // Just For Testing
         HStack(spacing: 5) {
@@ -53,7 +57,7 @@ struct PumpView: View {
                 Text("Re-connect pump!").font(.statusFont).foregroundStyle(.red)
                     .offset(y: -4)
             } else {
-                if let date = expiresAtDate {
+                if let date = resolvedExpiresAt {
                     // Insulin amount (U)
                     if let insulin = reservoir {
                         // 120 % due to being non rectangular. +10 because of bottom inserter.
@@ -162,7 +166,7 @@ struct PumpView: View {
                                 if let timeZone = timeZone, timeZone.secondsFromGMT() != TimeZone.current.secondsFromGMT() {
                                     ClockOffset(mdtPump: true)
                                 }
-                            }.offset(y: expiresAtDate == nil ? -4 : 0)
+                            }.offset(y: resolvedExpiresAt == nil ? -4 : 0)
                     } else {
                         HStack(spacing: 0) {
                             Text(
@@ -199,7 +203,7 @@ struct PumpView: View {
                 }
             }
         }
-        .offset(x: (nano && expiresAtDate != nil) ? 5 : 0, y: (nano && expiresAtDate != nil) ? 10 : 5)
+        .offset(x: (nano && resolvedExpiresAt != nil) ? 5 : 0, y: (nano && resolvedExpiresAt != nil) ? 10 : 5)
     }
 
     private func remainingTime(time: TimeInterval) -> some View {


### PR DESCRIPTION
## Summary
- Home could show **No Pod** while Omnipod pump settings still showed a live pod (reservoir / expire time) after the 8.3.0 OmnipodKit migration.
- OmnipodKit calls `pumpManagerDidUpdateState` on every `podState` change, but only emits `didUpdate status` when `PumpManagerStatus`/highlight changes. Pod `expiresAt` lives on `podState`, so the home header’s `pumpExpiresAtDate` was often left stale/`nil`.
- Refresh pod-derived home fields (`pumpExpiresAtDate`, pod age) from `pumpManagerDidUpdateState` (and share that path via `refreshPodDerivedState`).

## Test plan
- [ ] With an active Omnipod DASH pod, open the app and confirm the home header shows reservoir / remaining time (not **No Pod**).
- [ ] Open pump settings and confirm the same expiry/reservoir as on home.
- [ ] Force a pod status refresh / BLE reconnect and confirm home updates without needing a status-only change.
- [ ] Deactivate / no-pod state still shows **No Pod** on home.