### PR TITLE
Report memory / process-pressure telemetry with the statistics uploads

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 		38E98A2925F52C9300C0CED0 /* Error+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2225F52C9300C0CED0 /* Error+Extensions.swift */; };
 		38E98A2D25F52DC400C0CED0 /* NSLocking+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */; };
 		F2A11C1230200B0100EF9230 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A11C1130200B0100EF9230 /* Timeout.swift */; };
+		F2B33E0230220D0300EF9402 /* MemoryMetricsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B33E0130220D0300EF9401 /* MemoryMetricsService.swift */; };
 		38E98A3025F52FF700C0CED0 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2F25F52FF700C0CED0 /* Config.swift */; };
 		38E98A3725F5509500C0CED0 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A3625F5509500C0CED0 /* String+Extensions.swift */; };
 		38EA05DA261F6E7C0064E39B /* SimpleLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EA05D9261F6E7C0064E39B /* SimpleLogReporter.swift */; };
@@ -1005,6 +1006,7 @@
 		38E98A2225F52C9300C0CED0 /* Error+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Error+Extensions.swift"; sourceTree = "<group>"; };
 		38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLocking+Extensions.swift"; sourceTree = "<group>"; };
 		F2A11C1130200B0100EF9230 /* Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timeout.swift; sourceTree = "<group>"; };
+		F2B33E0130220D0300EF9401 /* MemoryMetricsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryMetricsService.swift; sourceTree = "<group>"; };
 		38E98A2F25F52FF700C0CED0 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		38E98A3625F5509500C0CED0 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		38EA05D9261F6E7C0064E39B /* SimpleLogReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleLogReporter.swift; sourceTree = "<group>"; };
@@ -2230,6 +2232,7 @@
 				38FCF3D525E8FDF40078B0D1 /* MD5.swift */,
 				38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */,
 				F2A11C1130200B0100EF9230 /* Timeout.swift */,
+				F2B33E0130220D0300EF9401 /* MemoryMetricsService.swift */,
 				38C4D33925E9A1ED00D30B77 /* NSObject+AssociatedValues.swift */,
 				3811DE5725C9D4D500A708ED /* ProgressBar.swift */,
 				3811DE5525C9D4D500A708ED /* Publisher.swift */,
@@ -3792,6 +3795,7 @@
 				23888883D4EA091C88480FF2 /* BolusProvider.swift in Sources */,
 				38E98A2D25F52DC400C0CED0 /* NSLocking+Extensions.swift in Sources */,
 				F2A11C1230200B0100EF9230 /* Timeout.swift in Sources */,
+				F2B33E0230220D0300EF9402 /* MemoryMetricsService.swift in Sources */,
 				19C3C72F2E97AE520000BE4D /* SearchResultsView.swift in Sources */,
 				19C3C7302E97AE520000BE4D /* FoodSearchStateModel.swift in Sources */,
 				19C3C7312E97AE520000BE4D /* BarcodeScannerService.swift in Sources */,

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -1301,7 +1301,8 @@ final class BaseAPSManager: APSManager, Injectable {
                 ),
                 id: getIdentifier(),
                 dob: settings.birthDate,
-                sex: settings.sexSetting
+                sex: settings.sexSetting,
+                Memory: MemoryMetricsService.shared.snapshot(full: true)
             )
             storage.save(dailystat, as: file)
             nightscout.uploadStatistics(dailystat: dailystat)
@@ -1309,7 +1310,8 @@ final class BaseAPSManager: APSManager, Injectable {
             let json = BareMinimum(
                 id: getIdentifier(),
                 created_at: Date.now,
-                Build_Version: Bundle.main.releaseVersionNumber ?? "UnKnown", Branch: branch()
+                Build_Version: Bundle.main.releaseVersionNumber ?? "UnKnown", Branch: branch(),
+                Memory: MemoryMetricsService.shared.snapshot(full: false)
             )
             nightscout.uploadVersion(json: json)
         }

--- a/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
@@ -251,6 +251,9 @@ import WebKit
                 .openAPS,
                 "Javascript function (\(name), \(requestId)) attempt \(attempts + 1) failed with error: \(error)"
             )
+            if error is TimeoutError {
+                MemoryMetricsService.increment(MemoryMetricsService.Keys.jsTimeouts)
+            }
             continuationStreams.removeValue(forKey: requestId)?.finish(throwing: error)
             // Rebuild even when giving up: otherwise the next JS call in this cycle
             // inherits the wedged WebView and burns its own timeout rediscovering it.
