### PR TITLE
[dev] Recover from WebContent-process termination/suspension instead of hanging the loop

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -307,6 +307,7 @@
 		38E98A2725F52C9300C0CED0 /* CollectionIssueReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2025F52C9300C0CED0 /* CollectionIssueReporter.swift */; };
 		38E98A2925F52C9300C0CED0 /* Error+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2225F52C9300C0CED0 /* Error+Extensions.swift */; };
 		38E98A2D25F52DC400C0CED0 /* NSLocking+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */; };
+		F2A11C1230200B0100EF9230 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A11C1130200B0100EF9230 /* Timeout.swift */; };
 		38E98A3025F52FF700C0CED0 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2F25F52FF700C0CED0 /* Config.swift */; };
 		38E98A3725F5509500C0CED0 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A3625F5509500C0CED0 /* String+Extensions.swift */; };
 		38EA05DA261F6E7C0064E39B /* SimpleLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EA05D9261F6E7C0064E39B /* SimpleLogReporter.swift */; };
@@ -1001,6 +1002,7 @@
 		38E98A2025F52C9300C0CED0 /* CollectionIssueReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionIssueReporter.swift; sourceTree = "<group>"; };
 		38E98A2225F52C9300C0CED0 /* Error+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Error+Extensions.swift"; sourceTree = "<group>"; };
 		38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLocking+Extensions.swift"; sourceTree = "<group>"; };
+		F2A11C1130200B0100EF9230 /* Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timeout.swift; sourceTree = "<group>"; };
 		38E98A2F25F52FF700C0CED0 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		38E98A3625F5509500C0CED0 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		38EA05D9261F6E7C0064E39B /* SimpleLogReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleLogReporter.swift; sourceTree = "<group>"; };
@@ -2222,6 +2224,7 @@
 				38A00B2225FC2B55006BC0B0 /* LRUCache.swift */,
 				38FCF3D525E8FDF40078B0D1 /* MD5.swift */,
 				38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */,
+				F2A11C1130200B0100EF9230 /* Timeout.swift */,
 				38C4D33925E9A1ED00D30B77 /* NSObject+AssociatedValues.swift */,
 				3811DE5725C9D4D500A708ED /* ProgressBar.swift */,
 				3811DE5525C9D4D500A708ED /* Publisher.swift */,
@@ -3772,6 +3775,7 @@
 				041D1E995A6AE92E9289DC49 /* BolusDataFlow.swift in Sources */,
 				23888883D4EA091C88480FF2 /* BolusProvider.swift in Sources */,
 				38E98A2D25F52DC400C0CED0 /* NSLocking+Extensions.swift in Sources */,
+				F2A11C1230200B0100EF9230 /* Timeout.swift in Sources */,
 				19C3C72F2E97AE520000BE4D /* SearchResultsView.swift in Sources */,
 				19C3C7302E97AE520000BE4D /* FoodSearchStateModel.swift in Sources */,
 				19C3C7312E97AE520000BE4D /* BarcodeScannerService.swift in Sources */,

--- a/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
@@ -2,6 +2,9 @@ import UIKit
 import WebKit
 
 @MainActor class WebViewScriptExecutor: NSObject, WKScriptMessageHandler {
+    static let defaultTimeout: Duration = .seconds(30)
+    private static let maxAttachAttempts = 10
+
     private var webView: WKWebView!
     private var continuationStreams = [String: AsyncThrowingStream<RawJSON, Error>.Continuation]()
     private var scripts = [
@@ -35,38 +38,32 @@ import WebKit
         ensureAttachedToWindow()
     }
 
-    deinit {
-        let view = self.webView
-        DispatchQueue.main.async {
-            view?.removeFromSuperview()
+    private func ensureAttachedToWindow(attempt: Int = 0) {
+        guard let webView, webView.superview == nil else { return }
+
+        guard let window = Self.hostWindow() else {
+            guard attempt < Self.maxAttachAttempts else {
+                debug(.openAPS, "WebView has no window to attach to; retrying on next JS call")
+                return
+            }
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1))
+                self.ensureAttachedToWindow(attempt: attempt + 1)
+            }
+            return
         }
+
+        webView.isUserInteractionEnabled = false
+        window.addSubview(webView)
+        debug(.openAPS, "WebView attached to window for background protection")
     }
 
