### PR TITLE
Improve device logging: entry types and device alerts

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -748,6 +748,13 @@ extension BaseDeviceDataManager: PumpManagerDelegate {
 
 extension BaseDeviceDataManager: DeviceManagerDelegate {
     func issueAlert(_ alert: Alert) {
+        // Device alerts (pod faults, expiry, occlusion, CGM alarms) otherwise
+        // never reach the log files — only the alert-history UI storage.
+        debug(
+            .deviceManager,
+            "Device alert [\(alert.identifier.managerIdentifier)/\(alert.identifier.alertIdentifier)]: " +
+                "\(alert.backgroundContent.title) — \(alert.backgroundContent.body)"
+        )
         alertHistoryStorage.storeAlert(
             AlertEntry(from: alert)
         )

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -763,11 +763,11 @@ extension BaseDeviceDataManager: DeviceManagerDelegate {
     func deviceManager(
         _: LoopKit.DeviceManager,
         logEventForDeviceIdentifier deviceIdentifier: String?,
-        type _: LoopKit.DeviceLogEntryType,
+        type: LoopKit.DeviceLogEntryType,
         message: String,
         completion: ((Error?) -> Void)?
     ) {
-        debug(.deviceManager, "device Manager for \(String(describing: deviceIdentifier)) : \(message)")
+        debug(.deviceManager, "Device \(deviceIdentifier ?? "?") [\(type.rawValue)]: \(message)")
         completion?(nil)
     }
 }


### PR DESCRIPTION
## What

Two small logging improvements to `DeviceDataManager`, no functional changes:

1. **Include the `DeviceLogEntryType` in device log lines.** The delegate previously discarded the type, so send/receive/error/connection events were indistinguishable in the log files, wrapped in `Optional()` noise:

   ```
   device Manager for Optional("17B437F6") : 17b437f608030e01008181
   ```
   becomes
   ```
   Device 17B437F6 [send]: 17b437f608030e01008181
   Device 17B437F6 [connection]: Pod connected 9E7F7BB7-...
   Device 17B437F6 [error]: Pod pairing failed: ...
   ```

2. **Log device alerts when they are issued.** Pod faults, expiry/occlusion alarms, and CGM alerts arrive via `issueAlert` but were only stored for the alert-history UI — a pod that faulted while no command was in flight left *no trace at all* in the log files. Now:

   ```
   Device alert [Omnipod-Dash/...]: Critical Pod Fault 203 — Insulin delivery stopped. Change Pod now.
   ```

## Why

While investigating the community-wide fault-203 reports (LoopKit/Loop#2437) and slow pod pairing against uploaded field logs, we found that pod faults frequently never appear in the log files users share when reporting problems — the only fault evidence is undecoded response hex, and idle-pod alarms are invisible. These two lines make user-supplied logs actually diagnostic for the pod issues everyone is currently trying to pin down.

## Testing

- Verified the new line formats against existing field logs and log tooling.
- No behavior change beyond the two log statements; `completion` handling untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)