### PR TITLE
Footprint checkpoint logging + commit identity in memory counter buckets

### DIFF
--- a/FreeAPS.xcodeproj/project.pbxproj
+++ b/FreeAPS.xcodeproj/project.pbxproj
@@ -309,6 +309,7 @@
 		38E98A2D25F52DC400C0CED0 /* NSLocking+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */; };
 		F2A11C1230200B0100EF9230 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A11C1130200B0100EF9230 /* Timeout.swift */; };
 		F2B33E0230220D0300EF9402 /* MemoryMetricsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B33E0130220D0300EF9401 /* MemoryMetricsService.swift */; };
+		F2C44F0230230E0400EF9502 /* FootprintLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2C44F0130230E0400EF9501 /* FootprintLog.swift */; };
 		38E98A3025F52FF700C0CED0 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A2F25F52FF700C0CED0 /* Config.swift */; };
 		38E98A3725F5509500C0CED0 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E98A3625F5509500C0CED0 /* String+Extensions.swift */; };
 		38EA05DA261F6E7C0064E39B /* SimpleLogReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38EA05D9261F6E7C0064E39B /* SimpleLogReporter.swift */; };
@@ -1007,6 +1008,7 @@
 		38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSLocking+Extensions.swift"; sourceTree = "<group>"; };
 		F2A11C1130200B0100EF9230 /* Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Timeout.swift; sourceTree = "<group>"; };
 		F2B33E0130220D0300EF9401 /* MemoryMetricsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoryMetricsService.swift; sourceTree = "<group>"; };
+		F2C44F0130230E0400EF9501 /* FootprintLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FootprintLog.swift; sourceTree = "<group>"; };
 		38E98A2F25F52FF700C0CED0 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		38E98A3625F5509500C0CED0 /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		38EA05D9261F6E7C0064E39B /* SimpleLogReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleLogReporter.swift; sourceTree = "<group>"; };
@@ -2233,6 +2235,7 @@
 				38E98A2C25F52DC400C0CED0 /* NSLocking+Extensions.swift */,
 				F2A11C1130200B0100EF9230 /* Timeout.swift */,
 				F2B33E0130220D0300EF9401 /* MemoryMetricsService.swift */,
+				F2C44F0130230E0400EF9501 /* FootprintLog.swift */,
 				38C4D33925E9A1ED00D30B77 /* NSObject+AssociatedValues.swift */,
 				3811DE5725C9D4D500A708ED /* ProgressBar.swift */,
 				3811DE5525C9D4D500A708ED /* Publisher.swift */,
@@ -3796,6 +3799,7 @@
 				38E98A2D25F52DC400C0CED0 /* NSLocking+Extensions.swift in Sources */,
 				F2A11C1230200B0100EF9230 /* Timeout.swift in Sources */,
 				F2B33E0230220D0300EF9402 /* MemoryMetricsService.swift in Sources */,