-    private func ensureAttachedToWindow() {
-        guard webView.superview == nil else { return }
-
-        var window: UIWindow?
-        if let windowScene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        {
-            window = windowScene.windows.first(where: { $0.isKeyWindow }) ?? windowScene.windows.first
-        }
-        if window == nil {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
-                window = windowScene.windows.first(where: { $0.isKeyWindow }) ?? windowScene.windows.first
-            }
-        }
-
-        if let window = window {
-            window.addSubview(webView)
-            debug(.openAPS, "WebView successfully attached to window for background protection")
-        } else {
-            // If we still can't find it, we can schedule a retry
-            DispatchQueue.main.async { [weak self] in
-                guard let self = self else { return }
-                self.ensureAttachedToWindow()
-            }
-        }
+    private static func hostWindow() -> UIWindow? {
+        let scenes = UIApplication.shared.connectedScenes
+        let windowScene = scenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+            ?? scenes.compactMap { $0 as? UIWindowScene }.first
+        guard let windowScene else { return nil }
+        return windowScene.windows.first(where: \.isKeyWindow) ?? windowScene.windows.first
     }
 
     private func createWebView() -> WKWebView {
@@ -119,7 +116,11 @@ import WebKit
         webView.evaluateJavaScript(script.body)
     }
 
-    func call(name: String, with arguments: [JSON], withBody body: String = "") async -> RawJSON {
+    func call(
+        name: String,
+        with arguments: [JSON],
+        withBody body: String = ""
+    ) async -> RawJSON {
         if let script = script(for: name) {
             return await callFunctionAsync(function: script, with: arguments, withBody: body)
         } else {
@@ -136,7 +137,11 @@ import WebKit
         await callFunctionAsync(function: function.variable, with: arguments, withBody: body)
     }
 
-    private func callFunctionAsync(function: String, with arguments: [JSON], withBody body: String = "") async -> RawJSON {
+    private func callFunctionAsync(
+        function: String,
+        with arguments: [JSON],
+        withBody body: String = ""
+    ) async -> RawJSON {
         let joined = arguments.map(\.rawJSON).joined(separator: ",")
 
         let script = """
@@ -146,15 +151,19 @@ import WebKit
         """
 
         do {
-            let result = try await evaluateFunction(body: script)
+            let result = try await evaluateFunction(name: function, body: script)
             return result
         } catch {
-            print(error)
+            warning(.openAPS, "Javascript function (\(function)) failed: \(error.localizedDescription)")
             return ""
         }
     }
 
-    private func evaluateFunction(body: String, attempts: Int = 0) async throws -> RawJSON {
+    private func evaluateFunction(
+        name: String,
+        body: String,
+        attempts: Int = 0
+    ) async throws -> RawJSON {
         ensureAttachedToWindow()
 
         let maxAttempts = 2
@@ -181,20 +190,30 @@ import WebKit
         }
 
         do {
-            try await webView.evaluateJavaScript(script)
+            return try await withTimeout("js.\(name)", Self.defaultTimeout) { [self] in
+                try await Task { @MainActor in
+                    try await webView.evaluateJavaScript(script)
 
-            for try await value in stream {
-                return value
+                    for try await value in stream {
+                        return value
+                    }
+                    throw NSError(
+                        domain: "WebViewScriptExecutor", code: 2,
+                        userInfo: [NSLocalizedDescriptionKey: "No result emitted"]
+                    )
+                }.value
             }
-            throw NSError(domain: "WebViewScriptExecutor", code: 2, userInfo: [NSLocalizedDescriptionKey: "No result emitted"])
         } catch {
-            print("Javascript function (\(requestId)) attempt \(attempts + 1) failed with error: \(error)")
+            warning(
+                .openAPS,
+                "Javascript function (\(name), \(requestId)) attempt \(attempts + 1) failed with error: \(error)"
+            )
             continuationStreams.removeValue(forKey: requestId)
             if attempts < maxAttempts {
                 webView?.removeFromSuperview()
                 webView = createWebView()
                 ensureAttachedToWindow()
-                return try await evaluateFunction(body: body, attempts: attempts + 1)
+                return try await evaluateFunction(name: name, body: body, attempts: attempts + 1)
             } else {
                 throw error
             }

--- a/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
@@ -4,9 +4,15 @@ import WebKit
 @MainActor class WebViewScriptExecutor: NSObject, WKScriptMessageHandler {
     static let defaultTimeout: Duration = .seconds(30)
     private static let maxAttachAttempts = 10
+    private static let readyMessageID = "__iaps_ready__"
 
     private var webView: WKWebView!
     private var continuationStreams = [String: AsyncThrowingStream<RawJSON, Error>.Continuation]()
+
+    /// True once the current WebView has loaded its document and every user script has run.
+    private var isReady = false
+    private var readyWaiters = [CheckedContinuation<Void, Error>]()
+    private var webViewGeneration = 0
     private var scripts = [
         FunctionScript(name: OpenAPS.Bundle.autosens, function: "freeaps_autosens"),
         FunctionScript(name: OpenAPS.Bundle.autotuneCore, function: "freeaps_autotuneCore"),
@@ -34,8 +40,38 @@ import WebKit
     init(frame _: CGRect = .zero) {
         super.init()
 
+        replaceWebView()
+    }
+
+    /// Tear down the current WebView and stand up a fresh one.
+    /// Anything waiting on the is failed rather.
+    private func replaceWebView() {
+        webView?.removeFromSuperview()
+        failReadyWaiters(
+            NSError(
+                domain: "WebViewScriptExecutor", code: 3,
+                userInfo: [NSLocalizedDescriptionKey: "WebView replaced before it became ready"]
+            )
+        )
+        isReady = false
+        webViewGeneration &+= 1
         webView = createWebView()
         ensureAttachedToWindow()
+    }
+
+    private func failReadyWaiters(_ error: Error) {
+        let waiters = readyWaiters
+        readyWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume(throwing: error)
+        }
+    }
+
+    private func awaitReady() async throws {
+        if isReady { return }
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            readyWaiters.append(continuation)
+        }
     }
 
     private func ensureAttachedToWindow(attempt: Int = 0) {
@@ -72,18 +108,37 @@ import WebKit
         contentController.add(self, name: "jsBridge")
         contentController.add(self, name: "scriptError")
 
+        // Register the oref bundles as user scripts.
+        // WebKit re-applies user scripts on every document load.
+        for source in userScriptSources() {
+            contentController.addUserScript(WKUserScript(
+                source: source,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            ))
+        }
+        contentController.addUserScript(WKUserScript(
+            source: """
+            window.webkit.messageHandlers.jsBridge.postMessage({ id: "\(Self.readyMessageID)", value: "" });
+            """,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        ))
+
         let config = WKWebViewConfiguration()
         config.userContentController = contentController
 
         let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
 
-        injectConsoleLogHandler(webView: webView)
-        loadScripts(webView: webView)
+        // User scripts only run as part of a document load.
+        // This is also what makes webViewWebContentProcessDidTerminate reliable.
+        webView.loadHTMLString("<html><body></body></html>", baseURL: nil)
 
         return webView
     }
 
-    private func injectConsoleLogHandler(webView: WKWebView) {
+    private func userScriptSources() -> [String] {
         let consoleScript = """
         var _consoleLog = function (message) {
             window.webkit.messageHandlers.consoleLog.postMessage(message.join(" "));
@@ -93,27 +148,11 @@ import WebKit
         });
 
         """
-        webView.evaluateJavaScript(consoleScript, completionHandler: nil)
+        return [consoleScript] + scripts.map(\.body) + [Script(name: OpenAPS.Prepare.log).body]
     }
 
     private func script(for name: String) -> FunctionScript? {
         scripts.filter { $0.name == name }.first
-    }
-
-    private func loadScripts(webView: WKWebView) {
-        for script in scripts {
-            includeScript(webView: webView, script: script)
-        }
-
-        includeScript(webView: webView, script: Script(name: OpenAPS.Prepare.log))
-    }
-
-    private func includeScript(webView: WKWebView, script: FunctionScript) {
-        includeScript(webView: webView, script: Script(name: "Script", body: script.body))
-    }
-
-    private func includeScript(webView: WKWebView, script: Script) {
-        webView.evaluateJavaScript(script.body)
     }
 
     func call(
@@ -168,6 +207,7 @@ import WebKit
 
         let maxAttempts = 2
         let requestId = UUID().uuidString
+        let generation = webViewGeneration
 
         let script = """
         (function () {
@@ -192,6 +232,8 @@ import WebKit
         do {
             return try await withTimeout("js.\(name)", Self.defaultTimeout) { [self] in
                 try await Task { @MainActor in
+                    try await awaitReady()
+
                     try await webView.evaluateJavaScript(script)
 
                     for try await value in stream {
@@ -210,9 +252,10 @@ import WebKit
             )
             continuationStreams.removeValue(forKey: requestId)
             if attempts < maxAttempts {
-                webView?.removeFromSuperview()
-                webView = createWebView()
-                ensureAttachedToWindow()
+                // Skip if the terminate delegate (or another failing call) already rebuilt the WebView.
+                if webViewGeneration == generation {
+                    replaceWebView()
+                }
                 return try await evaluateFunction(name: name, body: body, attempts: attempts + 1)
             } else {
                 throw error
@@ -229,6 +272,20 @@ import WebKit
         }
         if message.name == "scriptError", let logMessage = message.body as? String {
             warning(.openAPS, "JavaScript Error: \(logMessage)")
+        }
+        // The documentEnd user script fired: the document (re)loaded and every oref
+        // bundle has been injected, so queued calls may proceed.
+        if message.name == "jsBridge",
+           let body = message.body as? [String: Any],
+           body["id"] as? String == Self.readyMessageID
+        {
+            isReady = true
+            let waiters = readyWaiters
+            readyWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+            return
         }
         // Handle responses from evaluateFunction via jsBridge
         if message.name == "jsBridge",
@@ -253,5 +310,37 @@ import WebKit
                 ))
             }
         }
+    }
+}
+
+extension WebViewScriptExecutor: WKNavigationDelegate {
+    /// The WebContent (JS) process died — jetsam under memory pressure, a crash, or iOS
+    /// reclaiming it in the background. Every in-flight call would otherwise wait for a
+    /// reply that can no longer arrive, so fail them all now; their retry path picks up
+    /// the rebuilt WebView. Unlike a suspended process this one WebKit tells us about,
+    /// which is why it is worth handling separately from the watchdog.
+    func webViewWebContentProcessDidTerminate(_ terminatedWebView: WKWebView) {
+        guard terminatedWebView === webView else { return }
+
+        let pending = continuationStreams
+        continuationStreams.removeAll()
+        warning(
+            .openAPS,
+            "WebContent process terminated by iOS - failing \(pending.count) in-flight JS call(s) and rebuilding the WebView"
+        )
+        let error = NSError(
+            domain: "WebViewScriptExecutor", code: 510,
+            userInfo: [NSLocalizedDescriptionKey: "WebContent process terminated"]
+        )
+        for (_, continuation) in pending {
+            continuation.finish(throwing: error)
+        }
+        replaceWebView()
+    }
+
+    func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError error: Error) {
+        // The blank document that carries the user scripts failed to load, so nothing
+        // was injected and awaitReady() will time out. Log it or it is invisible.
+        warning(.openAPS, "WebView document load failed: \(error.localizedDescription)")
     }
 }

--- a/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
@@ -1,3 +1,4 @@
+import UIKit
 import WebKit
 
 @MainActor class WebViewScriptExecutor: NSObject, WKScriptMessageHandler {
@@ -31,6 +32,41 @@ import WebKit
         super.init()
 
         webView = createWebView()
+        ensureAttachedToWindow()
+    }
+
+    deinit {
+        let view = self.webView
+        DispatchQueue.main.async {
+            view?.removeFromSuperview()
+        }
+    }
+
+    private func ensureAttachedToWindow() {
+        guard webView.superview == nil else { return }
+
+        var window: UIWindow?
+        if let windowScene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+        {
+            window = windowScene.windows.first(where: { $0.isKeyWindow }) ?? windowScene.windows.first
+        }
+        if window == nil {
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+                window = windowScene.windows.first(where: { $0.isKeyWindow }) ?? windowScene.windows.first
+            }
+        }
+
+        if let window = window {
+            window.addSubview(webView)
+            debug(.openAPS, "WebView successfully attached to window for background protection")
+        } else {
+            // If we still can't find it, we can schedule a retry
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.ensureAttachedToWindow()
+            }
+        }
     }
 
     private func createWebView() -> WKWebView {
@@ -119,6 +155,8 @@ import WebKit
     }
 
     private func evaluateFunction(body: String, attempts: Int = 0) async throws -> RawJSON {
+        ensureAttachedToWindow()
+
         let maxAttempts = 2
         let requestId = UUID().uuidString
 
@@ -153,7 +191,9 @@ import WebKit
             print("Javascript function (\(requestId)) attempt \(attempts + 1) failed with error: \(error)")
             continuationStreams.removeValue(forKey: requestId)
             if attempts < maxAttempts {
+                webView?.removeFromSuperview()
                 webView = createWebView()
+                ensureAttachedToWindow()
                 return try await evaluateFunction(body: body, attempts: attempts + 1)
             } else {
                 throw error

--- a/FreeAPS/Sources/Helpers/Timeout.swift
+++ b/FreeAPS/Sources/Helpers/Timeout.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+struct TimeoutError: LocalizedError {
+    let name: String
+    let duration: Duration
+
+    var errorDescription: String? {
+        "\(name) timed out after \(duration.components.seconds)s"
+    }
+}
+
+func withTimeout<T: Sendable>(
+    _ name: String,
+    _ duration: Duration,
+    _ work: @escaping @Sendable() async throws -> T
+) async throws -> T {
+    let race = TimeoutRace<T>()
+
+    return try await withCheckedThrowingContinuation { continuation in
+        race.arm(continuation)
+
+        race.setTimer(Task {
+            try? await Task.sleep(for: duration)
+            race.finish(.failure(TimeoutError(name: name, duration: duration)))
+        })
+
+        Task {
+            do {
+                let value = try await work()
+                race.finish(.success(value))
+            } catch {
+                race.finish(.failure(error))
+            }
+        }
+    }
+}
+
+/// Resumes a continuation exactly once, for whichever racer gets there first.
+private final class TimeoutRace<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock(label: "withTimeout")
+    private var continuation: CheckedContinuation<T, Error>?
+    private var timer: Task<Void, Never>?
+
+    func arm(_ continuation: CheckedContinuation<T, Error>) {
+        lock.perform { self.continuation = continuation }
+    }
+
+    func setTimer(_ timer: Task<Void, Never>) {
+        let alreadyFinished: Bool = lock.perform {
+            guard continuation != nil else { return true }
+            self.timer = timer
+            return false
+        }
+        if alreadyFinished {
+            timer.cancel()
+        }
+    }
+
+    func finish(_ result: Result<T, Error>) {
+        let (continuation, timer) = lock.perform {
+            defer {
+                self.continuation = nil
+                self.timer = nil
+            }
+            return (self.continuation, self.timer)
+        }
+        timer?.cancel()
+        continuation?.resume(with: result)
+    }
+}

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -1325,6 +1325,5 @@ extension Home {
                 }
             }
         }
-
     }
 }

--- a/FreeAPS/Sources/Modules/Main/View/DeviceSetupView.swift
+++ b/FreeAPS/Sources/Modules/Main/View/DeviceSetupView.swift
@@ -29,7 +29,9 @@ struct DeviceSetupView: View {
                 } header: {
                     Text("Devices")
                 } footer: {
-                    Text("Pair your pump and CGM so iAPS can read glucose and deliver insulin. You can also set these up later in Settings.")
+                    Text(
+                        "Pair your pump and CGM so iAPS can read glucose and deliver insulin. You can also set these up later in Settings."
+                    )
                 }
             }
             .listStyle(.insetGrouped)

--- a/FreeAPS/Sources/Modules/Main/View/ExistingUserRestoreView.swift
+++ b/FreeAPS/Sources/Modules/Main/View/ExistingUserRestoreView.swift
@@ -64,13 +64,16 @@ struct ExistingUserRestoreView: View {
                 Text("Restore your settings")
                     .font(.largeTitle).bold()
                     .multilineTextAlignment(.center)
-                Text(model.usesLogin
-                    ? "Log in to your online backup account to restore your OpenAPS preferences and app settings."
-                    : "Enter the recovery token from your previous iAPS install to restore your OpenAPS preferences and app settings from your online backup.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
+                Text(
+                    model.usesLogin
+                        ? "Log in to your online backup account to restore your OpenAPS preferences and app settings."
+                        :
+                        "Enter the recovery token from your previous iAPS install to restore your OpenAPS preferences and app settings from your online backup."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
             }
 
             Picker("", selection: $model.usesLogin) {
@@ -172,9 +175,11 @@ struct ExistingUserRestoreView: View {
                 .foregroundStyle(Color.white)
             }
             .buttonStyle(.plain)
-            .disabled(model.state == .working
-                || model.email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                || model.password.isEmpty)
+            .disabled(
+                model.state == .working
+                    || model.email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                    || model.password.isEmpty
+            )
             .padding(.horizontal)
         }
     }
@@ -291,7 +296,10 @@ extension ExistingUserRestoreView {
                     case .noDevice:
                         self.loginMessage = NSLocalizedString("No backup is linked to this account yet.", comment: "")
                     case .unreachable:
-                        self.loginMessage = NSLocalizedString("Couldn't reach the server. Check your connection and try again.", comment: "")
+                        self.loginMessage = NSLocalizedString(
+                            "Couldn't reach the server. Check your connection and try again.",
+                            comment: ""
+                        )
                     }
                 },
                 receiveValue: { [weak self] token in
@@ -463,10 +471,12 @@ extension ExistingUserRestoreView {
                     },
                     receiveValue: { [weak self] profileStore in
                         guard let self else { return }
-                        guard let profile = profileStore.store["default"] else { then(); return }
+                        guard let profile = profileStore.store["default"] else { then()
+                            return }
 
                         let d = ProfileScheduleDecomposition.decompose(profile, units: units)
-                        guard d.problems.isEmpty else { then(); return }
+                        guard d.problems.isEmpty else { then()
+                            return }
 
                         self.storage.save(d.basal, as: OpenAPS.Settings.basalProfile)
                         self.storage.save(d.carbRatios, as: OpenAPS.Settings.carbRatios)

--- a/FreeAPS/Sources/Modules/Main/View/RecoveryTokenAccountView.swift
+++ b/FreeAPS/Sources/Modules/Main/View/RecoveryTokenAccountView.swift
@@ -84,13 +84,15 @@ struct RecoveryTokenAccountView: View {
     }
 
     private var disclaimer: some View {
-        Text("You don't need an account — your recovery token above already backs up and restores your settings. An account just lets you restore with an email and password instead of the token, and manage your devices.")
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .multilineTextAlignment(.center)
-            .padding()
-            .frame(maxWidth: .infinity)
-            .background(RoundedRectangle(cornerRadius: 12).fill(Color(.tertiarySystemBackground)))
+        Text(
+            "You don't need an account — your recovery token above already backs up and restores your settings. An account just lets you restore with an email and password instead of the token, and manage your devices."
+        )
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(RoundedRectangle(cornerRadius: 12).fill(Color(.tertiarySystemBackground)))
     }
 
     // MARK: - Account
@@ -256,7 +258,10 @@ struct RecoveryTokenAccountView: View {
                 .font(.headline)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(RoundedRectangle(cornerRadius: 14).fill(model.linked ? Color.accentColor : Color(.secondarySystemBackground)))
+                .background(
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(model.linked ? Color.accentColor : Color(.secondarySystemBackground))
+                )
                 .foregroundStyle(model.linked ? Color.white : Color.primary)
         }
         .buttonStyle(.plain)
@@ -340,11 +345,17 @@ extension RecoveryTokenAccountView {
                     case .tokenTaken:
                         self.message = NSLocalizedString("This device is already linked to another account.", comment: "")
                     case .tokenNotFound:
-                        self.message = NSLocalizedString("This device hasn't finished its first backup yet. Make sure Online Backup is on, then try again in a moment.", comment: "")
+                        self.message = NSLocalizedString(
+                            "This device hasn't finished its first backup yet. Make sure Online Backup is on, then try again in a moment.",
+                            comment: ""
+                        )
                     case .invalidToken:
                         self.message = NSLocalizedString("This device's recovery token looks invalid.", comment: "")
                     case .unreachable:
-                        self.message = NSLocalizedString("Couldn't reach the server. Check your connection and try again.", comment: "")
+                        self.message = NSLocalizedString(
+                            "Couldn't reach the server. Check your connection and try again.",
+                            comment: ""
+                        )
                     }
                 },
                 receiveValue: { [weak self] in
@@ -382,17 +393,29 @@ extension RecoveryTokenAccountView {
                     self.messageIsError = true
                     switch error {
                     case .emailTaken:
-                        self.message = NSLocalizedString("An account with that email already exists. Try linking instead.", comment: "")
+                        self.message = NSLocalizedString(
+                            "An account with that email already exists. Try linking instead.",
+                            comment: ""
+                        )
                     case .invalidEmail:
                         self.message = NSLocalizedString("That email doesn't look right.", comment: "")
                     case .weakPassword:
-                        self.message = NSLocalizedString("Please choose a stronger password (at least 8 characters).", comment: "")
+                        self.message = NSLocalizedString(
+                            "Please choose a stronger password (at least 8 characters).",
+                            comment: ""
+                        )
                     case .tokenInvalid:
-                        self.message = NSLocalizedString("This device hasn't finished its first backup yet. Make sure Online Backup is on, then try again in a moment.", comment: "")
+                        self.message = NSLocalizedString(
+                            "This device hasn't finished its first backup yet. Make sure Online Backup is on, then try again in a moment.",
+                            comment: ""
+                        )
                     case let .message(text):
                         self.message = text
                     case .unreachable:
-                        self.message = NSLocalizedString("Couldn't reach the server. Check your connection and try again.", comment: "")
+                        self.message = NSLocalizedString(
+                            "Couldn't reach the server. Check your connection and try again.",
+                            comment: ""
+                        )
                     }
                 },
                 receiveValue: { [weak self] in

--- a/FreeAPS/Sources/Modules/Main/View/RestoreCoreDataStatusView.swift
+++ b/FreeAPS/Sources/Modules/Main/View/RestoreCoreDataStatusView.swift
@@ -105,8 +105,7 @@ struct RestoreCoreDataStatusView: View {
         }
     }
 
-    @ViewBuilder
-    private func statusLabel(_ outcome: PresetOutcome) -> some View {
+    @ViewBuilder private func statusLabel(_ outcome: PresetOutcome) -> some View {
         switch outcome.status {
         case .success:
             Label(

--- a/FreeAPS/Sources/Modules/Main/View/SetupCompleteView.swift
+++ b/FreeAPS/Sources/Modules/Main/View/SetupCompleteView.swift
@@ -23,11 +23,13 @@ struct SetupCompleteView: View {
                     .foregroundStyle(.green)
                 Text("Setup complete")
                     .font(.largeTitle).bold()
-                Text("Your settings are in place. Turn on Closed Loop whenever you're ready for iAPS to adjust insulin automatically — you can always change this later in Settings.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal)
+                Text(
+                    "Your settings are in place. Turn on Closed Loop whenever you're ready for iAPS to adjust insulin automatically — you can always change this later in Settings."
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal)
             }
 
             Toggle(isOn: $closedLoop) {

--- a/FreeAPS/Sources/Modules/Main/View/UpgradeNoticeView.swift
+++ b/FreeAPS/Sources/Modules/Main/View/UpgradeNoticeView.swift
@@ -24,19 +24,24 @@ struct UpgradeNoticeView: View {
                 Text("iAPS updated")
                     .font(.largeTitle).bold()
                 Text(String(
-                    format: NSLocalizedString("You're now running version %@.", comment: "Upgrade notice subtitle, %@ is the version number"),
+                    format: NSLocalizedString(
+                        "You're now running version %@.",
+                        comment: "Upgrade notice subtitle, %@ is the version number"
+                    ),
                     version
                 ))
-                .font(.headline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
             }
 
-            Text("Updates can occasionally reset settings. Although rare, if you notice anything out of the ordinary — such as Closed Loop being off or Max IOB at 0 — we recommend checking your settings first.")
-                .font(.subheadline)
-                .multilineTextAlignment(.center)
-                .foregroundStyle(.secondary)
-                .padding(.horizontal)
+            Text(
+                "Updates can occasionally reset settings. Although rare, if you notice anything out of the ordinary — such as Closed Loop being off or Max IOB at 0 — we recommend checking your settings first."
+            )
+            .font(.subheadline)
+            .multilineTextAlignment(.center)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal)
 
             Spacer()
 

--- a/FreeAPS/Sources/Modules/Main/View/WelcomeView.swift
+++ b/FreeAPS/Sources/Modules/Main/View/WelcomeView.swift
@@ -87,8 +87,7 @@ struct WelcomeView: View {
         .interactiveDismissDisabled()
     }
 
-    @ViewBuilder
-    private func choiceCard(
+    @ViewBuilder private func choiceCard(
         title: LocalizedStringKey,
         subtitle: LocalizedStringKey,
         systemImage: String,

--- a/FreeAPS/Sources/Modules/Sharing/View/SharingRootView.swift
+++ b/FreeAPS/Sources/Modules/Sharing/View/SharingRootView.swift
@@ -109,7 +109,7 @@ extension Sharing {
         /// Auto-revoke Daily Log upload the moment the demographics stop qualifying,
         /// and tell the user why. Manual opt-out stays silent.
         private func enforceLogGate() {
-            if state.uploadLogs && !state.demographicsQualifyForLogs {
+            if state.uploadLogs, !state.demographicsQualifyForLogs {
                 state.uploadLogs = false
                 logsRevoked = true
             }
@@ -118,6 +118,7 @@ extension Sharing {
         var body: some View {
             Form {
                 // MARK: Master toggle
+
                 Section {
                     Toggle("Online Backup and Statistics", isOn: $state.uploadStats)
                 } footer: {


### PR DESCRIPTION
iOS can suspend/kill the WebContent process while iAPS app is in the background.

This PR adds 4 safeguards:
* a timeout for each JS invocation (the loops won't stay stuck forever if WebView is not running)
* attach WebView to the window (this does not prevent the `WebContent` process from being suspended, but hopefully makes it less likely/frequent)
* inject JS-bundles as user-scripts - this makes `WebKit` reinject them after relaunch
* detect and recover from `WebContent` process termination 

### Tested on device
  - timeouts ✅  (3 retries, timing out after 30s, then `Loop failed`)
  - `WebContent` termination: the WebView is recreated and the loop is failed (within ~1s).

### Caveat
- The iAPS process can still get suspended if WebView is suspended (background tasks will most likely expire before the timeouts happen)
- having a real pump with more BLE traffic will mitigate this
- in this case the timeouts will trigger on next BLE activity - the mechanisms will still work, but with a longer delay (5 min vs 1 min)
