### PR TITLE
Report the raw machine identifier instead of maintaining a device-name table in-app

### DIFF
--- a/FreeAPS/Sources/Helpers/UIDevice+Extensions.swift
+++ b/FreeAPS/Sources/Helpers/UIDevice+Extensions.swift
@@ -10,75 +10,7 @@ extension UIDevice {
             return identifier + String(UnicodeScalar(UInt8(value)))
         }
 
-        func mapToDevice(identifier: String) -> String {
-            switch identifier {
-            case "iPhone10,1":
-                return "iPhone 8"
-            case "iPhone10,2":
-                return "iPhone 8 Plus"
-            case "iPhone10,4":
-                return "iPhone 8"
-            case "iPhone10,5":
-                return "iPhone 8 Plus"
-            case "iPhone10,6":
-                return "iPhone X"
-
-            case "iPhone11,2":
-                return "iPhone Xs"
-            case "iPhone11,8":
-                return "iPhone XR"
-
-            case "iPhone12,1":
-                return "iPhone 11"
-            case "iPhone12,5":
-                return "iPhone 11 Pro Max"
-            case "iPhone12,8":
-                return "iPhone SE (2nd Gen)"
-
-            case "iPhone13,1":
-                return "iPhone 12 mini"
-            case "iPhone13,2":
-                return "iPhone 12"
-            case "iPhone13,3":
-                return "iPhone 12 Pro"
-            case "iPhone13,4":
-                return "iPhone 12 Pro Max"
-
-            case "iPhone14,2":
-                return "iPhone 13 Pro"
-            case "iPhone14,3":
-                return "iPhone 13 Pro Max"
-            case "iPhone14,4":
-                return "iPhone 13 mini"
-            case "iPhone14,5":
-                return "iPhone 13"
-            case "iPhone14,6":
-                return "iPhone SE (3rd Gen)"
-            case "iPhone14,7":
-                return "iPhone 14"
-            case "iPhone14,8":
-                return "iPhone 14 Plus"
-
-            case "iPhone15,2":
-                return "iPhone 14 Pro"
-            case "iPhone15,3":
-                return "iPhone 14 Pro Max"
-            case "iPhone15,4":
-                return "iPhone 15"
-            case "iPhone15,5":
-                return "iPhone 15 Plus"
-
-            case "iPhone16,1":
-                return "iPhone 15 Pro"
-            case "iPhone16,2":
-                return "iPhone 15 Pro Max"
-
-            default:
-                return identifier
-            }
-        }
-
-        return mapToDevice(identifier: identifier)
+        return identifier
     }
 
     var getOSInfo: String {

--- a/FreeAPS/Sources/Modules/AutoISF/View/AutoISFHistoryView.swift
+++ b/FreeAPS/Sources/Modules/AutoISF/View/AutoISFHistoryView.swift
@@ -91,16 +91,11 @@ struct AutoISFHistoryView: View {
 
             Divider()
 
-            let proMaxOffset_1: CGFloat = (device == "iPhone17,2" || device == "iPhone18,2" || device == "iPhone 15 Pro Max") ?
-                -21 : -9
-            let proMaxOffset_2: CGFloat = (device == "iPhone17,2" || device == "iPhone18,2" || device == "iPhone 15 Pro Max") ?
-                -10 : 0
-            let proMaxInset: CGFloat =
-                (
-                    device == "iPhone17,2" || device == "iPhone18,2" || device == "iPhone 15 Pro Max" || device ==
-                        "iPhone 17 Pro Max"
-                ) ? 25 :
-                15
+            // Pro Max screens (raw machine identifiers: 15/16/17 Pro Max)
+            let isProMax = ["iPhone16,2", "iPhone17,2", "iPhone18,2"].contains(device)
+            let proMaxOffset_1: CGFloat = isProMax ? -21 : -9
+            let proMaxOffset_2: CGFloat = isProMax ? -10 : 0
+            let proMaxInset: CGFloat = isProMax ? 25 : 15
 
             // Subtitle with non-localized variable acronyms
             HStack(spacing: 10) {

--- a/FreeAPS/Sources/Modules/Dynamic/View/DynamicHistoryView.swift
+++ b/FreeAPS/Sources/Modules/Dynamic/View/DynamicHistoryView.swift
@@ -119,11 +119,9 @@ struct DynamicHistoryView: View {
                             (item.tdd ?? 0) != 0 ? (tddFormatter.string(from: (item.tdd ?? 0) as NSNumber) ?? "") : "--"
                         ]
 
-                        let proMaxInset: CGFloat =
-                            (
-                                device == "iPhone17,2" || device == "iPhone18,2" || device == "iPhone 15 Pro Max" || device ==
-                                    "iPhone 17 Pro Max"
-                            ) ? 25 : 15
+                        // Pro Max screens (raw machine identifiers: 15/16/17 Pro Max)
+                        let proMaxInset: CGFloat = ["iPhone16,2", "iPhone17,2", "iPhone18,2"]
+                            .contains(device) ? 25 : 15
 
                         Grid(horizontalSpacing: 0) {
                             GridRow {


### PR DESCRIPTION
The identifier→marketing-name switch in `UIDevice+Extensions.swift` stopped at `iPhone16,2`, so 2023-and-older phones report "iPhone 15 Pro Max"-style names while every 16/17-series phone reports a raw `iPhone17,x`/`iPhone18,x` identifier. That half-mapped state means every consumer has to handle both forms — the Pro Max layout checks in `AutoISFHistoryView`/`DynamicHistoryView` were already comparing against a mix of raw identifiers and mapped names, including one (`"iPhone 17 Pro Max"`) the switch never actually produces, so that comparison could never match.

Rather than keep growing the table every hardware cycle, this removes it: `getDeviceId` now returns the raw machine identifier, always. The statistics site maps identifiers to marketing names at display time (already deployed), which also covers every older build that shipped with a stale table — something an in-app table can never do retroactively. The Pro Max screen checks now compare raw identifiers only (`iPhone16,2` / `17,2` / `18,2`).

Net effect: −70 lines, one canonical device string, and new-hardware support stops needing an app change at all.