@@ -327,6 +330,8 @@ extension WebViewScriptExecutor: WKNavigationDelegate {
     /// which is why it is worth handling separately from the watchdog.
     func webViewWebContentProcessDidTerminate(_ terminatedWebView: WKWebView) {
         guard terminatedWebView === webView else { return }
+
+        MemoryMetricsService.increment(MemoryMetricsService.Keys.webContentTerminations)
 
         let pending = continuationStreams
         continuationStreams.removeAll()

--- a/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/WebViewScriptExecutor.swift
@@ -252,7 +252,7 @@ import WebKit
                 "Javascript function (\(name), \(requestId)) attempt \(attempts + 1) failed with error: \(error)"
             )
             if error is TimeoutError {
-                MemoryMetricsService.increment(MemoryMetricsService.Keys.jsTimeouts)
+                MemoryMetricsService.increment(.jsTimeouts)
             }
             continuationStreams.removeValue(forKey: requestId)?.finish(throwing: error)
             // Rebuild even when giving up: otherwise the next JS call in this cycle
@@ -331,7 +331,7 @@ extension WebViewScriptExecutor: WKNavigationDelegate {
     func webViewWebContentProcessDidTerminate(_ terminatedWebView: WKWebView) {
         guard terminatedWebView === webView else { return }
 
-        MemoryMetricsService.increment(MemoryMetricsService.Keys.webContentTerminations)
+        MemoryMetricsService.increment(.webContentTerminations)
 
         let pending = continuationStreams
         continuationStreams.removeAll()

--- a/FreeAPS/Sources/Application/FreeAPSApp.swift
+++ b/FreeAPS/Sources/Application/FreeAPSApp.swift
@@ -39,6 +39,7 @@ import Swinject
         )
         isNewVersion()
         AppearanceManager.setupGlobalAppearance()
+        MemoryMetricsService.shared.start()
     }
 
     var body: some Scene {

--- a/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
+++ b/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
@@ -1,0 +1,146 @@
+import Foundation
+import MetricKit
+import UIKit
+import os
+
+/// Memory / process-pressure telemetry block attached to the statistics uploads.
+///
+/// Two tiers, matching the statistics sharing ladder:
+/// - App-behaviour numbers (footprint, OS kill counts, JS-engine incidents) describe the
+///   app, not the person or the phone, and ride along with BOTH the full Statistics
+///   payload and the BareMinimum version ping.
+/// - Hardware-derived numbers (device RAM, remaining per-app allowance) narrow down the
+///   phone model class, so they are only included at the full statistics level, where
+///   the model is shared anyway.
+struct MemoryStats: JSON, Equatable {
+    /// Physical footprint of the app process right now, MB.
+    var footprint_mb: Int?
+    /// Peak footprint over the last MetricKit reporting day, MB.
+    var peak_mb: Int?
+    /// UIKit memory-pressure warnings received, cumulative since install.
+    var pressure_warnings: Int?
+    /// OS kills for exceeding the app's own memory limit (jetsam), fg+bg, cumulative.
+    var jetsam_exits: Int?
+    /// OS kills of the backgrounded app to relieve system-wide memory pressure, cumulative.
+    var pressure_exits: Int?
+    /// Watchdog kills (unresponsive main thread), cumulative.
+    var watchdog_exits: Int?
+    /// WebContent (oref JS) process deaths detected by WebViewScriptExecutor, cumulative.
+    var webcontent_terminations: Int?
+    /// JS call attempts that hit the WebViewScriptExecutor watchdog timeout, cumulative.
+    /// One wedged loop cycle can add up to 3 (initial attempt + retries).
+    var js_timeouts: Int?
+    /// Physical RAM of the device, MB. Full statistics only.
+    var ram_mb: Int?
+    /// Memory iOS will still allow this app right now, MB. Full statistics only.
+    var available_mb: Int?
+}
+
+/// Collects the numbers behind `MemoryStats`.
+///
+/// MetricKit delivers its payloads at most once a day, covering the previous day, and
+/// only on a real device — on the simulator the MetricKit-derived fields simply stay nil.
+/// The exit counts are accumulated into monotonic totals; the server diffs successive
+/// uploads to get per-interval rates, which keeps this class free of upload-state
+/// bookkeeping (an upload that never happens loses nothing).
+final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
+    static let shared = MemoryMetricsService()
+
+    enum Keys {
+        static let pressureWarnings = "MemoryMetrics_pressureWarnings"
+        static let jetsamExits = "MemoryMetrics_jetsamExits"
+        static let pressureExits = "MemoryMetrics_pressureExits"
+        static let watchdogExits = "MemoryMetrics_watchdogExits"
+        static let peakFootprintMB = "MemoryMetrics_peakFootprintMB"
+        static let webContentTerminations = "MemoryMetrics_webContentTerminations"
+        static let jsTimeouts = "MemoryMetrics_jsTimeouts"
+    }
+
+    override private init() {
+        super.init()
+    }
+
+    /// Call once at app start.
+    func start() {
+        MXMetricManager.shared.add(self)
+        // Foundation-qualified: the app defines its own NotificationCenter protocol for DI.
+        Foundation.NotificationCenter.default.addObserver(
+            forName: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            Self.increment(Keys.pressureWarnings)
+        }
+    }
+
+    /// Static so call sites (WebViewScriptExecutor) don't need the singleton started first.
+    static func increment(_ key: String) {
+        let defaults = UserDefaults.standard
+        defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
+    }
+
+    func snapshot(full: Bool) -> MemoryStats {
+        let defaults = UserDefaults.standard
+        var stats = MemoryStats(
+            footprint_mb: Self.currentFootprintMB(),
+            peak_mb: defaults.object(forKey: Keys.peakFootprintMB) as? Int,
+            pressure_warnings: defaults.integer(forKey: Keys.pressureWarnings),
+            jetsam_exits: defaults.integer(forKey: Keys.jetsamExits),
+            pressure_exits: defaults.integer(forKey: Keys.pressureExits),
+            watchdog_exits: defaults.integer(forKey: Keys.watchdogExits),
+            webcontent_terminations: defaults.integer(forKey: Keys.webContentTerminations),
+            js_timeouts: defaults.integer(forKey: Keys.jsTimeouts)
+        )
+        if full {
+            stats.ram_mb = Int(ProcessInfo.processInfo.physicalMemory / 1_048_576)
+            stats.available_mb = Int(os_proc_available_memory()) / 1_048_576
+        }
+        return stats
+    }
+
+    // MARK: - MXMetricManagerSubscriber
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        for payload in payloads {
+            if let exits = payload.applicationExitMetrics {
+                let fg = exits.foregroundExitData
+                let bg = exits.backgroundExitData
+                add(
+                    fg.cumulativeMemoryResourceLimitExitCount + bg.cumulativeMemoryResourceLimitExitCount,
+                    to: Keys.jetsamExits
+                )
+                add(bg.cumulativeMemoryPressureExitCount, to: Keys.pressureExits)
+                add(
+                    fg.cumulativeAppWatchdogExitCount + bg.cumulativeAppWatchdogExitCount,
+                    to: Keys.watchdogExits
+                )
+            }
+            if let memory = payload.memoryMetrics {
+                let mb = Int(memory.peakMemoryUsage.converted(to: .megabytes).value.rounded())
+                UserDefaults.standard.set(mb, forKey: Keys.peakFootprintMB)
+            }
+        }
+    }
+
+    // MARK: - Internals
+
+    /// Each MetricKit payload's counts cover only that payload's day, so summing
+    /// successive payloads yields a correct running total.
+    private func add(_ count: Int, to key: String) {
+        guard count > 0 else { return }
+        let defaults = UserDefaults.standard
+        defaults.set(defaults.integer(forKey: key) + count, forKey: key)
+    }
+
+    private static func currentFootprintMB() -> Int? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return Int(info.phys_footprint / 1_048_576)
+    }
+}

