### PR TITLE
bolus calculator - intialize early inside `state.init()` 

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -100,6 +100,14 @@ extension Bolus {
             return formatter
         }()
 
+        override init(resolver: Resolver) {
+            super.init(resolver: resolver)
+            let settings = appCoordinator.settings.value
+            // need to initialize these before subscribe()
+            useCalc = settings.useCalc
+            eventualBG = settings.eventualBG
+        }
+
         override func subscribe() async {
             let settings = appCoordinator.settings.value
             let preferences = appCoordinator.preferences.value

--- a/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/AlternativeBolusCalcRootView.swift
@@ -6,7 +6,6 @@ import Swinject
 extension Bolus {
     struct AlternativeBolusCalcRootView: BaseView {
         let resolver: Resolver
-        let waitForSuggestion: Bool
         let fetch: Bool
         @EnvironmentObject var state: StateModel
         @State private var showInfo = false
@@ -29,14 +28,12 @@ extension Bolus {
 
         init(
             resolver: Resolver,
-            waitForSuggestion: Bool,
             fetch: Bool,
 //            state: StateModel,
             meal: FetchedResults<Meals>,
             mealEntries: any View
         ) {
             self.resolver = resolver
-            self.waitForSuggestion = waitForSuggestion
             self.fetch = fetch
 //            self.state = state
             self.meal = meal
@@ -270,14 +267,6 @@ extension Bolus {
                 }
                 label: { Text("Cancel") }
             )
-            .onAppear {
-                state.viewActive()
-                state.waitForCarbs = fetch
-                state.waitForSuggestionInitial = waitForSuggestion
-                state.waitForSuggestion = waitForSuggestion
-                state.calculateInsulin()
-                state.start()
-            }
             .popup(isPresented: showInfo, alignment: .bottom, direction: .center, type: .default) {
                 illustrationView()
             }

--- a/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/BolusRootView.swift
@@ -46,34 +46,36 @@ extension Bolus {
         }
 
         var body: some View {
+            calculator
+                .onAppear {
+                    state.viewActive()
+                    state.waitForCarbs = fetch
+                    state.waitForSuggestionInitial = waitForSuggestion
+                    state.waitForSuggestion = waitForSuggestion
+                    state.start()
+                }
+                .onDisappear {
+                    state.notActive()
+                }
+        }
+
+        @ViewBuilder private var calculator: some View {
             if state.useCalc {
                 if state.eventualBG {
                     DefaultBolusCalcRootView(
                         resolver: resolver,
-                        waitForSuggestion: waitForSuggestion,
                         fetch: fetch,
                         meal: meal,
                         mealEntries: mealEntries
                     )
-                    .onDisappear {
-                        if state.eventualBG {
-                            state.notActive()
-                        }
-                    }
                     .environmentObject(state)
                 } else {
                     AlternativeBolusCalcRootView(
                         resolver: resolver,
-                        waitForSuggestion: waitForSuggestion,
                         fetch: fetch,
                         meal: meal,
                         mealEntries: mealEntries
                     )
-                    .onDisappear {
-                        if !state.eventualBG {
-                            state.notActive()
-                        }
-                    }
                     .environmentObject(state)
                 }
             } else {
@@ -125,11 +127,6 @@ extension Bolus {
                                 .frame(maxWidth: .infinity, alignment: .center)
                         }
                     }
-                }
-            }
-            .onDisappear {
-                if !state.useCalc {
-                    state.notActive()
                 }
             }
             .dynamicTypeSize(...DynamicTypeSize.xxLarge)

--- a/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
+++ b/FreeAPS/Sources/Modules/Bolus/View/DefaultBolusCalcRootView.swift
@@ -6,7 +6,6 @@ import Swinject
 extension Bolus {
     struct DefaultBolusCalcRootView: BaseView {
         let resolver: Resolver
-        let waitForSuggestion: Bool
         let fetch: Bool
 
         @EnvironmentObject var state: StateModel
@@ -53,14 +52,12 @@ extension Bolus {
 
         init(
             resolver: Resolver,
-            waitForSuggestion: Bool,
             fetch: Bool,
 //            state: StateModel,
             meal: FetchedResults<Meals>,
             mealEntries: any View
         ) {
             self.resolver = resolver
-            self.waitForSuggestion = waitForSuggestion
             self.fetch = fetch
 //            self.state = state
             self.meal = meal
@@ -214,13 +211,6 @@ extension Bolus {
             .interactiveDismissDisabled()
             .compactSectionSpacing()
             .dynamicTypeSize(...DynamicTypeSize.xxLarge)
-            .onAppear {
-                state.viewActive()
-                state.waitForCarbs = fetch
-                state.waitForSuggestionInitial = waitForSuggestion
-                state.waitForSuggestion = waitForSuggestion
-                state.start()
-            }
             .navigationTitle("Enact Bolus")
             .navigationBarTitleDisplayMode(.inline)
             .navigationBarItems(


### PR DESCRIPTION
After the concurrency refactoring, state model `subscribe()` is now async.
In the bolus calculator view this resulted in "double rendering" - first a default calculator view is rendered, then `subscribe()` reads the settings, updates the published vars, and the configured bolus calculator view is rendered.

This resulted in screen "flickering" and double `determineBasal` calls. 

This PR fixes this by reading the settings inside state model's `init()`. Also some minor refactoring in the view - `.onAppear` and `.onDisappear` are defined once, instead of being repeated for each calculator view.
