### PR TITLE
Keep the 'iAPS not active' alert firing until looping resumes, and make it Time Sensitive

### DIFF
--- a/FreeAPS/Resources/FreeAPS.entitlements
+++ b/FreeAPS/Resources/FreeAPS.entitlements
@@ -12,6 +12,8 @@
 	<array>
 		<string>TAG</string>
 	</array>
+	<key>com.apple.developer.usernotifications.time-sensitive</key>
+	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>$(APP_GROUP_ID)</string>

--- a/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
+++ b/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
@@ -35,6 +35,7 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
         case carbsRequiredNotification = "FreeAPS.carbsRequiredNotification"
         case noLoopFirstNotification = "FreeAPS.noLoopFirstNotification"
         case noLoopSecondNotification = "FreeAPS.noLoopSecondNotification"
+        case noLoopRepeatingNotification = "FreeAPS.noLoopRepeatingNotification"
         case bolusFailedNotification = "FreeAPS.bolusFailedNotification"
         case pumpNotification = "FreeAPS.pumpNotification"
     }
@@ -141,18 +142,37 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
             let firstInterval = 20 // min
             let secondInterval = 40 // min
 
+            let repeatingInterval = 60 // min
+
             let firstContent = UNMutableNotificationContent()
             firstContent.title = title
             firstContent.body = String(format: body, firstInterval)
             if sound { firstContent.sound = .default }
+            // A stopped loop is exactly what Time Sensitive exists for: let the alert
+            // break through Focus / scheduled summaries instead of sitting silently.
+            firstContent.interruptionLevel = .timeSensitive
 
             let secondContent = UNMutableNotificationContent()
             secondContent.title = title
             secondContent.body = String(format: body, secondInterval)
             if sound { secondContent.sound = .default }
+            secondContent.interruptionLevel = .timeSensitive
+
+            // Silence used to end after the 40 min notification — a loop that stays
+            // wedged for hours never re-arms the chain, so nothing fired again. Keep
+            // reminding every hour until looping resumes (which cancels and re-arms).
+            let repeatingContent = UNMutableNotificationContent()
+            repeatingContent.title = title
+            repeatingContent.body = String(format: body, repeatingInterval)
+            if sound { repeatingContent.sound = .default }
+            repeatingContent.interruptionLevel = .timeSensitive
 
             let firstTrigger = UNTimeIntervalNotificationTrigger(timeInterval: 60 * TimeInterval(firstInterval), repeats: false)
             let secondTrigger = UNTimeIntervalNotificationTrigger(timeInterval: 60 * TimeInterval(secondInterval), repeats: false)
+            let repeatingTrigger = UNTimeIntervalNotificationTrigger(
+                timeInterval: 60 * TimeInterval(repeatingInterval),
+                repeats: true
+            )
 
             self.addRequest(
                 identifier: .noLoopFirstNotification,
@@ -165,6 +185,12 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
                 content: secondContent,
                 deleteOld: true,
                 trigger: secondTrigger
+            )
+            self.addRequest(
+                identifier: .noLoopRepeatingNotification,
+                content: repeatingContent,
+                deleteOld: true,
+                trigger: repeatingTrigger
             )
         }
     }


### PR DESCRIPTION
Last piece of the loop-stall work (#2003, #2004, #2005; analysis: https://open-iaps.app/docs/loop-stalls).

The missing-loop dead-man's-switch works, but it arms exactly two notifications (20 and 40 min) and then goes quiet — a loop that stays wedged never re-arms the chain, so a multi-hour gap means two banner pings at the start and silence for the rest. Our fleet data has a 5.4 h wedge overnight; two quiet banners at 23:20 and 23:40 are easy to sleep through, and without an interruption level a Sleep Focus swallows them entirely.

Two changes, reusing the existing localized strings (no new keys for Crowdin):

- a third, repeating notification every 60 min, cancelled/re-armed by each loop like the existing two, so the alerts never stop before the looping resumes;
- all three marked `.timeSensitive` (+ the matching entitlement) so they break through Focus modes — a stopped loop is the textbook case for it.

**Review note:** the entitlements addition needs the Time Sensitive Notifications capability on the App ID. Xcode automatic signing handles that by itself; if the fastlane pipeline manages the App ID explicitly it may need the capability enabled there. If that causes friction for the community build, I'm happy to drop the entitlement hunk — the repeating third notification is worth having on its own.