--- a/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
+++ b/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
@@ -15,46 +15,77 @@ import os
 struct MemoryStats: JSON, Equatable {
     /// Physical footprint of the app process right now, MB.
     var footprint_mb: Int?
-    /// Peak footprint over the last MetricKit reporting day, MB.
+    /// Peak footprint over the last MetricKit reporting day, MB (any version).
     var peak_mb: Int?
-    /// UIKit memory-pressure warnings received, cumulative since install.
-    var pressure_warnings: Int?
-    /// OS kills for exceeding the app's own memory limit (jetsam), fg+bg, cumulative.
-    var jetsam_exits: Int?
-    /// OS kills of the backgrounded app to relieve system-wide memory pressure, cumulative.
-    var pressure_exits: Int?
-    /// Watchdog kills (unresponsive main thread), cumulative.
-    var watchdog_exits: Int?
-    /// WebContent (oref JS) process deaths detected by WebViewScriptExecutor, cumulative.
-    var webcontent_terminations: Int?
-    /// JS call attempts that hit the WebViewScriptExecutor watchdog timeout, cumulative.
-    /// One wedged loop cycle can add up to 3 (initial attempt + retries).
-    var js_timeouts: Int?
+    /// Incident counters, bucketed by the build number they occurred under, so a
+    /// release-over-release comparison never smears events across an upgrade.
+    /// Keys are build numbers ("274"); the newest 6 buckets are retained.
+    var counters: [String: MemoryVersionCounters]?
     /// Physical RAM of the device, MB. Full statistics only.
     var ram_mb: Int?
     /// Memory iOS will still allow this app right now, MB. Full statistics only.
     var available_mb: Int?
 }
 
