### PR TITLE
[hotfix] [alpha] defer launching the app until we have access to our files

### DIFF
--- a/FreeAPS/Sources/Application/AppServices.swift
+++ b/FreeAPS/Sources/Application/AppServices.swift
@@ -18,6 +18,9 @@ import Swinject
     func started() async throws { try await startup?.value }
 
     private func performStartup(resolver: Resolver) async throws {
+        // Nothing below may run while our own files are unreadable.
+        await ProtectedData.waitUntilFilesAreReadable()
+
         try await startService(resolver.resolve(DataMigrations.self))
 
         let appCoordinator = resolver.resolve(AppCoordinator.self)!

--- a/FreeAPS/Sources/Application/FreeAPSApp.swift
+++ b/FreeAPS/Sources/Application/FreeAPSApp.swift
@@ -37,7 +37,6 @@ import Swinject
             .default,
             "iAPS Started: v\(Bundle.main.releaseVersionNumber ?? "")(\(Bundle.main.buildVersionNumber ?? "")) [buildDate: \(Bundle.main.buildDate)] [buildExpires: \(Bundle.main.profileExpiration ?? "")]"
         )
-        isNewVersion()
         AppearanceManager.setupGlobalAppearance()
     }
 
@@ -70,7 +69,15 @@ import Swinject
         }
     }
 
-    private func isNewVersion() {
+    fileprivate static func runVersionCheckOnce() {
+        guard !didRunVersionCheck else { return }
+        didRunVersionCheck = true
+        isNewVersion()
+    }
+
+    private static var didRunVersionCheck = false
+
+    private static func isNewVersion() {
         let userDefaults = UserDefaults.standard
         var version = userDefaults.string(forKey: IAPSconfig.version) ?? ""
         userDefaults.set(false, forKey: IAPSconfig.inBolusView)
@@ -117,6 +124,7 @@ private struct StartupGate<Content: View>: View {
         .task {
             do {
                 try await start()
+                FreeAPSApp.runVersionCheckOnce()
                 ready = true
             } catch {
                 self.error = error.localizedDescription

--- a/FreeAPS/Sources/Helpers/ProtectedData.swift
+++ b/FreeAPS/Sources/Helpers/ProtectedData.swift
@@ -8,4 +8,56 @@ enum ProtectedData {
     }
 
     static let didBecomeAvailable = UIApplication.protectedDataDidBecomeAvailableNotification
+
+    private static let probeName = "protection.test"
+
+    private static var filesBecameReadable = false
+
+    /// Whether the app can read its own Documents directory right now.
+    static func canReadOwnFiles() -> Bool {
+        if filesBecameReadable {
+            return true
+        }
+        filesBecameReadable = probe()
+        return filesBecameReadable
+    }
+
+    /// Suspends until `canReadOwnFiles()` is true. Returns immediately in the normal case.
+    static func waitUntilFilesAreReadable() async {
+        if canReadOwnFiles() {
+            return
+        }
+
+        debug(.default, "Launch deferred: cannot read our own files yet (no unlock since boot)")
+
+        // Polled rather than driven by `didBecomeAvailable`: the notification is the normal signal,
+        // but one that arrives before we subscribe would leave the launch waiting forever, and this
+        // cannot. The cost is one small read a second, only while the device has never been
+        // unlocked and the app has nothing else to do.
+        while !canReadOwnFiles() {
+            try? await Task.sleep(for: .seconds(1))
+        }
+
+        debug(.default, "Our files became readable, resuming launch")
+    }
+
+    private static func probe() -> Bool {
+        let fileManager = FileManager.default
+        guard let documents = try? fileManager.url(
+            for: .documentDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        ) else {
+            return false
+        }
+
+        let probeURL = documents.appendingPathComponent(probeName)
+
+        if !fileManager.fileExists(atPath: probeURL.path) {
+            try? Data("iAPS".utf8).write(to: probeURL, options: .completeFileProtectionUntilFirstUserAuthentication)
+        }
+
+        return (try? Data(contentsOf: probeURL)) != nil
+    }
 }


### PR DESCRIPTION
After a phone restart, before the user unlocks it for the first time - we don't have access to any of our files / UserDefaults/KeyChain. If iOS happens to auto-launch iAPS, and the user hasn't unlocked the device before that - iAPS won't be able to read any of the files and will reset to default settings, loses pump/cgm connection (this can be recovered from by immediately restarting iAPS).

This PR adds a launch gate that waits for the device to get unlocked, verifies access to files and launches the app only after this is confirmed.