### PR TITLE
libre 1-minute readings

### DIFF
--- a/FreeAPS/Sources/APS/AppCoordinator.swift
+++ b/FreeAPS/Sources/APS/AppCoordinator.swift
@@ -71,7 +71,7 @@ final class AppCoordinator: @unchecked Sendable {
     let glucoseSmoothed = CurrentValueSubject<[BloodGlucose], Never>([])
 
     // newest -> oldest
-    // this contains the glucose from glucoseSmoothed filtered by frequency (5min/1min, according to settings)
+    // this contains the glucose from glucoseSmoothed filtered by 5min frequency
     // this is consumed by OpenAPS, passed to oref0
     let glucoseFrequencyFiltered = CurrentValueSubject<[BloodGlucose], Never>([])
 

--- a/FreeAPS/Sources/APS/DeviceDataManager.swift
+++ b/FreeAPS/Sources/APS/DeviceDataManager.swift
@@ -324,6 +324,16 @@ final class BaseDeviceDataManager: DeviceDataManager, AppServiceSync {
             }
             .store(in: lifetime)
 
+        appCoordinator.settings
+            .removeDuplicates(by: {
+                $0.allowOneMinuteGlucose == $1.allowOneMinuteGlucose
+            })
+            .receive(on: processQueue)
+            .sink { [weak self] settings in
+                self?.setupLibre(settings: settings)
+            }
+            .store(in: lifetime)
+
         appCoordinator.settings.map(\.units).removeDuplicates()
             .receive(on: DispatchQueue.main) // important to be on main because of MainActor.assumeIsolated below
             .sink { units in
@@ -428,6 +438,12 @@ final class BaseDeviceDataManager: DeviceDataManager, AppServiceSync {
         }
 
         return Manager.init(rawState: rawState)
+    }
+
+    private func setupLibre(settings: FreeAPSSettings) {
+        dispatchPrecondition(condition: .onQueue(processQueue))
+        guard let cgmManager, KnownPlugins.isLibre2Cgm(pluginIdentifier: cgmManager.pluginIdentifier) else { return }
+        KnownPlugins.setupLibre2CgmInterval(everyMinute: settings.allowOneMinuteGlucose)
     }
 
     private func updatePumpData(completion: @escaping @Sendable() -> Void) {
@@ -1347,7 +1363,8 @@ private extension BaseDeviceDataManager {
         let status = CgmDisplayStatus(
             statusHighlight: (cgmManager as? CGMManagerUI)?.cgmStatusHighlight?.localizedMessage,
             sessionStartDate: KnownPlugins.sessionStart(cgmManager: cgmManager),
-            shouldUploadGlucose: cgmManager.shouldSyncToRemoteService || ConfigOverrides.allowUploadsFromNightscoutCGM
+            shouldUploadGlucose: cgmManager.shouldSyncToRemoteService || ConfigOverrides.allowUploadsFromNightscoutCGM,
+            oneMinuteReadings: KnownPlugins.isOneMinuteReadingsEnabled(for: cgmManager)
         )
 
         appCoordinator.setCgmStatus(status)
@@ -1366,6 +1383,8 @@ private extension BaseDeviceDataManager {
                 addDisplayGlucoseUnitObserver(cgmManagerUI)
             }
         }
+
+        setupLibre(settings: appCoordinator.settings.value)
 
         dispatchCgmInfo()
         dispatchCgmStatus()

--- a/FreeAPS/Sources/APS/KnownPlugins.swift
+++ b/FreeAPS/Sources/APS/KnownPlugins.swift
@@ -185,6 +185,23 @@ enum KnownPlugins {
         }
     }
 
+    static func isOneMinuteReadingsEnabled(for cgmManager: CGMManager) -> Bool {
+        switch cgmManager.pluginIdentifier {
+        case LibreTransmitterManagerV3.pluginIdentifier: return LibreTransmitter.Features.allowOneMinuteReadings
+        case LibreLoopCGMManager.pluginIdentifier:
+            return (cgmManager as? LibreLoopCGMManager)?.state.experimentalMinuteByMinuteForwarding ?? false
+        default: return false
+        }
+    }
+
+    static func isLibre2Cgm(pluginIdentifier: String) -> Bool {
+        pluginIdentifier == LibreTransmitterManagerV3.pluginIdentifier
+    }
+
+    static func setupLibre2CgmInterval(everyMinute: Bool) {
+        LibreTransmitter.Features.allowOneMinuteReadings = everyMinute
+    }
+
     static func pumpModel(_ pumpManager: PumpManager) -> String? {
         switch pumpManager.pluginIdentifier {
         case MinimedPumpManager.pluginIdentifier:

--- a/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
@@ -40,10 +40,10 @@ actor BaseGlucoseStorage: GlucoseStorage, AppService, LifetimeOwner {
         // both transforms must be explicitly @Sendable: plain closure literals formed here would be
         // inferred isolated to this actor, and Combine runs them synchronously on whatever executor
         // sends into the subject (SettingsManager's). Same fix as in BaseStateModel.
-        let extract: @Sendable(FreeAPSSettings) -> (Bool, Bool, Bool) = {
-            ($0.smoothGlucose, $0.orefOneMinuteGlucose, $0.allowOneMinuteLoop)
+        let extract: @Sendable(FreeAPSSettings) -> (Bool, Bool) = {
+            ($0.smoothGlucose, $0.allowOneMinuteLoop)
         }
-        let isDuplicate: @Sendable((Bool, Bool, Bool), (Bool, Bool, Bool)) -> Bool = { $0 == $1 }
+        let isDuplicate: @Sendable((Bool, Bool), (Bool, Bool)) -> Bool = { $0 == $1 }
 
         observe(
             appCoordinator.settings
@@ -194,8 +194,7 @@ actor BaseGlucoseStorage: GlucoseStorage, AppService, LifetimeOwner {
             }
         }
 
-        let minInterval = appCoordinator.settings.value.orefOneMinuteGlucose ? Self.filterIntervalOneMinute : Self
-            .filterIntervalFiveMinutes
+        let minInterval = Self.filterIntervalFiveMinutes
         let frequencyFiltered = FrequentGlucoseFiltering.filterFrequentGlucose(smoothed, interval: minInterval)
 
         // push alarm must happen before setGlucoseHistory

--- a/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
+++ b/FreeAPS/Sources/APS/Storage/GlucoseStorage.swift
@@ -41,7 +41,7 @@ actor BaseGlucoseStorage: GlucoseStorage, AppService, LifetimeOwner {
         // inferred isolated to this actor, and Combine runs them synchronously on whatever executor
         // sends into the subject (SettingsManager's). Same fix as in BaseStateModel.
         let extract: @Sendable(FreeAPSSettings) -> (Bool, Bool, Bool) = {
-            ($0.smoothGlucose, $0.allowOneMinuteGlucose, $0.allowOneMinuteLoop)
+            ($0.smoothGlucose, $0.orefOneMinuteGlucose, $0.allowOneMinuteLoop)
         }
         let isDuplicate: @Sendable((Bool, Bool, Bool), (Bool, Bool, Bool)) -> Bool = { $0 == $1 }
 
@@ -194,7 +194,7 @@ actor BaseGlucoseStorage: GlucoseStorage, AppService, LifetimeOwner {
             }
         }
 
-        let minInterval = appCoordinator.settings.value.allowOneMinuteGlucose ? Self.filterIntervalOneMinute : Self
+        let minInterval = appCoordinator.settings.value.orefOneMinuteGlucose ? Self.filterIntervalOneMinute : Self
             .filterIntervalFiveMinutes
         let frequencyFiltered = FrequentGlucoseFiltering.filterFrequentGlucose(smoothed, interval: minInterval)
 

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -2620,6 +2620,12 @@ Enact a temp Basal or a temp target */
 /* Smoothing of CGM readings */
 "Smooth Glucose Value" = "Smooth Glucose Value";
   
+
+/* Libre CGM settings */
+"Libre" = "Libre";
+"1-minute readings" = "1-minute readings";
+"Read the sensor every minute instead of every 5 minutes." = "Read the sensor every minute instead of every 5 minutes.";
+
 /* ------------------------------------------- Sharing -------------------------------------------------------*/
 
 /* Setting Title */

--- a/FreeAPS/Sources/Models/CgmDisplayInfo.swift
+++ b/FreeAPS/Sources/Models/CgmDisplayInfo.swift
@@ -18,4 +18,5 @@ struct CgmDisplayStatus: Equatable, Sendable {
     let statusHighlight: String?
     let sessionStartDate: Date?
     let shouldUploadGlucose: Bool
+    let oneMinuteReadings: Bool
 }

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -160,7 +160,6 @@ struct FreeAPSSettings: JSON, Equatable, Sendable {
     // 1-min loops
     var allowOneMinuteLoop: Bool = false // allow running loops every minute
     var allowOneMinuteGlucose: Bool = false // allow receiving 1-minute readings from libre2
-    var orefOneMinuteGlucose: Bool = false // allow sending 1-minute readings to oref, even if loops are with 5-minute intervals
 
     var ai: Bool = true
     var mealViewMicronutrients: Bool = false
@@ -805,9 +804,6 @@ extension FreeAPSSettings: Decodable {
         }
         if let allowOneMinuteGlucose = try? container.decode(Bool.self, forKey: .allowOneMinuteGlucose) {
             settings.allowOneMinuteGlucose = allowOneMinuteGlucose
-        }
-        if let orefOneMinuteGlucose = try? container.decode(Bool.self, forKey: .orefOneMinuteGlucose) {
-            settings.orefOneMinuteGlucose = orefOneMinuteGlucose
         }
 
         if let ai = try? container.decode(Bool.self, forKey: .ai) {

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -159,7 +159,9 @@ struct FreeAPSSettings: JSON, Equatable, Sendable {
     var ketoProtectBasalAbsolut: Decimal = 0
     // 1-min loops
     var allowOneMinuteLoop: Bool = false // allow running loops every minute
-    var allowOneMinuteGlucose: Bool = false // allow sending 1-minute readings to oref, even if loops are with 5-minute intervals
+    var allowOneMinuteGlucose: Bool = false // allow receiving 1-minute readings from libre2
+    var orefOneMinuteGlucose: Bool = false // allow sending 1-minute readings to oref, even if loops are with 5-minute intervals
+
     var ai: Bool = true
     var mealViewMicronutrients: Bool = false
     var nightTime = NightTimeConfiguration.default
@@ -803,6 +805,9 @@ extension FreeAPSSettings: Decodable {
         }
         if let allowOneMinuteGlucose = try? container.decode(Bool.self, forKey: .allowOneMinuteGlucose) {
             settings.allowOneMinuteGlucose = allowOneMinuteGlucose
+        }
+        if let orefOneMinuteGlucose = try? container.decode(Bool.self, forKey: .orefOneMinuteGlucose) {
+            settings.orefOneMinuteGlucose = orefOneMinuteGlucose
         }
 
         if let ai = try? container.decode(Bool.self, forKey: .ai) {

--- a/FreeAPS/Sources/Models/oref0/RecentCarbs.swift
+++ b/FreeAPS/Sources/Models/oref0/RecentCarbs.swift
@@ -6,7 +6,7 @@ struct RecentCarbs: Codable, Sendable {
     var bwCarbs: Double
     var journalCarbs: Double
     var mealCOB: Double
-    var currentDeviation: Double
+    var currentDeviation: Double?
     var maxDeviation: Double
     var minDeviation: Double
     var slopeFromMaxDeviation: Double

--- a/FreeAPS/Sources/Modules/CGM/CGMStateModel.swift
+++ b/FreeAPS/Sources/Modules/CGM/CGMStateModel.swift
@@ -14,6 +14,7 @@ extension CGM {
         @Published private(set) var cgmIdentifierToSetUp: String? = nil
 
         @Published var smoothGlucose = false
+        @Setting(\.allowOneMinuteGlucose) var allowOneMinuteGlucose = false
         @Published var sensorDays: Double = 10
 
         override func subscribe() async {

--- a/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
+++ b/FreeAPS/Sources/Modules/CGM/View/CGMRootView.swift
@@ -22,9 +22,20 @@ extension CGM {
             _state = StateObject(wrappedValue: StateModel(resolver: resolver))
         }
 
+        private func libre2Section() -> some View {
+            Section {
+                Toggle("1-minute readings", isOn: $state.allowOneMinuteGlucose)
+            }
+            header: { Text("Libre") }
+            footer: {
+                Text("Read the sensor every minute instead of every 5 minutes.")
+            }
+        }
+
         var body: some View {
             let cgmInfo = appUIState.cgmInfo
             let cgmStatus = appUIState.cgmStatus
+            let isLibre2 = cgmInfo.map { KnownPlugins.isLibre2Cgm(pluginIdentifier: $0.identifier) } ?? false
             NavigationView {
                 Form {
                     if let cgmInfo = cgmInfo, cgmInfo.isOnboarded, !cgmInfo.pumpIsCgm
@@ -85,7 +96,7 @@ extension CGM {
                         }
                     }
 
-                    if let cgmInfo = cgmInfo, cgmInfo.isOnboarded
+                    if let cgmInfo, cgmInfo.isOnboarded
                     {
                         if cgmInfo.allowCalibrations
                         {
@@ -107,6 +118,10 @@ extension CGM {
                                     "When using \(cgmInfo.name) iAPS doesn't know the type of sensor used or the sensor life-span."
                                 )
                             }
+                        }
+
+                        if isLibre2 {
+                            libre2Section()
                         }
 
                         Section(header: Text("Experimental")) {

--- a/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
+++ b/FreeAPS/Sources/Modules/Home/HomeStateModel.swift
@@ -48,7 +48,12 @@ extension Home {
         @Published var totalBolus: Decimal = 0
         @Published var isStatusPopupPresented: Bool = false
         @Published var readings: [ReadingsSnapshot] = []
-        @Published var loopStatistics: (Int, Int, Double, String) = (0, 0, 0, "")
+        @Published var loopStatistics: (loops: Int, readings: Int, percentage: Double, averageInterval: String) = (
+            loops: 0,
+            readings: 0,
+            percentage: 0,
+            averageInterval: ""
+        )
         @Published var standing: Bool = false
         @Published var preview: Bool = true
         @Published var useTargetButton: Bool = false
@@ -458,23 +463,41 @@ extension Home {
 
         private func setupLoopStatsBackground() {
             Task {
-                let loopStats = await self.coreDataStorage.fetchLoopStats(interval: DateFilter.today.startDate)
-                let readings = await self.coreDataStorage.fetchGlucose(interval: DateFilter.today.startDate).compactMap(\.glucose)
-                    .count
+                let todayStart = DateFilter.today.startDate
+                let todayStartDate = DateFilter.today.startDate as Date
+                let allowOneMinuteLoop = appCoordinator.settings.value.allowOneMinuteLoop
+                let glucoseRaw = appCoordinator.glucoseRaw.value
+                let glucoseFrequencyFiltered = appCoordinator.glucoseFrequencyFiltered.value
+                let readings = appCoordinator.glucoseRaw.value.count { $0.dateString >= todayStartDate }
+                let loopStats = await self.coreDataStorage.fetchLoopStats(interval: todayStart)
 
                 let result = await Task.detached {
-                    let loops = loopStats.compactMap({ each in each.loopStatus }).count
-                    let percentage = min(readings != 0 ? (Double(loops) / Double(readings) * 100) : 0, 100)
-                    // First loop date
-                    let time = (loopStats.last?.start ?? Date.now).subtractingTimeInterval(.minutes(5))
+                    let expectedLoops = allowOneMinuteLoop ?
+                        glucoseRaw.count { $0.dateString >= todayStartDate } :
+                        glucoseFrequencyFiltered.count { $0.dateString >= todayStartDate }
 
-                    let average = -1 * (time.timeIntervalSinceNow / 60) / max(Double(loops), 1)
+                    let loops = loopStats.count { $0.loopStatus == "Success" }
+                    let percentage = expectedLoops == 0 ? 0.0 : min(Double(loops) / Double(expectedLoops) * 100, 100)
+
+                    let loopStarts = loopStats
+                        .compactMap(\.start)
+                        .sorted()
+
+                    let intervals = zip(loopStarts, loopStarts.dropFirst()).map { previous, next in
+                        next.timeIntervalSince(previous) / 60
+                    }
+
+                    let averageInterval = intervals.isEmpty
+                        ? nil
+                        : intervals.reduce(0, +) / Double(intervals.count)
 
                     return (
-                        loops,
-                        readings,
-                        percentage,
-                        average.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1))) + " min"
+                        loops: loops,
+                        readings: readings,
+                        percentage: percentage,
+                        averageInterval: averageInterval
+                            .map { $0.formatted(.number.grouping(.never).rounded().precision(.fractionLength(1))) + " min" } ??
+                            "-"
                     )
                 }.value
                 self.loopStatistics = result

--- a/FreeAPS/Sources/Modules/Home/View/Previews/LoopsView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Previews/LoopsView.swift
@@ -3,7 +3,7 @@ import Foundation
 import SwiftUI
 
 struct LoopsView: View {
-    let loopStatistics: (Int, Int, Double, String)
+    let loopStatistics: (loops: Int, readings: Int, percentage: Double, averageInterval: String)
 
     private var formatter: NumberFormatter {
         let formatter = NumberFormatter()
@@ -14,10 +14,9 @@ struct LoopsView: View {
 
     var body: some View {
         VStack {
-            // Data
-            let loops = loopStatistics.0
-            let readings = loopStatistics.1
-            let percentage = loopStatistics.2
+            let loops = loopStatistics.loops
+            let readings = loopStatistics.readings
+            let percentage = loopStatistics.percentage
 
             Text(NSLocalizedString("Loops", comment: ""))
                 .padding(.bottom, 10).font(.previewHeadline)
@@ -26,7 +25,7 @@ struct LoopsView: View {
 
             HStack {
                 Text("Average Interval")
-                Text(loopStatistics.3)
+                Text(loopStatistics.averageInterval)
             }.font(.loopFont)
 
             HStack {

--- a/FreeAPS/Sources/Services/Network/NightscoutUploads/NightscoutConversions.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutUploads/NightscoutConversions.swift
@@ -248,6 +248,9 @@ actor CgmStateRecorder {
     private let storage: FileStorage
     private var lastSeenStart: Date?
 
+    /// How far two reported session starts must be apart to count as different sensors.
+    private static let sessionTolerance: TimeInterval = .minutes(30)
+
     init(storage: FileStorage) {
         self.storage = storage
     }
@@ -255,7 +258,7 @@ actor CgmStateRecorder {
     /// records a new sensor start if the status carries one; returns whether the log changed
     func noteStatus(_ cgmStatus: CgmDisplayStatus?) async -> Bool {
         guard let sessionStartDate = cgmStatus?.sessionStartDate,
-              abs(sessionStartDate.timeIntervalSince(lastSeenStart ?? .distantPast)) > 60
+              abs(sessionStartDate.timeIntervalSince(lastSeenStart ?? .distantPast)) > Self.sessionTolerance
         else { return false }
         lastSeenStart = sessionStartDate
         return await recordSensorStartIfNeeded(sessionStartDate)
@@ -281,11 +284,12 @@ actor CgmStateRecorder {
             .maybeModify(file: OpenAPS.Monitor.cgmState, as: NigtscoutTreatment.self) { inStorage in
                 // For Dexcom, each glucose event contains the sessionStartDate (which contains the correct timestamp of the latest sensor start)
                 // We only need to send the "Sensor Start" event once per change.
-                // This guard ensures we send a new "Sensor Start" event to NS only if the previously sent event happened more than 60 seconds before this one.
+                // This guard ensures we send a new "Sensor Start" event to NS only if the previously sent event happened
+                // more than `sessionTolerance` before this one.
                 //
-                // As a side effect, if there is jitter in the sessionStartDate (+/- few milliseconds each time), we will flood NS with the duplicated Session Start events over time.
+                // Without it, sources that jitter the sessionStartDate flood NS with duplicate Session Start events.
                 // See: https://github.com/Artificial-Pancreas/iAPS/issues/1806
-                if inStorage.contains(where: { abs($0.createdAt.timeIntervalSince(sessionStartDate)) < 60 }) {
+                if inStorage.contains(where: { abs($0.createdAt.timeIntervalSince(sessionStartDate)) < Self.sessionTolerance }) {
                     return nil // do not modify
                 }
 


### PR DESCRIPTION
* adding a toggle to enable 1-minute readings in Libre 2
* Libre 3 has this toggle built-in
* add `oneMinuteReadings: Bool` to CGM info
* nightscout uploads - account for constant drift in session-start reported by Libre 2
* separate settings: `var allowOneMinuteGlucose: Bool = false` (Libre2) and `var orefOneMinuteGlucose: Bool = false` (whether to send 1-minute readings to oref0, off by default, no UI to enable it for now - need more work on the oref0 side)