+/// One build's worth of incident counts. Counters start at zero when that build first
+/// runs and only ever grow, so the latest uploaded value IS the build's total —
+/// no server-side diffing needed for per-version numbers.
+struct MemoryVersionCounters: JSON, Equatable {
+    /// Marketing version ("8.3.5") for display; the dictionary key is the build number.
+    var version: String?
+    /// Highest MetricKit daily peak recorded while this build ran, MB.
+    var peak_mb: Int?
+    /// UIKit memory-pressure warnings received.
+    var pressure_warnings: Int
+    /// OS kills for exceeding the app's own memory limit (jetsam), fg+bg.
+    var jetsam_exits: Int
+    /// OS kills of the backgrounded app to relieve system-wide memory pressure.
+    var pressure_exits: Int
+    /// Watchdog kills (unresponsive main thread).
+    var watchdog_exits: Int
+    /// WebContent (oref JS) process deaths detected by WebViewScriptExecutor.
+    var webcontent_terminations: Int
+    /// JS call attempts that hit the WebViewScriptExecutor watchdog timeout.
+    /// One wedged loop cycle can add up to 3 (initial attempt + retries).
+    var js_timeouts: Int
+
+    init(version: String?) {
+        self.version = version
+        peak_mb = nil
+        pressure_warnings = 0
+        jetsam_exits = 0
+        pressure_exits = 0
+        watchdog_exits = 0
+        webcontent_terminations = 0
+        js_timeouts = 0
+    }
+}
+
 /// Collects the numbers behind `MemoryStats`.
 ///
 /// MetricKit delivers its payloads at most once a day, covering the previous day, and
 /// only on a real device — on the simulator the MetricKit-derived fields simply stay nil.
-/// The exit counts are accumulated into monotonic totals; the server diffs successive
-/// uploads to get per-interval rates, which keeps this class free of upload-state
-/// bookkeeping (an upload that never happens loses nothing).
+/// Because that delivery is late, MetricKit counts are filed into the bucket named by the
+/// payload's own build metadata, not the build that happens to be running — an upgrade
+/// therefore never swallows the previous build's last day of kills.
 final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
     static let shared = MemoryMetricsService()
 
-    enum Keys {
-        static let pressureWarnings = "MemoryMetrics_pressureWarnings"
-        static let jetsamExits = "MemoryMetrics_jetsamExits"
-        static let pressureExits = "MemoryMetrics_pressureExits"
-        static let watchdogExits = "MemoryMetrics_watchdogExits"
-        static let peakFootprintMB = "MemoryMetrics_peakFootprintMB"
-        static let webContentTerminations = "MemoryMetrics_webContentTerminations"
-        static let jsTimeouts = "MemoryMetrics_jsTimeouts"
+    enum Counter {
+        case pressureWarnings
+        case jetsamExits
+        case pressureExits
+        case watchdogExits
+        case webContentTerminations
+        case jsTimeouts
     }
+
+    private static let storageKey = "MemoryMetrics_versionCounters"
+    private static let latestPeakKey = "MemoryMetrics_peakFootprintMB"
+    /// Old buckets freeze once their build stops running and the server has already
+    /// ingested their totals, so retaining a handful bounds the payload without loss.
+    private static let maxBuckets = 6
+    private static let lock = NSLock()
 
     override private init() {
         super.init()
@@ -69,27 +100,34 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
             object: nil,
             queue: nil
         ) { _ in
-            Self.increment(Keys.pressureWarnings)
+            MemoryMetricsService.increment(.pressureWarnings)
         }
     }
 
     /// Static so call sites (WebViewScriptExecutor) don't need the singleton started first.
