### PR TITLE
BloodGlucose refactoring

### DIFF
--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -480,15 +480,12 @@ final class BaseDeviceDataManager: DeviceDataManager, AppServiceSync {
                 let dateRoundedTo1Second = newGlucoseSample.date.truncatedToSecond
                 return BloodGlucose(
                     _id: UUID().uuidString,
-                    sgv: value,
+                    glucose: value,
                     direction: .init(trendType: newGlucoseSample.trend),
                     date: Decimal(Int(dateRoundedTo1Second.timeIntervalSince1970 * 1000)),
                     dateString: dateRoundedTo1Second,
-                    unfiltered: Decimal(value),
                     uncalibrated: Decimal(uncalibrated),
-                    filtered: nil,
                     noise: nil,
-                    glucose: value,
                     type: "sgv",
                     sessionStartDate: sessionStart,
                 )

--- a/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/OpenAPS.swift
@@ -314,13 +314,16 @@ actor OpenAPS: Sendable {
     }
 
     private func readGlucoseHistory() -> [GlucoseEntry0] {
+        // frequency-filtered is derived from the smoothed glucose
+        // with smoothing enabled it contains smoothed values,
+        // otherwise they it contains raw (unsmoothed) values
         // newest->oldest
         appCoordinator.glucoseFrequencyFiltered.value.map { g in
             GlucoseEntry0(
                 date: nil,
                 displayTime: nil,
                 dateString: g.dateString.ISO8601Format(),
-                sgv: g.sgv,
+                sgv: g.glucose,
                 glucose: g.glucose,
                 type: g.type,
                 noise: g.noise,

--- a/FreeAPS/Sources/Helpers/DataSync/NightscoutGlucoseSync.swift
+++ b/FreeAPS/Sources/Helpers/DataSync/NightscoutGlucoseSync.swift
@@ -7,8 +7,7 @@ struct GlucoseSyncID: Hashable, Sendable {
 
 struct GlucoseSyncSignature: Hashable, Sendable {
     let dateString: Date
-    let glucose: Int?
-    let sgv: Int?
+    let glucose: Int
     let direction: BloodGlucose.Direction?
     let type: String?
 }
@@ -24,7 +23,6 @@ extension BloodGlucose: SyncRecord {
         GlucoseSyncSignature(
             dateString: dateString.truncatedToSecond,
             glucose: glucose,
-            sgv: sgv,
             direction: direction,
             type: type
         )

--- a/FreeAPS/Sources/Models/BloodGlucose.swift
+++ b/FreeAPS/Sources/Models/BloodGlucose.swift
@@ -23,9 +23,7 @@ struct BloodGlucose: JSON, Identifiable, Hashable, Codable, Sendable {
         case direction
         case date
         case dateString
-        case unfiltered
         case uncalibrated
-        case filtered
         case noise
         case glucose
         case type
@@ -39,21 +37,21 @@ struct BloodGlucose: JSON, Identifiable, Hashable, Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         _id = try container.decode(String.self, forKey: ._id)
 
-        do {
-            sgv = try container.decode(Int.self, forKey: .sgv)
-        } catch {
-            // The nightscout API returns a double instead of an int
-            sgv = Int(try container.decode(Double.self, forKey: .sgv))
+        guard let value = Self.decodeValue(from: container, forKey: .glucose)
+            ?? Self.decodeValue(from: container, forKey: .sgv)
+        else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.glucose,
+                .init(codingPath: container.codingPath, debugDescription: "neither `glucose` nor `sgv` present")
+            )
         }
+        glucose = value
 
         direction = try container.decodeIfPresent(Direction.self, forKey: .direction)
         date = try container.decode(Decimal.self, forKey: .date)
         dateString = try container.decode(Date.self, forKey: .dateString)
-        unfiltered = try container.decodeIfPresent(Decimal.self, forKey: .unfiltered) ?? Decimal(sgv)
-        uncalibrated = try container.decodeIfPresent(Decimal.self, forKey: .uncalibrated) ?? Decimal(sgv)
-        filtered = try container.decodeIfPresent(Decimal.self, forKey: .filtered)
+        uncalibrated = try container.decodeIfPresent(Decimal.self, forKey: .uncalibrated) ?? Decimal(value)
         noise = try container.decodeIfPresent(Int.self, forKey: .noise)
-        glucose = try container.decodeIfPresent(Int.self, forKey: .glucose) ?? sgv
         type = try container.decodeIfPresent(String.self, forKey: .type)
         activationDate = try container.decodeIfPresent(Date.self, forKey: .activationDate)
         sessionStartDate = try container.decodeIfPresent(Date.self, forKey: .sessionStartDate)
@@ -61,17 +59,39 @@ struct BloodGlucose: JSON, Identifiable, Hashable, Codable, Sendable {
         device = try container.decodeIfPresent(String.self, forKey: .device)
     }
 
+    private static func decodeValue(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) -> Int? {
+        if let int = try? container.decodeIfPresent(Int.self, forKey: key) { return int }
+        if let double = try? container.decodeIfPresent(Double.self, forKey: key) { return Int(double) }
+        return nil
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(_id, forKey: ._id)
+        try container.encode(glucose, forKey: .glucose)
+        try container.encodeIfPresent(direction, forKey: .direction)
+        try container.encode(date, forKey: .date)
+        try container.encode(dateString, forKey: .dateString)
+        try container.encode(uncalibrated, forKey: .uncalibrated)
+        try container.encodeIfPresent(noise, forKey: .noise)
+        try container.encodeIfPresent(type, forKey: .type)
+        try container.encodeIfPresent(activationDate, forKey: .activationDate)
+        try container.encodeIfPresent(sessionStartDate, forKey: .sessionStartDate)
+        try container.encodeIfPresent(transmitterID, forKey: .transmitterID)
+        try container.encodeIfPresent(device, forKey: .device)
+    }
+
     init(
         _id: String = UUID().uuidString,
-        sgv: Int,
+        glucose: Int,
         direction: Direction? = nil,
         date: Decimal,
         dateString: Date,
-        unfiltered: Decimal,
-        uncalibrated: Decimal,
-        filtered: Decimal? = nil,
+        uncalibrated: Decimal? = nil,
         noise: Int? = nil,
-        glucose: Int,
         type: String? = nil,
         activationDate: Date? = nil,
         sessionStartDate: Date? = nil,
@@ -79,15 +99,12 @@ struct BloodGlucose: JSON, Identifiable, Hashable, Codable, Sendable {
         device: String? = nil,
     ) {
         self._id = _id
-        self.sgv = sgv
+        self.glucose = glucose
         self.direction = direction
         self.date = date
         self.dateString = dateString
-        self.unfiltered = unfiltered
-        self.uncalibrated = uncalibrated
-        self.filtered = filtered
+        self.uncalibrated = uncalibrated ?? Decimal(glucose)
         self.noise = noise
-        self.glucose = glucose
         self.type = type
         self.activationDate = activationDate
         self.sessionStartDate = sessionStartDate
@@ -100,18 +117,15 @@ struct BloodGlucose: JSON, Identifiable, Hashable, Codable, Sendable {
         _id
     }
 
-    // TODO: do we have too many fields for glucose? (sgv == glucose?)
-
-    var sgv: Int
+    /// one glucose value of this reading, mg/dL.
+    /// different streams in AppCoordinator contain different blood glucose values (raw vs smoothed)
+    var glucose: Int
     var direction: Direction?
     let date: Decimal
     let dateString: Date
-    /// raw, un-smoothed value
-    var unfiltered: Decimal
+    /// raw value before calibration was applied
     let uncalibrated: Decimal
-    let filtered: Decimal?
     let noise: Int?
-    var glucose: Int
     let type: String?
     // TODO: unused, always nil?
     var activationDate: Date? = nil
@@ -120,7 +134,7 @@ struct BloodGlucose: JSON, Identifiable, Hashable, Codable, Sendable {
     var transmitterID: String? = nil
     var device: String? = nil
 
-    var isStateValid: Bool { sgv >= 39 && noise ?? 1 != 4 }
+    var isStateValid: Bool { glucose >= 39 && noise ?? 1 != 4 }
 
     static func == (lhs: BloodGlucose, rhs: BloodGlucose) -> Bool {
         lhs.dateString == rhs.dateString
@@ -171,7 +185,6 @@ extension BloodGlucose: SavitzkyGolaySmoothable {
         }
         set {
             glucose = Int(newValue)
-            sgv = Int(newValue)
         }
     }
 }
@@ -181,7 +194,6 @@ extension BloodGlucose {
         guard let id = entry.id else { return nil }
         let direction = (entry.trend?.direction).flatMap { BloodGlucose.Direction(rawValue: $0) }
         let glucose = Int(entry.glucose.rounded())
-        let glucoseDecimal = Decimal(entry.glucose.rounded())
         let type: String?
         switch entry.glucoseType {
         case .sensor: type = "sgv"
@@ -189,15 +201,11 @@ extension BloodGlucose {
         }
         return BloodGlucose(
             _id: id,
-            sgv: glucose,
+            glucose: glucose,
             direction: direction,
             date: Decimal(entry.date.timeIntervalSince1970 * 1000),
             dateString: entry.date,
-            unfiltered: glucoseDecimal,
-            uncalibrated: glucoseDecimal,
-            filtered: nil,
             noise: nil,
-            glucose: glucose,
             type: type,
             activationDate: nil,
             sessionStartDate: nil,
@@ -207,7 +215,7 @@ extension BloodGlucose {
     }
 
     var toNightscoutEntry: GlucoseEntry? {
-        let glucose = Double(unfiltered)
+        let glucose = Double(self.glucose)
 
         let glucoseType: GlucoseEntry.GlucoseType
         let isCalibration: Bool

--- a/FreeAPS/Sources/Models/ChartModel.swift
+++ b/FreeAPS/Sources/Models/ChartModel.swift
@@ -2,7 +2,10 @@ import Foundation
 
 class ChartModel: ObservableObject {
     @Published var suggestion: Suggestion?
+    /// smoothed values when smoothing is enabled, raw ones otherwise
     @Published var glucose: [BloodGlucose]
+    /// raw readings, drawn on top of `glucose` when smoothing is on
+    @Published var rawGlucose: [BloodGlucose]
     @Published var activity: [IOBEntryShort]
     @Published var cob: [IOBData] // we already have IOBData in storage and it contains COB values
     @Published var isManual: [BloodGlucose]
@@ -55,6 +58,7 @@ class ChartModel: ObservableObject {
     init(
         suggestion: Suggestion?,
         glucose: [BloodGlucose],
+        rawGlucose: [BloodGlucose],
         activity: [IOBEntryShort],
         cob: [IOBData],
         isManual: [BloodGlucose],
@@ -105,6 +109,7 @@ class ChartModel: ObservableObject {
     ) {
         self.suggestion = suggestion
         self.glucose = glucose
+        self.rawGlucose = rawGlucose
         self.activity = activity
         self.cob = cob
         self.isManual = isManual

--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -406,12 +406,9 @@ extension Bolus {
 
                 let saveToJSON = BloodGlucose(
                     _id: id,
-                    sgv: Int(glucose),
+                    glucose: Int(glucose),
                     date: Decimal(now.timeIntervalSince1970) * 1000,
                     dateString: now,
-                    unfiltered: glucose,
-                    uncalibrated: glucose,
-                    glucose: Int(glucose),
                     type: GlucoseType.manual.rawValue
                 )
                 _ = await glucoseStorage.storeGlucose([saveToJSON])

--- a/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
+++ b/FreeAPS/Sources/Modules/DataTable/DataTableStateModel.swift
@@ -261,12 +261,9 @@ extension DataTable {
 
                 let saveToJSON = BloodGlucose(
                     _id: id,
-                    sgv: Int(glucose),
+                    glucose: Int(glucose),
                     date: Decimal(now.timeIntervalSince1970) * 1000,
                     dateString: now,
-                    unfiltered: glucose,
-                    uncalibrated: glucose,
-                    glucose: Int(glucose),
                     type: GlucoseType.manual.rawValue
                 )
                 _ = await glucoseStorage.storeGlucose([saveToJSON])

--- a/FreeAPS/Sources/Modules/Home/HomeDataFlow.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeDataFlow.swift
@@ -8,6 +8,7 @@ enum Home {
 protocol HomeProvider: Provider {
     func heartbeatNow() async
     func smoothedGlucose(hours: Int) async -> [BloodGlucose]
+    func rawGlucose(hours: Int) async -> [BloodGlucose]
     func carbs(hours: Int) -> [CarbsEntry]
     func announcement(_ hours: Int) async -> [Announcement]
 //    func overrides() async -> [OverrideSnapshot]

--- a/FreeAPS/Sources/Modules/Home/HomeProvider.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeProvider.swift
@@ -68,6 +68,14 @@ extension Home {
             }
         }
 
+        func rawGlucose(hours: Int) -> [BloodGlucose] {
+            let now = Date()
+            // reverse to oldest->newest order
+            return appCoordinator.glucoseRaw.value.reversed().filter {
+                $0.dateString.addingTimeInterval(.hours(hours)) > now
+            }
+        }
+
         func manualGlucose(hours: Int) -> [BloodGlucose] {
             let now = Date()
             // reverse to oldest->newest order

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -84,6 +84,7 @@ extension Home {
         var data = ChartModel(
             suggestion: nil,
             glucose: [],
+            rawGlucose: [],
             activity: [],
             cob: [],
             isManual: [],
@@ -180,9 +181,11 @@ extension Home {
                 await me.cgmCensorDaysUpdated(sensorDays)
             }
 
-            observeUI(appCoordinator.glucoseRaw) { me, glucose in
-                // TODO: use the provided value inside the function, currently it re-reads from the storage
-                await me.glucoseDidUpdate(glucose)
+            observeUI(
+                appCoordinator.glucoseSmoothed,
+                map: { $0.map { [$0.dateString.timeIntervalSince1970, Double($0.glucose)] } }
+            ) { me, _ in
+                await me.glucoseDidUpdate()
             }
 
             observeUI(appCoordinator.suggested) { me, suggestion in
@@ -359,17 +362,17 @@ extension Home {
         }
 
         private func setupGlucose() async {
+            let rawGlucose = provider.rawGlucose(hours: filteredHours)
+
             data.isManual = provider.manualGlucose(hours: filteredHours)
+            // the chart draws the smoothed series + raw values on top
             data.glucose = provider.smoothedGlucose(hours: filteredHours)
+            data.rawGlucose = rawGlucose
             readings = await coreDataStorage.fetchGlucose(interval: DateFilter.today.startDate)
-            recentGlucose = data.glucose.last
-            if data.glucose.count >= 2 {
-                glucoseDelta =
-                    NSDecimalNumber(
-                        decimal:
-                        (recentGlucose?.unfiltered ?? 0) -
-                            data.glucose[data.glucose.count - 2].unfiltered
-                    ).intValue
+
+            recentGlucose = rawGlucose.last
+            if rawGlucose.count >= 2 {
+                glucoseDelta = rawGlucose[rawGlucose.count - 1].glucose - rawGlucose[rawGlucose.count - 2].glucose
             } else {
                 glucoseDelta = nil
             }
@@ -667,7 +670,7 @@ extension Home {
 }
 
 extension Home.StateModel {
-    private func glucoseDidUpdate(_: [BloodGlucose]) async {
+    private func glucoseDidUpdate() async {
         await setupGlucose()
         setupLoopStatsBackground()
     }

--- a/FreeAPS/Sources/Modules/Home/View/Chart/CalculatedGeometries.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/CalculatedGeometries.swift
@@ -99,6 +99,8 @@ private final class GeometriesBuilder {
     private let fullSize: CGSize
     private let data: ChartModel
     private let glucose: [BloodGlucose]
+    /// only drawn while smoothing is on
+    private let rawGlucose: [BloodGlucose]
     private let boluses: [PumpHistoryEvent]
     private let realCarbs: [CarbsEntry]
     private let fpus: [CarbsEntry]
@@ -138,6 +140,9 @@ private final class GeometriesBuilder {
 
         // these need to be sorted by date ascending (for the incremental matching against glucose values)
         glucose = data.glucose.sorted {
+            $0.dateString < $1.dateString
+        }
+        rawGlucose = data.rawGlucose.sorted {
             $0.dateString < $1.dateString
         }
         boluses = data.boluses.sorted {
@@ -658,8 +663,8 @@ private final class GeometriesBuilder {
     }
 
     private func calculateUnSmoothedGlucoseDots() -> [CGRect] {
-        glucose.map { value -> CGRect in
-            let position = unSmoothedGlucoseToCoordinate(value)
+        rawGlucose.map { value -> CGRect in
+            let position = glucoseToCoordinate(value)
             return CGRect(x: position.x - 2, y: position.y - 2, width: 4, height: 4)
         }
     }
@@ -1096,14 +1101,6 @@ private final class GeometriesBuilder {
     private func glucoseToCoordinate(_ glucoseEntry: BloodGlucose) -> CGPoint {
         let x = timeToXCoordinate(glucoseEntry.dateString.timeIntervalSince1970)
         let y = glucoseToYCoordinate(glucoseEntry.glucose)
-
-        return CGPoint(x: x, y: y)
-    }
-
-    private func unSmoothedGlucoseToCoordinate(_ glucoseEntry: BloodGlucose) -> CGPoint {
-        let x = timeToXCoordinate(glucoseEntry.dateString.timeIntervalSince1970)
-        let glucoseValue: Decimal = glucoseEntry.unfiltered
-        let y = glucoseToYCoordinate(Int(glucoseValue))
 
         return CGPoint(x: x, y: y)
     }

--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -185,6 +185,16 @@ struct MainChartView: View {
             .eraseToAnyPublisher()
     }
 
+    private func ping<T, Projection: Equatable>(
+        _ p: Published<T>.Publisher,
+        by projection: @escaping (T) -> Projection
+    ) -> AnyPublisher<Void, Never> {
+        p.map(projection)
+            .removeDuplicates()
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
     private func subscribeToUpdates() {
         guard updatesCancellable == nil else { return }
         let debouncedPublishers: [AnyPublisher<Void, Never>] = [
@@ -198,7 +208,9 @@ struct MainChartView: View {
             ping(data.$maxBasal),
             ping(data.$basalProfile),
             ping(data.$autotunedBasalProfile),
-            ping(data.$glucose),
+            ping(data.$glucose, by: { $0.map { [$0.dateString.timeIntervalSince1970, Double($0.glucose)] } }),
+            ping(data.$rawGlucose, by: { $0.map { [$0.dateString.timeIntervalSince1970, Double($0.glucose)] } }),
+            ping(data.$smooth),
             ping(data.$activity),
             ping(data.$cob),
             ping(data.$isManual),

--- a/FreeAPS/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
@@ -113,9 +113,10 @@ struct CurrentGlucoseView: View {
                 }
                 VStack(spacing: 15) {
                     let formatter = recent.type == GlucoseType.manual.rawValue ? manualGlucoseFormatter : glucoseFormatter
+                    let value = Decimal(recent.glucose)
                     let string =
                         formatter
-                            .string(from: Double(units == .mmolL ? recent.unfiltered.asMmolL : recent.unfiltered) as NSNumber) ??
+                            .string(from: Double(units == .mmolL ? value.asMmolL : value) as NSNumber) ??
                             ""
 
                     glucoseText(string).asAny()

--- a/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
+++ b/FreeAPS/Sources/Modules/NightscoutConfig/NightscoutConfigStateModel.swift
@@ -402,15 +402,11 @@ extension NightscoutConfig {
                     }
                     return BloodGlucose(
                         _id: id,
-                        sgv: Int(reading.glucose),
+                        glucose: Int(reading.glucose),
                         direction: nil,
                         date: Decimal(Int(date.timeIntervalSince1970 * 1000)),
                         dateString: date,
-                        unfiltered: Decimal(reading.glucose),
-                        uncalibrated: Decimal(reading.glucose),
-                        filtered: nil,
                         noise: nil,
-                        glucose: Int(reading.glucose),
                         type: "sgv",
                         activationDate: nil,
                         sessionStartDate: nil,

--- a/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
+++ b/FreeAPS/Sources/Services/LiveActivity/LiveActivityBridge.swift
@@ -92,8 +92,7 @@ extension LiveActivityAttributes.ContentState {
         let preparedReadings: LiveActivityAttributes.ValueSeries? = {
             guard let readings else { return nil }
             let validReadings = readings.compactMap { reading -> (Date, Int16)? in
-                let glucose = reading.sgv
-                return (reading.dateString, Int16(glucose))
+                (reading.dateString, Int16(reading.glucose))
             }
 
             let dates = validReadings.map(\.0)


### PR DESCRIPTION
- `BloodGlucose`: `sgv`, `unfiltered` and `filtered` removed; now `glucose` is the single value
- smoothed and raw glucose history were already available in the AppCoordinator - and the rest of the app already uses the correct one as needed
- main chart now reads both histories to render raw/smoothed dots

(since we are not using `BloodGlucose` to interact with Nightscout directly, it is safe to remove those fields)