### PR TITLE
fix: in DeviceDataManager - receive events from `appCoordinator.heartbeat` on the `processQueue`

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -185,6 +185,7 @@ final class BaseDeviceDataManager: Injectable, DeviceDataManager {
         setupCGM()
 
         appCoordinator.heartbeat
+            .receive(on: processQueue)
             .sink { [weak self] _ in
                 self?.heartbeat(forceRecommendLoop: true)
             }


### PR DESCRIPTION
This bug was introduced (and went unnoticed) during the switch to the plugin architecture.

Without this fix, an event published into `appCoordinator.heartbeat` is "received" on the same thread it was published from.

 So when we publish an event into `heartbeat` from the main thread (long-press on home screen):
 * `DeviceDataManager` receives it on main thread as well
 * it calls `self.heartbeat()`
 * it runs the code inside `processQueue.safeSync`
 * inside it kicks off a pump update procedure
 * main thread is forced to wait for `processQueue.safeSync` to finish - which in turn has to wait for the response from the pump
 * if the pump takes too long to respond (timeout, connection issues) - iAPS becomes unresponsive/dead-locked for the iOS watchdog
 * iOS kills iAPS