### PR TITLE
Recover from WebContent-process termination instead of hanging the loop

### DIFF
--- a/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
@@ -43,6 +43,7 @@ import WebKit
         config.userContentController = contentController
 
         let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
 
         injectConsoleLogHandler(webView: webView)
         loadScripts(webView: webView)
@@ -194,5 +195,29 @@ import WebKit
                 ))
             }
         }
+    }
+}
+
+extension WebViewScriptExecutor: WKNavigationDelegate {
+    /// The WebContent (JS) process died — jetsam under memory pressure, a crash, or iOS
+    /// reclaiming it in the background. Every in-flight call would otherwise wait forever
+    /// for a reply that can no longer arrive, and the injected oref bundles are gone, so
+    /// fail all pending calls now (their retry path rebuilds and retries) and replace the
+    /// WebView with a fresh one.
+    func webViewWebContentProcessDidTerminate(_: WKWebView) {
+        let pending = continuationStreams
+        continuationStreams.removeAll()
+        warning(
+            .openAPS,
+            "WebContent process terminated by iOS — failing \(pending.count) in-flight JS call(s) and rebuilding the WebView"
+        )
+        for (_, continuation) in pending {
+            continuation.finish(throwing: NSError(
+                domain: "WebViewScriptExecutor",
+                code: 510,
+                userInfo: [NSLocalizedDescriptionKey: "WebContent process terminated"]
+            ))
+        }
+        webView = createWebView()
     }
 }


### PR DESCRIPTION
Companion to #2003, from the same fleet-log analysis (https://open-iaps.app/docs/loop-stalls).

The script executor sets no navigation delegate, so when iOS kills the WebView's WebContent process (jetsam under memory pressure — the wedge rate in our data tracks hardware age, iPhone 11/13-era phones being the worst), nothing notices: in-flight JS calls wait forever for a reply that can't come, and the injected oref bundles are gone.

This PR implements `webViewWebContentProcessDidTerminate`: log a warning, fail every pending call immediately (their existing retry path rebuilds the WebView and retries), and replace the WebView with a fresh one.

Independent of #2003 but they complement each other: this handles the case where WebKit *tells* us the process died; the watchdog handles the case where it's silently suspended and nothing is ever delivered.