-    static func increment(_ key: String) {
-        let defaults = UserDefaults.standard
-        defaults.set(defaults.integer(forKey: key) + 1, forKey: key)
+    /// Files the event under the currently running build.
+    static func increment(_ counter: Counter) {
+        mutateBucket(build: currentBuild(), version: currentVersion()) { bucket in
+            switch counter {
+            case .pressureWarnings: bucket.pressure_warnings += 1
+            case .jetsamExits: bucket.jetsam_exits += 1
+            case .pressureExits: bucket.pressure_exits += 1
+            case .watchdogExits: bucket.watchdog_exits += 1
+            case .webContentTerminations: bucket.webcontent_terminations += 1
+            case .jsTimeouts: bucket.js_timeouts += 1
+            }
+        }
     }
 
     func snapshot(full: Bool) -> MemoryStats {
-        let defaults = UserDefaults.standard
+        Self.lock.lock()
+        let counters = Self.loadMap()
+        Self.lock.unlock()
+
         var stats = MemoryStats(
             footprint_mb: Self.currentFootprintMB(),
-            peak_mb: defaults.object(forKey: Keys.peakFootprintMB) as? Int,
-            pressure_warnings: defaults.integer(forKey: Keys.pressureWarnings),
-            jetsam_exits: defaults.integer(forKey: Keys.jetsamExits),
-            pressure_exits: defaults.integer(forKey: Keys.pressureExits),
-            watchdog_exits: defaults.integer(forKey: Keys.watchdogExits),
-            webcontent_terminations: defaults.integer(forKey: Keys.webContentTerminations),
-            js_timeouts: defaults.integer(forKey: Keys.jsTimeouts)
+            peak_mb: UserDefaults.standard.object(forKey: Self.latestPeakKey) as? Int,
+            counters: counters.isEmpty ? nil : counters
         )
         if full {
             stats.ram_mb = Int(ProcessInfo.processInfo.physicalMemory / 1_048_576)
@@ -102,35 +140,91 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
 
     func didReceive(_ payloads: [MXMetricPayload]) {
         for payload in payloads {
+            // The payload names the build it describes; use it so a day's counts that
+            // arrive after an upgrade still land on the build they happened under.
+            let build = payload.metaData?.applicationBuildVersion ?? Self.currentBuild()
+            let version = payload.latestApplicationVersion
+
             if let exits = payload.applicationExitMetrics {
                 let fg = exits.foregroundExitData
                 let bg = exits.backgroundExitData
-                add(
-                    fg.cumulativeMemoryResourceLimitExitCount + bg.cumulativeMemoryResourceLimitExitCount,
-                    to: Keys.jetsamExits
-                )
-                add(bg.cumulativeMemoryPressureExitCount, to: Keys.pressureExits)
-                add(
-                    fg.cumulativeAppWatchdogExitCount + bg.cumulativeAppWatchdogExitCount,
-                    to: Keys.watchdogExits
-                )
+                let jetsam = fg.cumulativeMemoryResourceLimitExitCount + bg.cumulativeMemoryResourceLimitExitCount
+                let pressure = bg.cumulativeMemoryPressureExitCount
+                let watchdog = fg.cumulativeAppWatchdogExitCount + bg.cumulativeAppWatchdogExitCount
+                if jetsam + pressure + watchdog > 0 {
+                    Self.mutateBucket(build: build, version: version) { bucket in
+                        bucket.jetsam_exits += jetsam
+                        bucket.pressure_exits += pressure
+                        bucket.watchdog_exits += watchdog
+                    }
+                }
             }
             if let memory = payload.memoryMetrics {
                 let mb = Int(memory.peakMemoryUsage.converted(to: .megabytes).value.rounded())
-                UserDefaults.standard.set(mb, forKey: Keys.peakFootprintMB)
+                UserDefaults.standard.set(mb, forKey: Self.latestPeakKey)
+                Self.mutateBucket(build: build, version: version) { bucket in
+                    bucket.peak_mb = max(bucket.peak_mb ?? 0, mb)
+                }
             }
         }
     }
 
-    // MARK: - Internals
+    // MARK: - Bucket storage
 
-    /// Each MetricKit payload's counts cover only that payload's day, so summing
-    /// successive payloads yields a correct running total.
-    private func add(_ count: Int, to key: String) {
-        guard count > 0 else { return }
-        let defaults = UserDefaults.standard
-        defaults.set(defaults.integer(forKey: key) + count, forKey: key)
+    private static func mutateBucket(
+        build: String,
+        version: String?,
+        _ change: (inout MemoryVersionCounters) -> Void
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+
+        var map = loadMap()
+        var bucket = map[build] ?? MemoryVersionCounters(version: version)
+        if bucket.version == nil {
+            bucket.version = version
+        }
+        change(&bucket)
+        map[build] = bucket
+
+        // Prune oldest buckets (numeric build order, string fallback) beyond the cap.
+        if map.count > maxBuckets {
+            let sorted = map.keys.sorted {
+                switch (Int($0), Int($1)) {
+                case let (.some(a), .some(b)): return a < b
+                case (.some, .none): return true
+                case (.none, .some): return false
+                case (.none, .none): return $0 < $1
+                }
+            }
+            for key in sorted.prefix(map.count - maxBuckets) {
+                map.removeValue(forKey: key)
+            }
+        }
+
+        if let data = try? JSONCoding.encoder.encode(map) {
+            UserDefaults.standard.set(data, forKey: storageKey)
+        }
     }
+
+    private static func loadMap() -> [String: MemoryVersionCounters] {
+        guard let data = UserDefaults.standard.data(forKey: storageKey),
+              let map = try? JSONCoding.decoder.decode([String: MemoryVersionCounters].self, from: data)
+        else {
+            return [:]
+        }
+        return map
+    }
+
+    private static func currentBuild() -> String {
+        Bundle.main.buildVersionNumber ?? "0"
+    }
+
+    private static func currentVersion() -> String? {
+        Bundle.main.releaseVersionNumber
+    }
+
+    // MARK: - Gauges
 
     private static func currentFootprintMB() -> Int? {
         var info = task_vm_info_data_t()

--- a/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
+++ b/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
@@ -15,11 +15,13 @@ import os
 struct MemoryStats: JSON, Equatable {
     /// Physical footprint of the app process right now, MB.
     var footprint_mb: Int?
-    /// Peak footprint over the last MetricKit reporting day, MB (any version).
+    /// Peak footprint over the last MetricKit reporting day, MB (any release).
     var peak_mb: Int?
-    /// Incident counters, bucketed by the build number they occurred under, so a
+    /// Incident counters, bucketed by the release they occurred under, so a
     /// release-over-release comparison never smears events across an upgrade.
-    /// Keys are build numbers ("274"); the newest 6 buckets are retained.
+    /// Keys are "version(build)" composites ("8.3.5(274)") — build number alone is
+    /// ambiguous because plain Xcode builds don't increment it, and version alone
+    /// can't separate two builds of the same release. The newest 6 buckets are retained.
     var counters: [String: MemoryVersionCounters]?
     /// Physical RAM of the device, MB. Full statistics only.
     var ram_mb: Int?
@@ -31,8 +33,6 @@ struct MemoryStats: JSON, Equatable {
 /// runs and only ever grow, so the latest uploaded value IS the build's total —
 /// no server-side diffing needed for per-version numbers.
 struct MemoryVersionCounters: JSON, Equatable {
-    /// Marketing version ("8.3.5") for display; the dictionary key is the build number.
-    var version: String?
     /// Highest MetricKit daily peak recorded while this build ran, MB.
     var peak_mb: Int?
     /// UIKit memory-pressure warnings received.
@@ -49,8 +49,7 @@ struct MemoryVersionCounters: JSON, Equatable {
     /// One wedged loop cycle can add up to 3 (initial attempt + retries).
     var js_timeouts: Int
 
-    init(version: String?) {
-        self.version = version
+    init() {
         peak_mb = nil
         pressure_warnings = 0
         jetsam_exits = 0
@@ -105,9 +104,9 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
     }
 
     /// Static so call sites (WebViewScriptExecutor) don't need the singleton started first.
-    /// Files the event under the currently running build.
+    /// Files the event under the currently running release.
     static func increment(_ counter: Counter) {
-        mutateBucket(build: currentBuild(), version: currentVersion()) { bucket in
+        mutateBucket(key: currentBucketKey()) { bucket in
             switch counter {
             case .pressureWarnings: bucket.pressure_warnings += 1
             case .jetsamExits: bucket.jetsam_exits += 1
@@ -140,10 +139,14 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
 
     func didReceive(_ payloads: [MXMetricPayload]) {
         for payload in payloads {
-            // The payload names the build it describes; use it so a day's counts that
+            // The payload names the release it describes; use it so a day's counts that
             // arrive after an upgrade still land on the build they happened under.
-            let build = payload.metaData?.applicationBuildVersion ?? Self.currentBuild()
-            let version = payload.latestApplicationVersion
+            let key: String
+            if let build = payload.metaData?.applicationBuildVersion {
+                key = Self.bucketKey(version: payload.latestApplicationVersion, build: build)
+            } else {
+                key = Self.currentBucketKey()
+            }
 
             if let exits = payload.applicationExitMetrics {
                 let fg = exits.foregroundExitData
@@ -152,7 +155,7 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
                 let pressure = bg.cumulativeMemoryPressureExitCount
                 let watchdog = fg.cumulativeAppWatchdogExitCount + bg.cumulativeAppWatchdogExitCount
                 if jetsam + pressure + watchdog > 0 {
-                    Self.mutateBucket(build: build, version: version) { bucket in
+                    Self.mutateBucket(key: key) { bucket in
                         bucket.jetsam_exits += jetsam
                         bucket.pressure_exits += pressure
                         bucket.watchdog_exits += watchdog
@@ -162,7 +165,7 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
             if let memory = payload.memoryMetrics {
                 let mb = Int(memory.peakMemoryUsage.converted(to: .megabytes).value.rounded())
                 UserDefaults.standard.set(mb, forKey: Self.latestPeakKey)
-                Self.mutateBucket(build: build, version: version) { bucket in
+                Self.mutateBucket(key: key) { bucket in
                     bucket.peak_mb = max(bucket.peak_mb ?? 0, mb)
                 }
             }
@@ -172,30 +175,21 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
     // MARK: - Bucket storage
 
     private static func mutateBucket(
-        build: String,
-        version: String?,
+        key: String,
         _ change: (inout MemoryVersionCounters) -> Void
     ) {
         lock.lock()
         defer { lock.unlock() }
 
         var map = loadMap()
-        var bucket = map[build] ?? MemoryVersionCounters(version: version)
-        if bucket.version == nil {
-            bucket.version = version
-        }
+        var bucket = map[key] ?? MemoryVersionCounters()
         change(&bucket)
-        map[build] = bucket
+        map[key] = bucket
 
-        // Prune oldest buckets (numeric build order, string fallback) beyond the cap.
+        // Prune oldest buckets (release order: version tuple, then build) beyond the cap.
         if map.count > maxBuckets {
             let sorted = map.keys.sorted {
-                switch (Int($0), Int($1)) {
-                case let (.some(a), .some(b)): return a < b
-                case (.some, .none): return true
-                case (.none, .some): return false
-                case (.none, .none): return $0 < $1
-                }
+                releaseOrder($0).lexicographicallyPrecedes(releaseOrder($1))
             }
             for key in sorted.prefix(map.count - maxBuckets) {
                 map.removeValue(forKey: key)
@@ -216,12 +210,21 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
         return map
     }
 
-    private static func currentBuild() -> String {
-        Bundle.main.buildVersionNumber ?? "0"
+    /// "8.3.5(274)" — version alone collides across builds of one release, build alone
+    /// collides across releases (plain Xcode builds don't increment it).
+    private static func bucketKey(version: String?, build: String) -> String {
+        "\(version ?? "?")(\(build))"
     }
 
-    private static func currentVersion() -> String? {
-        Bundle.main.releaseVersionNumber
+    private static func currentBucketKey() -> String {
+        bucketKey(version: Bundle.main.releaseVersionNumber, build: Bundle.main.buildVersionNumber ?? "0")
+    }
+
+    /// Sortable release order for pruning: version numbers first, build number last.
+    /// Unparseable keys sort oldest (pruned first).
+    private static func releaseOrder(_ key: String) -> [Int] {
+        let parts = key.split(whereSeparator: { !$0.isNumber }).compactMap { Int($0) }
+        return parts.isEmpty ? [-1] : parts
     }
 
     // MARK: - Gauges

--- a/FreeAPS/Sources/Models/BareMinimum.swift
+++ b/FreeAPS/Sources/Models/BareMinimum.swift
@@ -5,4 +5,7 @@ struct BareMinimum: JSON, Equatable {
     var created_at: Date
     var Build_Version: String
     var Branch: String
+    /// App-behaviour memory telemetry only — never hardware-identifying fields.
+    /// See MemoryStats for the tier split.
+    var Memory: MemoryStats?
 }

--- a/FreeAPS/Sources/Models/Statistics.swift
+++ b/FreeAPS/Sources/Models/Statistics.swift
@@ -21,6 +21,7 @@ struct Statistics: JSON, Equatable {
     var id: String
     var dob: Date
     var sex: Int
+    var Memory: MemoryStats?
 
     init(
         created_at: Date,
@@ -42,7 +43,8 @@ struct Statistics: JSON, Equatable {
         Statistics: Stats,
         id: String,
         dob: Date,
-        sex: Int
+        sex: Int,
+        Memory: MemoryStats? = nil
     ) {
         self.created_at = created_at
         self.iPhone = iPhone
@@ -64,6 +66,7 @@ struct Statistics: JSON, Equatable {
         self.id = id
         self.dob = dob
         self.sex = sex
+        self.Memory = Memory
     }
 
     static func == (lhs: Statistics, rhs: Statistics) -> Bool {
@@ -97,6 +100,7 @@ extension Statistics {
         case id
         case dob
         case sex
+        case Memory
     }
 }
 


### PR DESCRIPTION
Follow-on from the loop-stall work (https://open-iaps.app/docs/loop-stalls and the #2003–#2007 discussion). Two questions came out of that investigation that log files fundamentally can't answer:

1. **Does iOS actually kill the WebContent process?** (@yurique's question on #2004/#2005) — the death is silent, so absence of log traces proves nothing either way. The best I could do was infer it from 28 wedges that survived repeated foregroundings.
2. **Why do older phones wedge at up to ~30× the rate of current ones?** Memory pressure is the suspect, but nothing in our logs measures it.

This PR adds a small `Memory` block to the statistics upload the app already sends (~2–3×/day), so those questions become measurable across the whole fleet instead of inferred from the ~10% of devices that share logs:

* **MetricKit** (`MXAppExitMetric` / `MXMemoryMetric`): OS-recorded counts of jetsam kills, background memory-pressure kills, and watchdog kills, plus daily peak footprint — iOS telling us directly why it terminated the app, no inference.
* **Live gauges** at upload time: current `phys_footprint`, and (full-statistics tier only) device RAM and `os_proc_available_memory` headroom.
* **Two executor counters**: WebContent-process terminations (incremented in the `didTerminate` handler from #2007) and JS watchdog timeouts. These matter doubly now: since #2007 caps wedges at 30 s, the multi-hour log signature I scanned for is gone — these counters are how we keep measuring wedge frequency after the fix hides it, and they measure it from *every* stats device, not just log sharers.

### What each tier sends

Devices on the minimal sharing level today send only `{id, Branch, created_at, Build_Version}`. With this PR the minimal ping gains app-behaviour numbers only — nothing about the person or the phone:

```json
"Memory": {
  "footprint_mb": 69,
  "peak_mb": 201,
  "counters": {
    "8.3.5(276)": {
      "peak_mb": 201,
      "pressure_warnings": 0, "jetsam_exits": 0, "pressure_exits": 0,
      "watchdog_exits": 0, "webcontent_terminations": 0, "js_timeouts": 0
    }
  }
}
```

The full-statistics tier additionally gets `"ram_mb": 7645, "available_mb": 3306` — those two narrow down the phone model class, so they are deliberately excluded from the minimal tier, where the model is not shared. Full field-by-field documentation (source, meaning, tier) is published at **https://open-iaps.app/statistics/memory-diagnostics**, which is also where the collected fleet data is reported.

### Design notes

* **Counters are bucketed per `version(build)`** so events never smear across an upgrade — "did this release make memory pressure better or worse" stays answerable per release. Composite keys because build number alone collides for local Xcode builds (CFBundleVersion stays 1) and version alone can't separate two builds of one release. Newest 6 buckets are retained; old ones freeze and have already been uploaded.
* **MetricKit counts are filed by the payload's own build metadata**, not the running build — MetricKit delivers a day late, so without this, every upgrade would dump the old build's last day of kills onto the new build.
* **Counters are monotonic** (UserDefaults, survives updates, resets only on reinstall); the server diffs successive uploads, so the app carries no upload-state bookkeeping and a failed upload loses nothing.
* MetricKit only delivers on physical devices — on simulators those fields simply stay `nil`. No entitlements, no new permissions, no user-facing strings.

### Tested

Running on my phone (built via Actions) and verified end-to-end: the block arrives in the open-iaps statistics intake and feeds the page above. My own numbers — 69 MB footprint, 201 MB daily peak against a ~3.4 GB allowance, all counters zero — are exactly what a healthy current-gen phone should report; the signal this exists for lives on the older, smaller-RAM devices once the fleet picks it up.

Files: `MemoryMetricsService.swift` (new, Helpers), `Statistics.swift` / `BareMinimum.swift` (optional `Memory` field), `APSManager.swift` (attach to both payloads), `WebViewScriptExecutor.swift` (two one-line counter hooks), `FreeAPSApp.swift` (start the MetricKit subscriber), pbxproj registration.