+				F2C44F0230230E0400EF9502 /* FootprintLog.swift in Sources */,
 				19C3C72F2E97AE520000BE4D /* SearchResultsView.swift in Sources */,
 				19C3C7302E97AE520000BE4D /* FoodSearchStateModel.swift in Sources */,
 				19C3C7312E97AE520000BE4D /* BarcodeScannerService.swift in Sources */,

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -1352,25 +1352,7 @@ final class BaseAPSManager: APSManager, Injectable {
     }
 
     private func branch() -> String {
-        var branch = "Unknown"
-        if let branchFileURL = Bundle.main.url(forResource: "branch", withExtension: "txt"),
-           let branchFileContent = try? String(contentsOf: branchFileURL)
-        {
-            let lines = branchFileContent.components(separatedBy: .newlines)
-            for line in lines {
-                let components = line.components(separatedBy: "=")
-                if components.count == 2 {
-                    let key = components[0].trimmingCharacters(in: .whitespaces)
-                    let value = components[1].trimmingCharacters(in: .whitespaces)
-
-                    if key == "BRANCH" {
-                        branch = value
-                        break
-                    }
-                }
-            }
-        }
-        return branch
+        Bundle.main.gitBranch ?? "Unknown"
     }
 
     private func loopStats(loopStatRecord: LoopStats, error: Error?) {

--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -224,6 +224,7 @@ final class BaseAPSManager: APSManager, Injectable {
         }
 
         debug(.apsManager, "Starting loop with a delay of \(UIApplication.shared.backgroundTimeRemaining.rounded())")
+        FootprintLog.log("loop start")
 
         lastStartLoopDate = Date()
 
@@ -288,6 +289,7 @@ final class BaseAPSManager: APSManager, Injectable {
 
     // Loop exit point
     private func loopCompleted(error: Error? = nil, loopStatRecord: LoopStats) {
+        FootprintLog.log("loop end")
         appCoordinator.isLooping.send(false)
 
         if let apsError = error {
@@ -560,7 +562,10 @@ final class BaseAPSManager: APSManager, Injectable {
     }
 
     func autotune() -> AnyPublisher<Autotune?, Never> {
-        openAPS.autotune().eraseToAnyPublisher()
+        FootprintLog.log("autotune start")
+        return openAPS.autotune()
+            .handleEvents(receiveOutput: { _ in FootprintLog.log("autotune end") })
+            .eraseToAnyPublisher()
     }
 
     func enactAnnouncement(_ announcement: Announcement) {
@@ -1063,6 +1068,8 @@ final class BaseAPSManager: APSManager, Injectable {
             return
         }
 
+        FootprintLog.log("statistics start")
+
         if settings.uploadStats {
             let units = settings.units
             let preferences = settingsManager.preferences
@@ -1316,6 +1323,7 @@ final class BaseAPSManager: APSManager, Injectable {
             )
             nightscout.uploadVersion(json: json)
         }
+        FootprintLog.log("statistics end")
     }
 
     private func getIdentifier() -> String {

--- a/FreeAPS/Sources/Application/FreeAPSApp.swift
+++ b/FreeAPS/Sources/Application/FreeAPSApp.swift
@@ -145,6 +145,7 @@ private struct LaunchedAppView: View {
             .environmentObject(appServices)
             .onChange(of: scenePhase) {
                 debug(.default, "APPLICATION PHASE: \(scenePhase)")
+                FootprintLog.log("app \(scenePhase)")
                 if scenePhase == .active {
                     appServices.deviceManager.didBecomeActive()
                 }

--- a/FreeAPS/Sources/Helpers/Bundle+Extensions.swift
+++ b/FreeAPS/Sources/Helpers/Bundle+Extensions.swift
@@ -9,6 +9,25 @@ extension Bundle {
         infoDictionary?["CFBundleVersion"] as? String
     }
 
+    /// "<branch-or-tag> <short sha>" as written into branch.txt by the build phase
+    /// (e.g. "dev 81a532e"). The commit is the identity of the code that is running —
+    /// build numbers are per-builder counters and version alone spans many commits.
+    /// Nil when branch.txt is missing or malformed.
+    var gitBranch: String? {
+        guard let url = url(forResource: "branch", withExtension: "txt"),
+              let content = try? String(contentsOf: url)
+        else { return nil }
+        for line in content.components(separatedBy: .newlines) {
+            let parts = line.components(separatedBy: "=")
+            guard parts.count == 2,
+                  parts[0].trimmingCharacters(in: .whitespaces) == "BRANCH"
+            else { continue }
+            let value = parts[1].trimmingCharacters(in: .whitespaces)
+            return value.isEmpty ? nil : value
+        }
+        return nil
+    }
+
     var buildDate: Date {
         if let infoPath = Bundle.main.path(forResource: "Info", ofType: "plist"),
            let infoAttr = try? FileManager.default.attributesOfItem(atPath: infoPath),

--- a/FreeAPS/Sources/Helpers/FootprintLog.swift
+++ b/FreeAPS/Sources/Helpers/FootprintLog.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Writes the app's current physical memory footprint into the device log at named
+/// checkpoints, so a MetricKit daily peak can be bracketed between known activities
+/// without attaching Instruments (which distorts normal behaviour too much to be
+/// representative).
+///
+/// Cost per call is one `task_info` syscall plus one log line — microseconds, safe
+/// from any thread, no timers and no state. At the current checkpoints (loop
+/// start/end, autotune, statistics build, app phase changes) that is roughly 600
+/// log lines a day, a rounding error against normal log volume.
+enum FootprintLog {
+    static func log(_ tag: String) {
+        guard let mb = currentFootprintMB() else { return }
+        debug(.apsManager, "MEMORY: footprint \(mb) MB [\(tag)]")
+    }
+
+    private static func currentFootprintMB() -> Int? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return Int(info.phys_footprint / 1_048_576)
+    }
+}

--- a/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
+++ b/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
@@ -93,6 +93,12 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
     /// Call once at app start.
     func start() {
         MXMetricManager.shared.add(self)
+        // Materialise the running build's bucket immediately (zero-filled), so
+        // "this build ran and recorded no incidents" is an explicit row rather than
+        // an absence — otherwise a bucket only appears on the first incident or
+        // MetricKit payload, and a clean build is indistinguishable from one that
+        // never ran.
+        Self.mutateBucket(key: Self.currentBucketKey()) { _ in }
         // Foundation-qualified: the app defines its own NotificationCenter protocol for DI.
         Foundation.NotificationCenter.default.addObserver(
             forName: UIApplication.didReceiveMemoryWarningNotification,

--- a/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
+++ b/FreeAPS/Sources/Helpers/MemoryMetricsService.swift
@@ -17,11 +17,11 @@ struct MemoryStats: JSON, Equatable {
     var footprint_mb: Int?
     /// Peak footprint over the last MetricKit reporting day, MB (any release).
     var peak_mb: Int?
-    /// Incident counters, bucketed by the release they occurred under, so a
+    /// Incident counters, bucketed by the build they occurred under, so a
     /// release-over-release comparison never smears events across an upgrade.
-    /// Keys are "version(build)" composites ("8.3.5(274)") — build number alone is
-    /// ambiguous because plain Xcode builds don't increment it, and version alone
-    /// can't separate two builds of the same release. The newest 6 buckets are retained.
+    /// Keys are "version(build)" composites ("8.3.5(274)"), unique per device; the
+    /// commit each bucket was built from is recorded inside the bucket (`branch`),
+    /// which is what aggregates across devices. The newest 6 buckets are retained.
     var counters: [String: MemoryVersionCounters]?
     /// Physical RAM of the device, MB. Full statistics only.
     var ram_mb: Int?
@@ -33,6 +33,13 @@ struct MemoryStats: JSON, Equatable {
 /// runs and only ever grow, so the latest uploaded value IS the build's total —
 /// no server-side diffing needed for per-version numbers.
 struct MemoryVersionCounters: JSON, Equatable {
+    /// "<branch> <sha>" the build came from (branch.txt), e.g. "dev 81a532e" — the
+    /// code identity that is comparable across devices. Build numbers are not: each
+    /// builder's Actions run counter differs and local Xcode builds stay at 1.
+    var branch: String?
+    /// When this bucket was created, i.e. when this build first ran on the device.
+    /// Lets the server turn counts into rates (incidents per day on that build).
+    var since: Date?
     /// Highest MetricKit daily peak recorded while this build ran, MB.
     var peak_mb: Int?
     /// UIKit memory-pressure warnings received.
@@ -50,6 +57,8 @@ struct MemoryVersionCounters: JSON, Equatable {
     var js_timeouts: Int
 
     init() {
+        branch = nil
+        since = nil
         peak_mb = nil
         pressure_warnings = 0
         jetsam_exits = 0
@@ -98,7 +107,7 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
         // an absence — otherwise a bucket only appears on the first incident or
         // MetricKit payload, and a clean build is indistinguishable from one that
         // never ran.
-        Self.mutateBucket(key: Self.currentBucketKey()) { _ in }
+        Self.mutateCurrentBucket { _ in }
         // Foundation-qualified: the app defines its own NotificationCenter protocol for DI.
         Foundation.NotificationCenter.default.addObserver(
             forName: UIApplication.didReceiveMemoryWarningNotification,
@@ -112,7 +121,7 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
     /// Static so call sites (WebViewScriptExecutor) don't need the singleton started first.
     /// Files the event under the currently running release.
     static func increment(_ counter: Counter) {
-        mutateBucket(key: currentBucketKey()) { bucket in
+        mutateCurrentBucket { bucket in
             switch counter {
             case .pressureWarnings: bucket.pressure_warnings += 1
             case .jetsamExits: bucket.jetsam_exits += 1
@@ -145,14 +154,12 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
 
     func didReceive(_ payloads: [MXMetricPayload]) {
         for payload in payloads {
-            // The payload names the release it describes; use it so a day's counts that
-            // arrive after an upgrade still land on the build they happened under.
-            let key: String
-            if let build = payload.metaData?.applicationBuildVersion {
-                key = Self.bucketKey(version: payload.latestApplicationVersion, build: build)
-            } else {
-                key = Self.currentBucketKey()
-            }
+            // The payload names the build it describes; file under that build so a day's
+            // counts that arrive after an upgrade still land where they happened. MetricKit
+            // knows version + build number but not the commit, so this resolves to the
+            // bucket for that (version, build) — the newest one if several exist.
+            let target: (version: String, build: String)? = payload.metaData
+                .map { (payload.latestApplicationVersion, $0.applicationBuildVersion) }
 
             if let exits = payload.applicationExitMetrics {
                 let fg = exits.foregroundExitData
@@ -161,7 +168,7 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
                 let pressure = bg.cumulativeMemoryPressureExitCount
                 let watchdog = fg.cumulativeAppWatchdogExitCount + bg.cumulativeAppWatchdogExitCount
                 if jetsam + pressure + watchdog > 0 {
-                    Self.mutateBucket(key: key) { bucket in
+                    Self.mutateBucket(matching: target) { bucket in
                         bucket.jetsam_exits += jetsam
                         bucket.pressure_exits += pressure
                         bucket.watchdog_exits += watchdog
@@ -171,7 +178,7 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
             if let memory = payload.memoryMetrics {
                 let mb = Int(memory.peakMemoryUsage.converted(to: .megabytes).value.rounded())
                 UserDefaults.standard.set(mb, forKey: Self.latestPeakKey)
-                Self.mutateBucket(key: key) { bucket in
+                Self.mutateBucket(matching: target) { bucket in
                     bucket.peak_mb = max(bucket.peak_mb ?? 0, mb)
                 }
             }
@@ -180,28 +187,86 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
 
     // MARK: - Bucket storage
 
-    private static func mutateBucket(
-        key: String,
-        _ change: (inout MemoryVersionCounters) -> Void
-    ) {
+    /// Mutate the bucket for the build that is running right now, creating it if needed.
+    ///
+    /// The bucket key is "version(build)". That is unique for Actions builds (the run
+    /// counter increments) but a local Xcode build keeps build number 1 across commits,
+    /// so the key alone would merge different code into one bucket. Hence: if the key's
+    /// bucket exists but was created from a different commit, this build gets its own
+    /// bucket keyed "version(build) sha". A bucket that predates the `branch` field
+    /// (earlier instrumented builds) is adopted by the running commit.
+    private static func mutateCurrentBucket(_ change: (inout MemoryVersionCounters) -> Void) {
         lock.lock()
         defer { lock.unlock() }
 
         var map = loadMap()
+        let base = currentBucketKey()
+        let branch = Bundle.main.gitBranch
+        let key: String
+        if let existing = map[base], let owner = existing.branch, let branch, owner != branch {
+            // Same version + build number, different commit — a local rebuild.
+            let sha = branch.split(separator: " ").last.map(String.init) ?? branch
+            key = "\(base) \(sha)"
+        } else {
+            key = base
+        }
+        mutate(&map, key: key, branch: branch, change)
+        store(map)
+    }
+
+    /// Mutate the bucket for a (version, build) named by a MetricKit payload — the newest
+    /// bucket carrying that composite, or a fresh one if none exists. Falls back to the
+    /// running build when the payload has no metadata.
+    private static func mutateBucket(
+        matching target: (version: String, build: String)?,
+        _ change: (inout MemoryVersionCounters) -> Void
+    ) {
+        guard let target else {
+            mutateCurrentBucket(change)
+            return
+        }
+        lock.lock()
+        defer { lock.unlock() }
+
+        var map = loadMap()
+        let base = bucketKey(version: target.version, build: target.build)
+        let candidates = map.filter { $0.key == base || $0.key.hasPrefix(base + " ") }
+        let key = candidates.max { ($0.value.since ?? .distantPast) < ($1.value.since ?? .distantPast) }?.key ?? base
+        // A brand-new bucket for the running build can be stamped with the running commit;
+        // one for an older build cannot (we don't know it), the server resolves that from history.
+        let branch = base == currentBucketKey() ? Bundle.main.gitBranch : nil
+        mutate(&map, key: key, branch: branch, change)
+        store(map)
+    }
+
+    /// Caller holds `lock`.
+    private static func mutate(
+        _ map: inout [String: MemoryVersionCounters],
+        key: String,
+        branch: String?,
+        _ change: (inout MemoryVersionCounters) -> Void
+    ) {
         var bucket = map[key] ?? MemoryVersionCounters()
+        if bucket.since == nil { bucket.since = Date() }
+        if bucket.branch == nil { bucket.branch = branch }
         change(&bucket)
         map[key] = bucket
 
-        // Prune oldest buckets (release order: version tuple, then build) beyond the cap.
+        // Prune oldest buckets beyond the cap: version tuple, then build number, then age.
         if map.count > maxBuckets {
-            let sorted = map.keys.sorted {
-                releaseOrder($0).lexicographicallyPrecedes(releaseOrder($1))
+            let sorted = map.sorted { a, b in
+                let ra = releaseOrder(a.key), rb = releaseOrder(b.key)
+                if ra != rb { return ra.lexicographicallyPrecedes(rb) }
+                return (a.value.since ?? .distantPast) < (b.value.since ?? .distantPast)
             }
-            for key in sorted.prefix(map.count - maxBuckets) {
-                map.removeValue(forKey: key)
+            for entry in sorted.prefix(map.count - maxBuckets) {
+                map.removeValue(forKey: entry.key)
             }
         }
+    }
 
+    /// Caller holds `lock`.
+    private static func store(_ map: [String: MemoryVersionCounters]) {
         if let data = try? JSONCoding.encoder.encode(map) {
             UserDefaults.standard.set(data, forKey: storageKey)
         }
@@ -216,8 +281,7 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
         return map
     }
 
-    /// "8.3.5(274)" — version alone collides across builds of one release, build alone
-    /// collides across releases (plain Xcode builds don't increment it).
+    /// "8.3.5(274)" — version + build number, unique per device.
     private static func bucketKey(version: String?, build: String) -> String {
         "\(version ?? "?")(\(build))"
     }
@@ -227,9 +291,11 @@ final class MemoryMetricsService: NSObject, MXMetricManagerSubscriber {
     }
 
     /// Sortable release order for pruning: version numbers first, build number last.
+    /// Only the "version(build)" part is parsed — a sha suffix is not a number.
     /// Unparseable keys sort oldest (pruned first).
     private static func releaseOrder(_ key: String) -> [Int] {
-        let parts = key.split(whereSeparator: { !$0.isNumber }).compactMap { Int($0) }
+        let head = key.split(separator: " ").first.map(String.init) ?? key
+        let parts = head.split(whereSeparator: { !$0.isNumber }).compactMap { Int($0) }
         return parts.isEmpty ? [-1] : parts
     }
 


### PR DESCRIPTION
Follow-up to #2017, as promised there — two small pieces:

**1. Footprint checkpoint logging** (`FootprintLog.swift`): one debug-log line with the current `phys_footprint` at the moments that matter — loop start/end, autotune start/end, statistics build start/end, and app phase changes (active/inactive/background). This is for the question Instruments can't reasonably answer on a phone that's looping someone's real life: *what* drives the daily memory peaks. Zero cost when nothing reads it; it's just debug lines in the existing log.

First day of data from my own phone (iPhone 17,1) already gives an answer:

| checkpoint | n | min | avg | max |
|---|---|---|---|---|
| loop start | 94 | 42 MB | 45 MB | 49 MB |
| loop end | 94 | 43 MB | 45 MB | 50 MB |
| autotune start → end | 1 | 44 → 44 MB | | |
| statistics start → end | 1 | 45 → 55 MB | | |
| app active (UI open) | 1 | **96 MB** | | |

The background loop is flat at ~45 MB all day — no growth across 94 cycles, autotune free, statistics +10 MB released afterwards. Opening the UI doubles the footprint on the spot. So the 150–200 MB MetricKit daily peaks we're seeing (437 MB on an SE 3 in the fleet) are foreground/UI-session driven, not loop driven — worth knowing before anyone goes hunting for a loop-side leak.

**2. Counter buckets learn their commit** (follows from what the first fleet days showed on #2017): bucketing by version+build number turned out not to aggregate across devices — the build number is each builder's own Actions run counter, so the same `dev 81a532e` shows up as build 482, 278, 154, 56 and 1 on five different phones. Each bucket now records `branch` (the `branch.txt` "<branch> <sha>" string, i.e. the actual code identity) and `since` (when that build first ran on the device, so counts can become per-day rates). A local Xcode rebuild of the same version at build 1 gets its own bucket instead of merging with the previous commit's; MetricKit payloads (which know version+build but not commit) file into the newest matching bucket. `branch.txt` parsing moved to a shared `Bundle.gitBranch` so APSManager and the bucket code read it the same way.

Both additive; the server side already handles old and new payload shapes. Running on my phone since yesterday — the numbers above and the per-commit fleet view at https://open-iaps.app/statistics/memory-diagnostics are produced by this build.
