### PR TITLE
Watchdog timeout for WebView JS calls — a suspended WebContent process can no longer wedge the loop

### DIFF
--- a/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
@@ -118,6 +118,13 @@ import WebKit
         }
     }
 
+    /// How long to wait for the JS bridge to reply before declaring the call wedged.
+    /// Healthy calls complete in 1–2 s; the margin covers autotune-sized work on old
+    /// hardware. Without this, a suspended WebContent process leaves the loop hanging
+    /// forever — field logs show silent multi-hour gaps that resolve the moment the
+    /// app is foregrounded (the reply arrives when iOS resumes the WebContent process).
+    private let watchdogTimeout: TimeInterval = 90
+
     private func evaluateFunction(body: String, attempts: Int = 0) async throws -> RawJSON {
         let maxAttempts = 2
         let requestId = UUID().uuidString
@@ -145,12 +152,44 @@ import WebKit
         do {
             try await webView.evaluateJavaScript(script)
 
-            for try await value in stream {
-                return value
+            // Race the bridge reply against a watchdog. If the WebContent process is
+            // suspended (or silently killed) mid-call, the reply never comes and never
+            // errors — the timeout is the only way the loop learns something is wrong.
+            let timeout = watchdogTimeout
+            return try await withThrowingTaskGroup(of: RawJSON.self) { group in
+                group.addTask {
+                    for try await value in stream {
+                        return value
+                    }
+                    throw NSError(
+                        domain: "WebViewScriptExecutor",
+                        code: 2,
+                        userInfo: [NSLocalizedDescriptionKey: "No result emitted"]
+                    )
+                }
+                group.addTask {
+                    try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                    throw NSError(
+                        domain: "WebViewScriptExecutor",
+                        code: 408,
+                        userInfo: [
+                            NSLocalizedDescriptionKey: "JS call did not reply within \(Int(timeout)) s — WebContent process suspended or wedged"
+                        ]
+                    )
+                }
+                guard let first = try await group.next() else {
+                    throw NSError(
+                        domain: "WebViewScriptExecutor",
+                        code: 2,
+                        userInfo: [NSLocalizedDescriptionKey: "No result emitted"]
+                    )
+                }
+                group.cancelAll()
+                return first
             }
-            throw NSError(domain: "WebViewScriptExecutor", code: 2, userInfo: [NSLocalizedDescriptionKey: "No result emitted"])
         } catch {
-            print("Javascript function (\(requestId)) attempt \(attempts + 1) failed with error: \(error)")
+            // warning() (not print) so wedge recoveries show up in the device log
+            warning(.openAPS, "Javascript function (\(requestId)) attempt \(attempts + 1) failed: \(error.localizedDescription)")
             continuationStreams.removeValue(forKey: requestId)
             if attempts < maxAttempts {
                 webView = createWebView()


### PR DESCRIPTION
While looking into the \"long gaps between Start determine basal and SUGGESTED\" question, I scanned two weeks of logs uploaded to open-iaps.app (83 devices, ~266k loop cycles). Full write-up: https://open-iaps.app/docs/loop-stalls

The biggest failure mode (75% of the 289 wedges found): the app is alive and logging, but the oref pipeline is stuck inside a JS stage. `evaluateFunction` awaits the jsBridge reply with no timeout — when iOS suspends the WKWebView's WebContent process mid-call, the reply never arrives and never errors, so the cycle hangs silently. The two longest wedges (5.2 h and 1.8 h) completed the *moment* the user foregrounded the app, i.e. exactly when iOS resumed the WebContent process.

This PR races the bridge reply against a 90 s watchdog. On timeout, the existing retry path takes over: rebuild the WebView (fresh WebContent process) and retry, so a wedge now costs about a minute instead of hours. The failure log also moves from `print` to `warning(.openAPS, …)` so recoveries are visible in uploaded device logs.

90 s is deliberately generous — healthy calls finish in 1–2 s, and the margin covers autotune-sized work on older hardware (fleet data: only 0.1% of cycles legitimately exceed 60 s).

Related PRs from the same analysis (all independent, all touch this area, happy to rebase whichever merges last): WebContent-terminate recovery, WKUserScript injection, no-loop alert escalation.